### PR TITLE
Let timeline-chart create gap states

### DIFF
--- a/packages/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/packages/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -206,38 +206,18 @@ export class TspDataProvider {
         let nextPossibleState = entry.end;
         row.states.forEach((state: TimeGraphState, idx: number) => {
             const end = state.end - chartStart;
-            if (state.style) {
-                states.push({
-                    id: row.entryId + '-' + idx,
-                    label: state.label,
-                    range: {
-                        start: state.start - chartStart,
-                        end
-                    },
-                    data: {
-                        style: state.style
-                    }
-                });
-                this.totalRange = this.totalRange < end ? end : this.totalRange;
-            } else {
-                const nextIndex = idx + 1;
-                const nextState = row.states[nextIndex];
-                if (nextState && nextState.start > state.end + BigInt(1)) {
-                    // Add gap state
-                    states.push({
-                        // TODO: We should probably remove id from state. We don't use it anywhere.
-                        id: row.entryId + '-' + idx,
-                        label: '',
-                        range: {
-                            start: end,
-                            end: nextState.start - chartStart
-                        },
-                        data: {
-                            style: gapStyle
-                        }
-                    });
+            states.push({
+                id: row.entryId + '-' + idx,
+                label: state.label,
+                range: {
+                    start: state.start - chartStart,
+                    end
+                },
+                data: {
+                    style: state.style
                 }
-            }
+            });
+            this.totalRange = this.totalRange < end ? end : this.totalRange;
             if (idx === 0) {
                 prevPossibleState = state.start - chartStart;
             }
@@ -256,7 +236,8 @@ export class TspDataProvider {
             states,
             annotations: [],
             prevPossibleState,
-            nextPossibleState
+            nextPossibleState,
+            gapStyle
         };
     }
 

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -414,6 +414,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     borderColor: state.selected ? 0xeef20c : (borderColor ? borderColor.color : 0x000000)
                 };
             }
+            return undefined;
         }
         return this.getDefaultStateStyle(state);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17280,9 +17280,9 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timeline-chart@next:
-  version "0.3.0-next.23af71d.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.23af71d.0.tgz#777172471d4899a2ba1e7749ab15590f2b32a861"
-  integrity sha512-o85c50jk160xmyc/MoR/e7Ap43KuuJXcwbXLk6bCMepL0LvSHhIe5rk8d1WoxQpc8WWelLLzcLeSRXRdx9AR3g==
+  version "0.3.0-next.bde456b.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.bde456b.0.tgz#981af79f3001d66f642ce26ac398b5cae57be984"
+  integrity sha512-T9ILYpbc3wHoRwPI7oFxSz3I34k9Y9XJ9L++1N8TV39FXh9eWBEVjMLgyx3OEcyVjjkREmOdkZm1f7oTlkUZyw==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"


### PR DESCRIPTION
Do not add gap states to the row model, but include all states including
null states (states without a style). Add the optional gap style for a
row to the row model. This will allow the timeline-chart to create its
own gaps dynamically as needed for its current view range.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>