### PR TITLE
Add user survey to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Prerequisites: A GitHub account (for logging into Gitpod)
     * Head to the trace viewer tab in the left side menu to get started.
     * The tool is loaded with the example traces from a set of [Trace Visualisation Labs](https://github.com/tuxology/tracevizlab). To analyse your own traces, [download the application](https://github.com/theia-ide/theia-trace-extension#download-the-application) for Linux.
 
+🍉🍋 **How was your tool taste test?** Let us know your thoughts in this quick [User Survey](https://forms.gle/716YQZZGwbMHEFMf7) 📝 (8 minutes) 
+
 ![gitpod-live-demo-setup](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/gitpod-live-demo-setup-0.0.2.gif)
 
 ## Download an external build of the application 


### PR DESCRIPTION
Having the survey available and visible at the moment prospective users
are trying the tool makes users more likely to give spontaneous
feedback. This feedback can be processed periodically.

Advantages:
 * Feedback is more accurate since users write their impressions right
    after they experience the tool.
 * Source of feedback doesn't require devs having to actively seek it.

Disadvantages:
 * Feedback may take a while to be seen and considered which could make
    some prospective users feel like they're speaking into the void.
    The delay will be especially significant in these early stages
    while the dev process shifts towards receiving continuous feedback.
 * Possible garbage survey results from trolls. This risk seems minimal.

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>

![image](https://user-images.githubusercontent.com/28311615/142934913-0a56153c-850b-4d26-84db-55642a5ac651.png)
