### PR TITLE
Indicate when data is still loading

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -92,6 +92,8 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             </button>
             <div className='title-bar-label' title={outputName} onClick={() => this.setFocus()}>
                 {outputName}
+                <i id={this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner'} className='fa fa-refresh fa-spin'
+                    style={{ marginTop: '5px', visibility: 'hidden'}} />
             </div>
         </React.Fragment>;
     }

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -501,6 +501,11 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private async fetchTimegraphData(range: TimelineChart.TimeGraphRange, resolution: number) {
+        if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')!.style.visibility = 'visible';
+        }
+
         const treeNodes = listToTree(this.state.timegraphTree, this.state.columns);
         const orderedTreeIds = getAllExpandedNodeIds(treeNodes, this.state.collapsedNodes);
         const overlap = range.end - range.start;
@@ -514,6 +519,10 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         this.arrowLayer.addArrows(timeGraphData.arrows);
         this.rangeEventsLayer.addRangeEvents(timeGraphData.rangeEvents);
 
+        if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')!.style.visibility = 'hidden';
+        }
         return {
             rows: timeGraphData ? timeGraphData.rows : [],
             range: newRange,

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -829,6 +829,10 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
     }
 
     private async updateXY() {
+        if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')!.style.visibility = 'visible';
+        }
         let start = BigInt(0);
         let end = BigInt(0);
         const viewRange = this.props.viewRange;
@@ -848,6 +852,10 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
             } else {
                 this.buildScatterData(xyDataResponse.model.series);
             }
+        }
+        if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')!.style.visibility = 'hidden';
         }
     }
 


### PR DESCRIPTION
Users expressed frustration that they would start interpreting the data and then additional chart elements would suddenly appear. Therefore in timeline-chart and xy-charts when data is being fetched due to user interactions (toggle tree, zoom and pan) show a loading spinner next to the title bar.

Examples:
![Screen Recording 2022-03-16 at 2 57 28 PM](https://user-images.githubusercontent.com/92893187/158681153-b6a7bfa9-16af-49a3-8ee8-78f6db324dac.gif)
![Screen Recording 2022-03-16 at 3 03 33 PM](https://user-images.githubusercontent.com/92893187/158681557-c0d9d0f3-37c4-44d3-9bd2-dbf27eaf00b0.gif)
![Screen Recording 2022-03-16 at 3 04 19 PM](https://user-images.githubusercontent.com/92893187/158681722-c11bc3c2-6119-49d8-a1c2-4fc6e7f6f910.gif)

Fixes #649