### PR TITLE
Persist opened views on page refresh

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -307,13 +307,14 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     }
 
     render(): JSX.Element {
+        const shouldRenderOutputs = (this.state.style.width > 0 && this.props.outputs.length);
         return <div className='trace-context-container'
             onContextMenu={event => this.onContextMenu(event)}
             onKeyDown={event => this.onKeyDown(event)}
             ref={this.traceContextContainer}>
             <TooltipComponent ref={this.tooltipComponent} />
             <TooltipXYComponent ref={this.tooltipXYComponent} />
-            {this.props.outputs.length ? this.renderOutputs() : this.renderPlaceHolder()}
+            {shouldRenderOutputs ? this.renderOutputs() : this.renderPlaceHolder()}
         </div>;
     }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -1,5 +1,5 @@
 import { DisposableCollection, MessageService, Path } from '@theia/core';
-import { ApplicationShell, Message, StatusBar, WidgetManager } from '@theia/core/lib/browser';
+import { ApplicationShell, Message, StatusBar, WidgetManager, StatefulWidget } from '@theia/core/lib/browser';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { inject, injectable, postConstruct } from 'inversify';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
@@ -29,7 +29,7 @@ export interface TraceViewerWidgetOptions {
 }
 
 @injectable()
-export class TraceViewerWidget extends ReactWidget {
+export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     static ID = 'trace-viewer';
     static LABEL = 'Trace Viewer';
 
@@ -240,6 +240,22 @@ export class TraceViewerWidget extends ReactWidget {
                 progress.report({ message: 'Complete', work: { done: 100, total: 100 } });
                 progress.cancel();
             });
+    }
+
+    storeState(): OutputDescriptor[] {
+        /*
+        TODO - BigInt support for storing state
+        JSON.stringify cannot serialize BigInt
+        */
+        return this.outputDescriptors;
+    }
+
+    restoreState(state: OutputDescriptor[]): void {
+        /*
+        TODO - BigInt support for restoring state
+        Identify what values need to be BigInt and convert.
+        */
+        this.outputDescriptors = state;
     }
 
     private async fetchMarkerSets(expUUID: string) {


### PR DESCRIPTION
Implement StatefulWidget in the TraceViewer class and hook into the StoreState and RestoreState methods, which preserve data in LocalStorage.  This works with browser and electron.

Currently only storing outputDescriptors (opened views), but can built upon for future features.

Handled an edge-case bug where timeline-chart components crashed when state.style.width = 0 in TraceContextComponent.  This also stops unopened experiment tab views from loading
on startup.

Signed-off-by: Will Yang <william.yang@ericsson.com>