### PR TITLE
Throttle xy-chart data update

### DIFF
--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -8,7 +8,6 @@ import { EntryTree } from './utils/filter-tree/entry-tree';
 import { getAllExpandedNodeIds } from './utils/filter-tree/utils';
 import { TreeNode } from './utils/filter-tree/tree-node';
 import ColumnHeader from './utils/filter-tree/column-header';
-import { cloneDeep } from 'lodash';
 import debounce from 'lodash.debounce';
 
 type DataTreeOutputProps = AbstractOutputProps & {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -18,6 +18,7 @@ import { BIMath } from 'timeline-chart/lib/bigint-utils';
 import { scaleLinear } from 'd3-scale';
 import { axisLeft } from 'd3-axis';
 import { select } from 'd3-selection';
+import { throttle } from 'lodash';
 
 type XYOuputState = AbstractOutputState & {
     selectedSeriesId: number[];
@@ -82,6 +83,8 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
     private preventDefaultHandler: ((event: WheelEvent) => void) | undefined;
 
     private onSelectionChanged = (payload: { [key: string]: string; }) => this.doHandleSelectionChangedSignal(payload);
+
+    private _throttledUpdateXY = throttle(() => this.updateXY(), 500);
 
     constructor(props: AbstractOutputProps) {
         super(props);
@@ -167,7 +170,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         const outputStatusChanged = this.state.outputStatus !== prevState.outputStatus;
         const needToUpdate = viewRangeChanged || checkedSeriesChanged || collapsedNodesChanged || chartWidthChanged || outputStatusChanged;
         if (needToUpdate) {
-            this.updateXY();
+            this._throttledUpdateXY();
         }
         if (this.chartRef.current) {
             if (this.preventDefaultHandler === undefined) {


### PR DESCRIPTION
Using throttling to prevent flooding the trace-server with requests when xy chart is updated. Fixes the issue of delayed movement during panning, as well as the misalignment between charts. I decided to use throttle instead of debounce since debounce would trigger only when the user stops panning, whereas throttle invokes the update once every 500ms. I've attached a video showing the performance of a panning operation, you can compare it to the video in #470 that shows a 37 second delay. Please suggest if there's any other performance optimizations for this scenario or tricks to achieve smoother pan animation.

https://user-images.githubusercontent.com/92893187/159570352-fd96001c-3810-482a-ae68-0f68d982273e.mp4

fixes #470
fixes #453

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>