### PR TITLE
Add undo/redo functionality(hardcode)

### DIFF
--- a/theia-extensions/viewer-prototype/tsconfig.json
+++ b/theia-extensions/viewer-prototype/tsconfig.json
@@ -40,5 +40,14 @@
         {
             "path": "../../packages/react-components"
         }
+    ],
+    "@typescript-eslint/no-this-alias": [
+        "error",
+        {
+            "allowDestructuring": true, // Allow `const { props, state } = this`; false by default
+            "allowedNames": [
+                "self"
+            ] // Allow `const self = this`; `[]` by default
+        }
     ]
 }


### PR DESCRIPTION
Currently, the timeRange is stored in undo/redo stack so that the user is able to redo/undo zoom in/zoom out/pan left/pan right. I tried to make it generic by storing the entire context instead of just the timeRange so that other settings such as backgroundTheme can be undone/redone as well. I tried undoStack.push(this) but it doesn’t seem to be the right way.

https://github.com/typescript-eslint/typescript-eslint/blob/v3.10.1/packages/eslint-plugin/docs/rules/no-this-alias.md
Also, 'const self = this' is not allowed as indicated in the link above. That's why one check is not successful, but it works well locally on my laptop.

Any advice is appreciated!
Signed-off-by: Yining Wang <yining.wang@ericsson.com>