### PR TITLE
Use time range queries for states, annotations, arrows and xy

### DIFF
--- a/packages/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/packages/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -64,7 +64,7 @@ export class TspDataProvider {
 
         const start = totalTimeRange.getStart() + viewRange.start;
         const end = totalTimeRange.getStart() + viewRange.end;
-        const timeGraphStateParams = QueryHelper.selectionTimeQuery(QueryHelper.splitRangeIntoEqualParts(start, end, nbTimes), ids);
+        const timeGraphStateParams = QueryHelper.selectionTimeRangeQuery(start, end, nbTimes, ids);
         const tspClientResponse = await this.client.fetchTimeGraphStates(this.traceUUID, this.outputId, timeGraphStateParams);
         const stateResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && stateResponse) {
@@ -94,7 +94,7 @@ export class TspDataProvider {
             additionalProps['requested_marker_set'] = markerSetId;
         }
 
-        const annotationParams = QueryHelper.selectionTimeQuery(QueryHelper.splitRangeIntoEqualParts(start, end, nbTimes), ids, additionalProps);
+        const annotationParams = QueryHelper.selectionTimeRangeQuery(start, end, nbTimes, ids, additionalProps);
 
         const annotations: Map<number, TimelineChart.TimeGraphAnnotation[]> = new Map();
         const tspClientResponse2 = await this.client.fetchAnnotations(this.traceUUID, this.outputId, annotationParams);
@@ -144,8 +144,7 @@ export class TspDataProvider {
         if (viewRange && nbTimes) {
             const start = viewRange.start + this.timeGraphEntries[0].start;
             const end = viewRange.end + this.timeGraphEntries[0].start;
-            const fetchParameters = QueryHelper.selectionTimeQuery(QueryHelper.splitRangeIntoEqualParts(
-                start, end, nbTimes), ids);
+            const fetchParameters = QueryHelper.selectionTimeRangeQuery(start, end, nbTimes, ids);
             const tspClientResponseArrows = await this.client.fetchTimeGraphArrows(this.traceUUID, this.outputId, fetchParameters);
             const stateResponseArrows = tspClientResponseArrows.getModel();
             if (tspClientResponseArrows.isOk() && stateResponseArrows && stateResponseArrows.model) {

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -43,7 +43,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
     }
 
     async fetchTree(): Promise<ResponseStatus> {
-        const parameters = QueryHelper.timeQuery([this.props.range.getStart(), this.props.range.getEnd()]);
+        const parameters = QueryHelper.timeRangeQuery(this.props.range.getStart(), this.props.range.getEnd());
         // TODO: use the data tree endpoint instead of the xy tree endpoint
         const tspClientResponse = await this.props.tspClient.fetchXYTree(this.props.traceId, this.props.outputDescriptor.id, parameters);
         const treeResponse = tspClientResponse.getModel();
@@ -162,9 +162,9 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
         if (this.props.selectionRange) {
             let payload: any;
             if (this.props.selectionRange.getStart() < this.props.selectionRange.getEnd()) {
-                payload = QueryHelper.timeQuery([this.props.selectionRange.getStart(), this.props.selectionRange.getEnd()]);
+                payload = QueryHelper.timeRangeQuery(this.props.selectionRange.getStart(), this.props.selectionRange.getEnd());
             } else {
-                payload = QueryHelper.timeQuery([this.props.selectionRange.getEnd(), this.props.selectionRange.getStart()]);
+                payload = QueryHelper.timeRangeQuery(this.props.selectionRange.getEnd(), this.props.selectionRange.getStart());
             }
 
             payload.parameters.isFiltered = true;

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -308,7 +308,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         const outputId = this.props.outputDescriptor.id;
 
         // Fetch columns
-        const tspClientResponse = await tspClient.fetchTableColumns(traceUUID, outputId, QueryHelper.timeQuery([BigInt(0), BigInt(1)]));
+        const tspClientResponse = await tspClient.fetchTableColumns(traceUUID, outputId, QueryHelper.query());
         const columnsResponse = tspClientResponse.getModel();
 
         if (!tspClientResponse.isOk() || !columnsResponse) {

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -169,7 +169,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     async fetchTree(): Promise<ResponseStatus> {
-        const parameters = QueryHelper.timeQuery([this.props.range.getStart(), this.props.range.getEnd()]);
+        const parameters = QueryHelper.timeRangeQuery(this.props.range.getStart(), this.props.range.getEnd());
         const tspClientResponse = await this.props.tspClient.fetchTimeGraphTree(this.props.traceId, this.props.outputDescriptor.id, parameters);
         const treeResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && treeResponse) {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -141,7 +141,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
     }
 
     async fetchTree(): Promise<ResponseStatus> {
-        const parameters = QueryHelper.timeQuery([this.props.range.getStart(), this.props.range.getEnd()]);
+        const parameters = QueryHelper.timeRangeQuery(this.props.range.getStart(), this.props.range.getEnd());
         const tspClientResponse = await this.props.tspClient.fetchXYTree(this.props.traceId, this.props.outputDescriptor.id, parameters);
         const treeResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && treeResponse) {
@@ -905,8 +905,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
             end = viewRange.getEnd();
         }
 
-        const xyDataParameters = QueryHelper.selectionTimeQuery(
-            QueryHelper.splitRangeIntoEqualParts(start, end, this.getChartWidth()), this.state.checkedSeries);
+        const xyDataParameters = QueryHelper.selectionTimeRangeQuery(start, end, this.getChartWidth(), this.state.checkedSeries);
 
         const tspClientResponse = await this.props.tspClient.fetchXY(this.props.traceId, this.props.outputDescriptor.id, xyDataParameters);
         const xyDataResponse = tspClientResponse.getModel();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9623,7 +9623,7 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-json-bigint@sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473:
+"json-bigint@github:sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473":
   version "1.0.0"
   resolved "https://codeload.github.com/sidorares/json-bigint/tar.gz/2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
   dependencies:
@@ -13959,9 +13959,9 @@ tslib@^2.2.0, tslib@^2.3.1:
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsp-typescript-client@next:
-  version "0.4.0-next.04e64a4.0"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.04e64a4.0.tgz#77c63f1c344b92bb949dd360152f958aa89f10e2"
-  integrity sha512-6zFLsymOeFVWEGZZdaTPURav1wZA2T3UI+L/4gD2x2VEZr6foz8kM+RR+vV5zP3z09NjSwPhRaNBAfhmsquXiQ==
+  version "0.4.0-next.d59ed63.0"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.d59ed63.0.tgz#db12249b6f694339d7cd024baedcb126a1c2df95"
+  integrity sha512-RJ9eCiqtTdEjHF7G+14Ub0vyJsPnGzUuFSViWgesSY9JEADrGUm+NwnDEWT3uK7lmk/U8BmqAZ7tro4uSFUDZw==
   dependencies:
     json-bigint sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473
     node-fetch "^2.5.0"


### PR DESCRIPTION
Use the new QueryHelper methods for requested time range queries instead
of requested times array.

Signed-off-by: Patrick Tasse <patrick.tasse@gmail.com>