### PR TITLE
Add relevant documentation to trace explorer menu

### DIFF
--- a/packages/react-components/style/trace-explorer.css
+++ b/packages/react-components/style/trace-explorer.css
@@ -164,3 +164,9 @@
 .source-code-tooltip {
     text-decoration: underline;
 }
+
+.trace-help-link {
+    color: var(--theia-textLink-foreground);
+    text-decoration: none;
+    font-weight: bold;
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
@@ -5,7 +5,7 @@ import { CommandService } from '@theia/core';
 import { OpenTraceCommand } from '../../trace-viewer/trace-viewer-commands';
 import { PortBusy, TraceServerConfigService } from '../../../common/trace-server-config';
 import { PreferenceService } from '@theia/core/lib/browser';
-import { TRACE_PATH, TRACE_PORT } from '../../trace-server-preference';
+import { TRACE_PATH, TRACE_PORT, TRACE_HELP_INTRO, TRACE_HELP_EXAMPLE } from '../../trace-server-preference';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../../tsp-client-provider-impl';
 import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
@@ -72,6 +72,15 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
                     {loading && <span>Connecting to trace server</span>}
                     {!loading && <span>Open Trace</span>}
                 </button>
+            </div>
+            <div className='center' style={{ marginTop: '20px'}}>
+                <span>Need some help?</span><br />
+            </div>
+            <div className='center' style={{ marginTop: '10px'}}>
+                <a href={TRACE_HELP_INTRO} className='trace-help-link'>What is tracing?</a><br />
+            </div>
+            <div className='center' style={{ marginTop: '5px'}}>
+                <a href={TRACE_HELP_EXAMPLE} className='trace-help-link'>How to record a trace</a>
             </div>
         </div>;
     }

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
@@ -3,6 +3,8 @@ import { TRACE_SERVER_DEFAULT_PORT } from '../common/trace-server-url-provider';
 
 export const TRACE_PATH = 'trace-viewer.path';
 export const TRACE_PORT = 'trace-viewer.port';
+export const TRACE_HELP_INTRO = 'https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing';
+export const TRACE_HELP_EXAMPLE = 'https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/004-record-kernel-trace-ftrace';
 
 export const ServerSchema: PreferenceSchema = {
     scope: PreferenceScope.Folder,


### PR DESCRIPTION
fixes #509

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>

![Screen Shot 2021-11-02 at 11 34 29 AM](https://user-images.githubusercontent.com/92893187/139907061-7d0d5e57-9c84-4292-b5b1-5b32021d4240.png)

Not sure where to keep links for external sites, for now I added constants to trace-server-preference.ts

Links Used:
- 'What is tracing?': https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing
- 'How to record a trace': https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/004-record-kernel-trace-ftrace

