### PR TITLE
Clean-up readme for the move to eclipse-cdt-cloud and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,52 @@
 # Trace Viewer extension for Theia applications
 
-Theia trace viewer extension using the [tsp-typescript-client](https://github.com/eclipse-cdt-cloud/tsp-typescript-client) and [Trace Server Protocol](https://github.com/eclipse-cdt-cloud/trace-server-protocol).
+Theia trace viewer extension using the [tsp-typescript-client][tspc]) and [Trace Server Protocol][tsp].
 
-Prerequisites for running this extension are the same as those for [running the Theia IDE](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
+Prerequisites for running this extension are the same as those for [running the Theia IDE][theia-prereq].
 
 **👋 Want to help?** Read our [contributor guide](CONTRIBUTING.md) and follow the instructions to contribute code.
-⚠️ The application and its development environment works best on Linux operating systems. If you are trying to run the application or the development environment on Windows or MacOs and you are encountering issues, please open a [GitHub issue](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues).
+⚠️ The application and its development environment works best on Linux operating systems. If you are trying to run the application or the development environment on Windows or MacOs and you are encountering issues, please open a [GitHub issue][issues].
 
 ## What is Tracing?
 
 Tracing is another tool in the developer or sysadmin's toolbox. It is best used to understand very complex systems, or even simple ones, but the real added value comes when trying to **understand complexity when all other approaches fail**.
 
-* Read more about [when tracing is required for understanding a problem](https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing#when-to-trace).
+* Read more about [when tracing is required for understanding a problem][tracevizlab-when].
 
 `Tracing` consists in recording specific information during a program's or operating system's execution to better understand what is happening on the system. Every location in the code that we want to trace is called a `tracepoint` and every time a tracepoint is hit is called an `event`.
 
 The `tracing` we're discussing here is high speed, low overhead tracing. With such tracing, the tracepoints can be present in the code at all times (linux has tons of tracepoints in its code, ready to be hooked to), they have a near-zero overhead when not tracing and a very low one one with a tracer enabled. Tracers can handle hundreds of thousands events/second.
 
-* Learn more about tracing [here](https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing#what-is-tracing).
+* Learn more about tracing [here][tracevizlab-what-chapter].
 
-Source: Text adapted from tracevizlab [001-what-is-tracing](https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing)
+Source: Text adapted from tracevizlab [001-what-is-tracing][tracevizlab-what-file]
 
 ## Try a live demo via Gitpod
 
 Click the Gitpod button below to access a live demo of the trace viewer. In a couple of clicks and around 2 minutes, you'll be on your way!
 
-[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/eclipse-cdt-cloud/theia-trace-extension)
+[![Gitpod ready-to-code][gitpod-logo]][gitpod-ext]
 
 Prerequisites: A GitHub account (for logging into Gitpod)
 
-* Click [here](https://gitpod.io/#https://github.com/eclipse-cdt-cloud/theia-trace-extension) to open Gitpod.
+* Click [here][gitpod-ext] to open Gitpod.
 * After logging in, it takes around a minute for Gitpod to set up the in-browser IDE used to build the project.
 * When the workspace has loaded, the project builds automatically in about a minute. Then, the workspace pops a notification saying a service (i.e. the tool) is now available. Open the application in the browser.
-![gitpod-service-ready-notification](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-service-ready-notification-0.0.3.PNG)
-* If you don't see a notification, follow this alternative way to [open the application](https://github.com/eclipse-cdt-cloud/theia-trace-extension#open-via-remote-explorer).
+![gitpod-service-ready-notification][gitpod-service-ready-notification]
+* If you don't see a notification, follow this alternative way to [open the application](#gidpod-open-via-remote-explorer).
 * After opening the tool, the interface loads in a few seconds.
 * Now you're ready to try the trace viewer!
   * Head to the trace viewer tab in the left side menu to get started.
   * Click the "Open Trace" button, and then select a directory containing traces, e.g. “103compare-package-managers → apt”
-  * The tool is loaded with the example traces from a set of [Trace Visualisation Labs](https://github.com/tuxology/tracevizlab). To analyze your own traces, [download the application](https://github.com/eclipse-cdt-cloud/theia-trace-extension#download-the-application) for Linux.
+  * The tool is loaded with the example traces from a set of [Trace Visualisation Labs][tracevizlab]. To analyze your own traces, [download the application](#download-an-external-build-of-the-application) for Linux.
 
-![gitpod-live-demo-setup](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-live-demo-setup-0.0.2.gif)
+![gitpod-live-demo-setup][gitpod-live-demo-setup]
 
 ## Download an external build of the application
 
-If you'd like to explore your own traces, you can **[download a Theia IDE build with this trace viewer extension here](https://www.dorsal.polymtl.ca/files/other/electron-theia-trace-example-app-0.0.1.AppImage)!**
+If you'd like to explore your own traces, you can **[download a Theia IDE build with this trace viewer extension here][app-image]**
 
-* **For Linux systems only**
-* **Prerequisite: Java 11** (required since this tool reuses the [Eclipse Trace Compass server](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d) which runs on Java)
+* **Prerequisite: Java 11** (required since this tool uses the [Eclipse Trace Compass server][tc-server] which runs on Java)
   * If you get a confusing error "Error opening serial port ${this.port}. (Port busy)" when you try to run the app, it's likely that Java is missing.
 * **No compilation or additional downloads necessary!** Just change the AppImage file's permissions to make it executable (command: `chmod +x <filename>`) and run it.
 
@@ -55,9 +54,9 @@ If you'd like to explore your own traces, you can **[download a Theia IDE build 
 
 The **theia-trace-extension** project publishes the following packages to npm:
 
-* [theia-traceviewer](https://www.npmjs.com/package/theia-traceviewer): The Theia trace viewer extension. Add this package to the package.json of your Theia application.
-* [traceviewer-base](https://www.npmjs.com/package/traceviewer-base): This package contains trace management utilities for managing traces using Trace Server applications that implement the TSP.
-* [traceviewer-react-components](https://www.npmjs.com/package/traceviewer-react-components): This package contains views and utilities for visualizing traces and logs via the TSP connected to a Trace Server application.
+* [theia-traceviewer][npm-viewer]: The Theia trace viewer extension. Add this package to the package.json of your Theia application.
+* [traceviewer-base][npm-viewer-base]: This package contains trace management utilities for managing traces using Trace Server applications that implement the TSP.
+* [traceviewer-react-components][npm-viewer-react]: This package contains views and utilities for visualizing traces and logs via the TSP connected to a Trace Server application.
 
 While being initially used within the *theia-traceviewer*, the code base of *traceviewer-base* and *traceviewer-react-components* is independent of any Theia APIs and can be integrated into other web applications.
 
@@ -69,7 +68,7 @@ Here is the step in order to build the trace viewer
 2. `cd theia-trace-extension`
 3. Now you are ready to build the application: `yarn`
 
-**Note for some Debian-based machines**: On some distributions, there are 2 yarn commands. If you get an error message saying **ERROR: There are no scenarios; must have at least one.**, you are using the wrong yarn. See [https://github.com/yarnpkg/yarn/issues/2821](https://github.com/yarnpkg/yarn/issues/2821).
+**Note for some Debian-based machines**: On some distributions, there are 2 yarn commands. If you get an error message saying **ERROR: There are no scenarios; must have at least one.**, you are using the wrong yarn. See [yarn issue #2821][yarn-issue-2821].
 
 You can also run two scripts to watch for changes and rebuild automatically:
 
@@ -97,14 +96,14 @@ You can find those example applications under `examples/`.
 
 ### Run the Trace Server
 
-In order to open traces, you need a trace server running on the same machine as the trace extension. You can download the [Eclipse Trace Compass server](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d) or let `yarn` download and run it:
+In order to open traces, you need a trace server running on the same machine as the trace extension. You can download the [Eclipse Trace Compass server][tc-server] or let `yarn` download and run it:
 
 ```bash
 yarn download:server
 yarn start:server
 ```
 
-You can also build the trace-server yourself using Trace Compass and the Incubator. Take a look at the [instructions here](https://www.eclipse.org/tracecompass/download.html#trace-server).
+You can also build the trace-server yourself using Trace Compass and the Incubator. Take a look at the [instructions here][tc-server-build].
 
 ### Run the example app
 
@@ -151,19 +150,19 @@ The configured Linux package(s) will be generated in the folder `examples/electr
 
 This section describes how to operate the Theia trace extension to view and analyze traces. The UI and view interactions are preliminary and subject to revisions in the future.
 
-![theia-trace-extension](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-0.0.3.png)
+![theia-trace-extension][image-viewer]
 
 ### Open the Trace Viewer
 
 To open the **Trace Viewer**, select the **Trace Viewer** icon in the left sidebar:
 
-![Trace Viewer Icon](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-icon.png)
+![Trace Viewer Icon][image-icon]
 
 #### Add Trace Viewer to sidebar
 
 If the **Trace Viewer** icon is not in the left sidebar, select menu **View** from the top-level menu and then select **Trace Viewer** in the list of views. The **Trace Viewer** icon will appear on the left, below the **File Explorer** Icon.
 
-![Add Trace Viewer to sidebar](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-viewer.gif)
+![Add Trace Viewer to sidebar][image-sidebar]
 
 ### Open a trace
 
@@ -177,7 +176,7 @@ There are a few ways to open traces. The main ones are using the **Open Trace Di
 
 Regardless of the opening method used, if the selection is a folder, the tool will look for traces in **Common Trace Format (CTF)** format, such as **Linux Tracing Toolkit traces (LTTng)** Kernel and UST (Userspace) traces, and open all found CTF traces together under the same timeline. The trace events of each CTF trace will be analyzed in chronological order. With this, several traces can be opened as a group (e.g. LTTng Kernel and UST Traces).
 
-The example Trace Compass trace server above supports LTTng Kernel and UST traces. Example LTTng traces can be retrieved from the [Trace Compass Tutorials](https://github.com/dorsal-lab/tracevizlab). Just download the archive [TraceCompassTutorialTraces](https://github.com/dorsal-lab/tracevizlab/blob/master/labs/TraceCompassTutorialTraces.tgz), extract them into a local directory on your computer. They can also be automatically downloaded by running `yarn download:sample-traces` from the repository's root.
+The example Trace Compass trace server above supports LTTng Kernel and UST traces. Example LTTng traces can be retrieved from the [Trace Compass Tutorials][tracevizlab]. Just download the archive [TraceCompassTutorialTraces][tracevizlab-traces], extract them into a local directory on your computer. They can also be automatically downloaded by running `yarn download:sample-traces` from the repository's root.
 
 #### Via the Open Trace dialog (folders only)
 
@@ -188,23 +187,23 @@ This is the most intuitive way to open traces and trace groups, but it can only 
 
 ⚠️ The root of a **Common Trace Format (CTF)** trace is a **folder**. A CTF trace is a folder that contains metadata and trace data files.
 
-![Open Trace Dialog](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-dialog.gif)
+![Open Trace Dialog][image-dialog]
 
 #### Via the File Explorer
 
 You can open any supported trace format via the file explorer context menu. For a single trace, right-click on the trace file, or folder (for a CTF trace), then select **Open With → Open Trace**. To open several CTF trace files as a group, right-click on the parent folder instead.
 
-![Open With Trace Viewer](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-with-trace-viewer.gif)
+![Open With Trace Viewer][image-open-with]
 
 ### Open a view
 
 To open a view, in the **Trace Viewer** select an opened trace in the **Opened Traces** widget, then click on a view in the **Available Views** list to open it.
 
-![Open View](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-view.gif)
+![Open View][image-open-view]
 
 ⚠️ **An available view can display empty results, even if the analysis completes correctly.** The **Available Views** widget lists all the views that could be used with the selected trace(s) based on their trace format (regardless of the event types that were enabled in the trace or the events present in the trace). The tool cannot yet inform the user whether results are empty because of:
 
-* A bad reason: Some events required for the analysis were not enabled in the trace. [#322](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/322)
+* A bad reason: Some events required for the analysis were not enabled in the trace. [#322][issue-322]
 * A neutral reason: All required events are enabled in the trace, but there are no instances of these events in the trace.
 
 ### Navigation
@@ -216,7 +215,7 @@ To open a view, in the **Trace Viewer** select an opened trace in the **Opened T
 * WASD keys: 'W' zooms in, 'S' zooms out
 * Toolbar: Zoom in, Zoom out, Reset zoom (see screenshot)
 
-![Trace Viewer Toolbar Zoom Buttons](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-toolbar-zoom-buttons.png)
+![Trace Viewer Toolbar Zoom Buttons][image-zoom-buttons]
 
 #### Panning
 
@@ -225,8 +224,7 @@ To open a view, in the **Trace Viewer** select an opened trace in the **Opened T
 
 #### Important limitations
 
-* XY Charts can be painfully laggy to navigate even with reasonable trace sizes. [#470](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/470)
-* There is no visual indication when chart data is still loading. Data can pop into existence several seconds after the chart is opened or after navigation.
+During updating of a view, a progress wheel is shown in the view's title bar until data is available. Depending on the size of trace, window range, or complexity of the analysis this can take several seconds after the chart is opened or after navigation.
 
 ### Item properties
 
@@ -235,7 +233,7 @@ This section shows detailed information about a selected:
 * Time Graph State (Bar section in a Gantt chart), or
 * Event in the Events Table
 
-![Trace Viewer Item Properties](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-item-properties-0.0.2.png)
+![Trace Viewer Item Properties][image-properties]
 
 ## Related code
 
@@ -243,12 +241,12 @@ This trace viewer depends on code from several other repos. Sometimes resolving 
 
 | Project | Description | Related issues | Links |
 |---------------|----|--------------------------|---|
-| [Theia](https://theia-ide.org/) | Theia is a framework for making custom IDEs. It provides reusable components (e.g. text editor, terminal) and is extensible. For example, this trace viewer is an extension for Theia-based IDEs. | | [Code](https://github.com/eclipse-theia/theia), [Ecosystem](https://github.com/eclipse-theia) |
-| [Trace Compass](https://www.eclipse.org/tracecompass/) | Trace analysis tool and precursor to this trace viewer. | [label:"Trace Compass"](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/Trace%20Compass) | [Dev info](https://wiki.eclipse.org/Trace_Compass), [Dev setup](https://wiki.eclipse.org/Trace_Compass/Development_Environment_Setup) |
-| [Trace Compass Server](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d) | A reference implementation of a Trace Server. Manages and analyzes trace files and provides this data to the trace viewer over the [Trace Server Protocol (TSP)](https://github.com/eclipse-cdt-cloud/trace-server-protocol). This Trace Server implementation was originally part of Trace Compass, so it requires the same dev setup. Because a protocol is used for communication (TSP), it is possible to develop alternative Trace Servers that are independent of Trace Compass. | [label:"Trace Server"](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/Trace%20Server) | [Dev setup](https://wiki.eclipse.org/Trace_Compass/Development_Environment_Setup) (same as Trace Compass), [Code](https://git.eclipse.org/r/admin/repos/tracecompass.incubator/org.eclipse.tracecompass.incubator) (same repo as Trace Compass incubator) |
-| [Trace Server Protocol (TSP)](https://github.com/eclipse-cdt-cloud/trace-server-protocol) | Protocol used by the trace viewer to communicate with the trace server. | [label:"trace server protocol"](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/trace%20server%20protocol) | |
-| [Client-side Trace Server Protocol implementation](https://github.com/eclipse-cdt-cloud/tsp-typescript-client) | A client-side implementation of the Trace Server Protocol. Allows the trace viewer to communicate with the server. | | |
-| [Timeline Chart](https://github.com/eclipse-cdt-cloud/timeline-chart) | Implements the Gantt charts used in this trace viewer. | [label:timeline-chart](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/timeline-chart) | |
+| [Theia][theia-webpage] | Theia is a framework for making custom IDEs. It provides reusable components (e.g. text editor, terminal) and is extensible. For example, this trace viewer is an extension for Theia-based IDEs. | | [Code][theia-code], [Ecosystem][theia-ecosystem] |
+| [Trace Compass][tc-project] | Trace analysis tool and precursor to this trace viewer. | [label:"Trace Compass"][tc-gh-label] | [Dev info][tc-dev-info], [Dev setup][tc-dev-setup] |
+| [Trace Compass Server][tc-server] | A reference implementation of a Trace Server. Manages and analyzes trace files and provides this data to the trace viewer over the [Trace Server Protocol (TSP)][tsp]. This Trace Server implementation was originally part of Trace Compass, so it requires the same dev setup. Because a protocol is used for communication (TSP), it is possible to develop alternative Trace Servers that are independent of Trace Compass. | [label:"Trace Server"][tc-server-gh-label] | [Dev setup][tc-dev-setup] (same as Trace Compass), [Code][tci-code] (same repo as Trace Compass incubator) |
+| [Trace Server Protocol (TSP)][tsp] | Protocol used by the trace viewer to communicate with the trace server. | [label:"trace server protocol"][tsp-gh-label] | |
+| [Client-side Trace Server Protocol implementation][tspc] | A client-side implementation of the Trace Server Protocol. Allows the trace viewer to communicate with the server. | | |
+| [Timeline Chart][timeline-chart] | Implements the Gantt charts used in this trace viewer. | [label:timeline-chart][timeline-chart-gh-label] | |
 
 ## Troubleshooting
 
@@ -260,7 +258,7 @@ This section discusses known issues on Windows.
 
 When starting the Trace Extension using `yarn start:browser` on Windows, you might get the following error:
 
-```
+```bash
 $ TRACE_SERVER_PATH=../../trace-compass-server/tracecompass-server theia start --plugins=local-dir:../plugins
 'TRACE_SERVER_PATH' is not recognized as an internal or external command,
 operable program or batch file.
@@ -273,7 +271,7 @@ The expression `TRACE_SERVER_PATH=../../trace-compass-server/tracecompass-server
 
 When adding new packages on Windows using yarn (e.g `yarn add @vscode/codicons`) you might encounter the following error:
 
-```
+```bash
 An unexpected error occurred: "expected workspace package to exist for {some package name}"
 ```
 
@@ -283,16 +281,16 @@ A simple solution would be restoring the project to a clean state prior to the i
 
 The diagram below shows the main parts of the Trace Viewer's front end (left side) and back end (right side), as well as how they exchange information.
 
-![Trace viewer architecture diagram](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-viewer-architecture.PNG)
-Source: [EclipseCon 2021 Presentation](https://www.eclipsecon.org/sites/default/files/slides/EclipseCon2021-TraceCompassCloud.pdf) (slide 18), Bernd Hufmann
+![Trace viewer architecture diagram][image-arch]
+Source: [EclipseCon 2021 Presentation][eclipsecon2021-slides] (slide 18), Bernd Hufmann
 
 ## Gitpod: Open the Trace Viewer extension
 
 When the project is opened in Gitpod, it should build automatically and then pop a notification saying a service (i.e. the example application) is now available.
 
-![gitpod-service-ready-notification](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-service-ready-notification-0.0.2.PNG)
+![gitpod-service-ready-notification][gitpod-service-ready-notification]
 
-### Open via Remote Explorer
+### Gidpod: Open via Remote Explorer
 
 If there is no notification, you can open the application directly in the **Remote Explorer** view.
 
@@ -301,7 +299,7 @@ If there is no notification, you can open the application directly in the **Remo
    * Via the Command palette or Open View menu (type "view remote explorer")
 2. Once in the **Remote Explorer**, select "Open Browser" for the port 3000. By default, the application is hosted on port 3000.
 
-![Open Browser](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-browser.png)
+![Open Browser][image-open-browser]
 
 ## Tests
 
@@ -356,8 +354,52 @@ pip install -r requirements.txt
 * Above, the `./requirements.txt` file has [the ADR tool][tools] to install.
 
 [adr]: https://adr.github.io
+[app-image]: https://www.dorsal.polymtl.ca/files/other/electron-theia-trace-example-app-0.0.1.AppImage
 [docs]: https://wiki.eclipse.org/Trace_Compass/Design_Documents
+[eclipsecon2021-slides]: https://www.eclipsecon.org/sites/default/files/slides/EclipseCon2021-TraceCompassCloud.pdf
 [ext]: https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid
 [gh]: https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/
+[gitpod-ext]: https://gitpod.io/#https://github.com/eclipse-cdt-cloud/theia-trace-extension
+[gitpod-live-demo-setup]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-live-demo-setup-0.0.2.gif
+[gitpod-logo]: https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod
+[gitpod-service-ready-notification]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-service-ready-notification-0.0.3.PNG
+[issues]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues
+[issue-322]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/322
+[npm-viewer-base]: https://www.npmjs.com/package/traceviewer-base
+[npm-viewer-react]: https://www.npmjs.com/package/traceviewer-react-components
+[npm-viewer]: https://www.npmjs.com/package/theia-traceviewer
 [render]: https://github.com/nielsvaneck/render-md-mermaid#render-md-mermaidsh
+[image-arch]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-viewer-architecture.PNG
+[image-dialog]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-dialog.gif
+[image-icon]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-icon.png
+[image-open-browser]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-browser.png
+[image-open-view]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-view.gif
+[image-open-with]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-with-trace-viewer.gif
+[image-properties]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-item-properties-0.0.2.png
+[image-sidebar]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-viewer.gif
+[image-viewer]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-0.0.3.png
+[image-zoom-buttons]: https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-toolbar-zoom-buttons.png
+[tc-dev-info]: https://wiki.eclipse.org/Trace_Compass
+[tc-dev-setup]: https://wiki.eclipse.org/Trace_Compass/Development_Environment_Setup
+[tc-gh-label]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/Trace%20Compass
+[tc-project]: https://www.eclipse.org/tracecompass/
+[tc-server]: https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d
+[tc-server-build]: https://www.eclipse.org/tracecompass/download.html#trace-server
+[tc-server-gh-label]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/Trace%20Server
+[tci-code]: https://git.eclipse.org/r/admin/repos/tracecompass.incubator/org.eclipse.tracecompass.incubator
+[theia-prereq]: https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites
+[theia-webpage]: https://theia-ide.org
+[theia-code]: https://github.com/eclipse-theia/theia
+[theia-ecosystem]: https://github.com/eclipse-theia
+[timeline-chart]: https://github.com/eclipse-cdt-cloud/timeline-chart
+[timeline-chart-gh-label]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/timeline-chart
 [tools]: https://pypi.org/project/adr-tools-python/
+[tracevizlab]: https://github.com/dorsal-lab/Tracevizlab/
+[tracevizlab-traces]: https://github.com/dorsal-lab/tracevizlab/blob/master/labs/TraceCompassTutorialTraces.tgz
+[tracevizlab-what-file]: https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing
+[tracevizlab-what-chapter]: https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing#what-is-tracing
+[tracevizlab-when]: https://github.com/dorsal-lab/Tracevizlab/tree/master/labs/001-what-is-tracing#when-to-trace
+[tsp]: https://github.com/eclipse-cdt-cloud/trace-server-protocol
+[tspc]: https://github.com/eclipse-cdt-cloud/tsp-typescript-client
+[tsp-gh-label]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/trace%20server%20protocol
+[yarn-issue-2821]: https://github.com/yarnpkg/yarn/issues/2821

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trace Viewer extension for Theia applications
 
-Theia trace viewer extension using the [tsp-typescript-client](https://github.com/theia-ide/tsp-typescript-client) and [Trace Server Protocol](https://github.com/theia-ide/trace-server-protocol).
+Theia trace viewer extension using the [tsp-typescript-client](https://github.com/eclipse-cdt-cloud/tsp-typescript-client) and [Trace Server Protocol](https://github.com/eclipse-cdt-cloud/trace-server-protocol).
 
 Prerequisites for running this extension are the same as those for [running the Theia IDE](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
 
@@ -25,22 +25,22 @@ Source: Text adapted from tracevizlab [001-what-is-tracing](https://github.com/d
 
 Click the Gitpod button below to access a live demo of the trace viewer. In a couple of clicks and around 2 minutes, you'll be on your way!
 
-[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/theia-ide/theia-trace-extension)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/eclipse-cdt-cloud/theia-trace-extension)
 
 Prerequisites: A GitHub account (for logging into Gitpod)
 
-* Click [here](https://gitpod.io/#https://github.com/theia-ide/theia-trace-extension) to open Gitpod.
+* Click [here](https://gitpod.io/#https://github.com/eclipse-cdt-cloud/theia-trace-extension) to open Gitpod.
 * After logging in, it takes around a minute for Gitpod to set up the in-browser IDE used to build the project.
 * When the workspace has loaded, the project builds automatically in about a minute. Then, the workspace pops a notification saying a service (i.e. the tool) is now available. Open the application in the browser.
-![gitpod-service-ready-notification](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/gitpod-service-ready-notification-0.0.3.PNG)
-* If you don't see a notification, follow this alternative way to [open the application](https://github.com/theia-ide/theia-trace-extension#open-via-remote-explorer).
+![gitpod-service-ready-notification](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-service-ready-notification-0.0.3.PNG)
+* If you don't see a notification, follow this alternative way to [open the application](https://github.com/eclipse-cdt-cloud/theia-trace-extension#open-via-remote-explorer).
 * After opening the tool, the interface loads in a few seconds.
 * Now you're ready to try the trace viewer!
   * Head to the trace viewer tab in the left side menu to get started.
   * Click the "Open Trace" button, and then select a directory containing traces, e.g. “103compare-package-managers → apt”
-  * The tool is loaded with the example traces from a set of [Trace Visualisation Labs](https://github.com/tuxology/tracevizlab). To analyze your own traces, [download the application](https://github.com/theia-ide/theia-trace-extension#download-the-application) for Linux.
+  * The tool is loaded with the example traces from a set of [Trace Visualisation Labs](https://github.com/tuxology/tracevizlab). To analyze your own traces, [download the application](https://github.com/eclipse-cdt-cloud/theia-trace-extension#download-the-application) for Linux.
 
-![gitpod-live-demo-setup](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/gitpod-live-demo-setup-0.0.2.gif)
+![gitpod-live-demo-setup](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-live-demo-setup-0.0.2.gif)
 
 ## Download an external build of the application
 
@@ -151,19 +151,19 @@ The configured Linux package(s) will be generated in the folder `examples/electr
 
 This section describes how to operate the Theia trace extension to view and analyze traces. The UI and view interactions are preliminary and subject to revisions in the future.
 
-![theia-trace-extension](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-0.0.3.png)
+![theia-trace-extension](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-0.0.3.png)
 
 ### Open the Trace Viewer
 
 To open the **Trace Viewer**, select the **Trace Viewer** icon in the left sidebar:
 
-![Trace Viewer Icon](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-icon.png)
+![Trace Viewer Icon](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-icon.png)
 
 #### Add Trace Viewer to sidebar
 
 If the **Trace Viewer** icon is not in the left sidebar, select menu **View** from the top-level menu and then select **Trace Viewer** in the list of views. The **Trace Viewer** icon will appear on the left, below the **File Explorer** Icon.
 
-![Add Trace Viewer to sidebar](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-viewer.gif)
+![Add Trace Viewer to sidebar](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-viewer.gif)
 
 ### Open a trace
 
@@ -188,23 +188,23 @@ This is the most intuitive way to open traces and trace groups, but it can only 
 
 ⚠️ The root of a **Common Trace Format (CTF)** trace is a **folder**. A CTF trace is a folder that contains metadata and trace data files.
 
-![Open Trace Dialog](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-dialog.gif)
+![Open Trace Dialog](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-trace-dialog.gif)
 
 #### Via the File Explorer
 
 You can open any supported trace format via the file explorer context menu. For a single trace, right-click on the trace file, or folder (for a CTF trace), then select **Open With → Open Trace**. To open several CTF trace files as a group, right-click on the parent folder instead.
 
-![Open With Trace Viewer](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-open-with-trace-viewer.gif)
+![Open With Trace Viewer](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-with-trace-viewer.gif)
 
 ### Open a view
 
 To open a view, in the **Trace Viewer** select an opened trace in the **Opened Traces** widget, then click on a view in the **Available Views** list to open it.
 
-![Open View](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-open-view.gif)
+![Open View](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-view.gif)
 
 ⚠️ **An available view can display empty results, even if the analysis completes correctly.** The **Available Views** widget lists all the views that could be used with the selected trace(s) based on their trace format (regardless of the event types that were enabled in the trace or the events present in the trace). The tool cannot yet inform the user whether results are empty because of:
 
-* A bad reason: Some events required for the analysis were not enabled in the trace. [#322](https://github.com/theia-ide/theia-trace-extension/issues/322)
+* A bad reason: Some events required for the analysis were not enabled in the trace. [#322](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/322)
 * A neutral reason: All required events are enabled in the trace, but there are no instances of these events in the trace.
 
 ### Navigation
@@ -216,7 +216,7 @@ To open a view, in the **Trace Viewer** select an opened trace in the **Opened T
 * WASD keys: 'W' zooms in, 'S' zooms out
 * Toolbar: Zoom in, Zoom out, Reset zoom (see screenshot)
 
-![Trace Viewer Toolbar Zoom Buttons](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-toolbar-zoom-buttons.png)
+![Trace Viewer Toolbar Zoom Buttons](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-toolbar-zoom-buttons.png)
 
 #### Panning
 
@@ -225,7 +225,7 @@ To open a view, in the **Trace Viewer** select an opened trace in the **Opened T
 
 #### Important limitations
 
-* XY Charts can be painfully laggy to navigate even with reasonable trace sizes. [#470](https://github.com/theia-ide/theia-trace-extension/issues/470)
+* XY Charts can be painfully laggy to navigate even with reasonable trace sizes. [#470](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/470)
 * There is no visual indication when chart data is still loading. Data can pop into existence several seconds after the chart is opened or after navigation.
 
 ### Item properties
@@ -235,7 +235,7 @@ This section shows detailed information about a selected:
 * Time Graph State (Bar section in a Gantt chart), or
 * Event in the Events Table
 
-![Trace Viewer Item Properties](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-item-properties-0.0.2.png)
+![Trace Viewer Item Properties](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-item-properties-0.0.2.png)
 
 ## Related code
 
@@ -243,12 +243,12 @@ This trace viewer depends on code from several other repos. Sometimes resolving 
 
 | Project | Description | Related issues | Links |
 |---------------|----|--------------------------|---|
-| [Theia](https://theia-ide.org/) | Theia is a framework for making custom IDEs. It provides reusable components (e.g. text editor, terminal) and is extensible. For example, this trace viewer is an extension for Theia-based IDEs. | | [Code](https://github.com/eclipse-theia/theia), [Ecosystem](https://github.com/theia-ide) |
-| [Trace Compass](https://www.eclipse.org/tracecompass/) | Trace analysis tool and precursor to this trace viewer. | [label:"Trace Compass"](https://github.com/theia-ide/theia-trace-extension/labels/Trace%20Compass) | [Dev info](https://wiki.eclipse.org/Trace_Compass), [Dev setup](https://wiki.eclipse.org/Trace_Compass/Development_Environment_Setup) |
-| [Trace Compass Server](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d) | A reference implementation of a Trace Server. Manages and analyzes trace files and provides this data to the trace viewer over the [Trace Server Protocol (TSP)](https://github.com/theia-ide/trace-server-protocol). This Trace Server implementation was originally part of Trace Compass, so it requires the same dev setup. Because a protocol is used for communication (TSP), it is possible to develop alternative Trace Servers that are independent of Trace Compass. | [label:"Trace Server"](https://github.com/theia-ide/theia-trace-extension/labels/Trace%20Server) | [Dev setup](https://wiki.eclipse.org/Trace_Compass/Development_Environment_Setup) (same as Trace Compass), [Code](https://git.eclipse.org/r/admin/repos/tracecompass.incubator/org.eclipse.tracecompass.incubator) (same repo as Trace Compass incubator) |
-| [Trace Server Protocol (TSP)](https://github.com/theia-ide/trace-server-protocol) | Protocol used by the trace viewer to communicate with the trace server. | [label:"trace server protocol"](https://github.com/theia-ide/theia-trace-extension/labels/trace%20server%20protocol) | |
-| [Client-side Trace Server Protocol implementation](https://github.com/theia-ide/tsp-typescript-client) | A client-side implementation of the Trace Server Protocol. Allows the trace viewer to communicate with the server. | | |
-| [Timeline Chart](https://github.com/theia-ide/timeline-chart) | Implements the Gantt charts used in this trace viewer. | [label:timeline-chart](https://github.com/theia-ide/theia-trace-extension/labels/timeline-chart) | |
+| [Theia](https://theia-ide.org/) | Theia is a framework for making custom IDEs. It provides reusable components (e.g. text editor, terminal) and is extensible. For example, this trace viewer is an extension for Theia-based IDEs. | | [Code](https://github.com/eclipse-theia/theia), [Ecosystem](https://github.com/eclipse-theia) |
+| [Trace Compass](https://www.eclipse.org/tracecompass/) | Trace analysis tool and precursor to this trace viewer. | [label:"Trace Compass"](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/Trace%20Compass) | [Dev info](https://wiki.eclipse.org/Trace_Compass), [Dev setup](https://wiki.eclipse.org/Trace_Compass/Development_Environment_Setup) |
+| [Trace Compass Server](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d) | A reference implementation of a Trace Server. Manages and analyzes trace files and provides this data to the trace viewer over the [Trace Server Protocol (TSP)](https://github.com/eclipse-cdt-cloud/trace-server-protocol). This Trace Server implementation was originally part of Trace Compass, so it requires the same dev setup. Because a protocol is used for communication (TSP), it is possible to develop alternative Trace Servers that are independent of Trace Compass. | [label:"Trace Server"](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/Trace%20Server) | [Dev setup](https://wiki.eclipse.org/Trace_Compass/Development_Environment_Setup) (same as Trace Compass), [Code](https://git.eclipse.org/r/admin/repos/tracecompass.incubator/org.eclipse.tracecompass.incubator) (same repo as Trace Compass incubator) |
+| [Trace Server Protocol (TSP)](https://github.com/eclipse-cdt-cloud/trace-server-protocol) | Protocol used by the trace viewer to communicate with the trace server. | [label:"trace server protocol"](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/trace%20server%20protocol) | |
+| [Client-side Trace Server Protocol implementation](https://github.com/eclipse-cdt-cloud/tsp-typescript-client) | A client-side implementation of the Trace Server Protocol. Allows the trace viewer to communicate with the server. | | |
+| [Timeline Chart](https://github.com/eclipse-cdt-cloud/timeline-chart) | Implements the Gantt charts used in this trace viewer. | [label:timeline-chart](https://github.com/eclipse-cdt-cloud/theia-trace-extension/labels/timeline-chart) | |
 
 ## Troubleshooting
 
@@ -283,14 +283,14 @@ A simple solution would be restoring the project to a clean state prior to the i
 
 The diagram below shows the main parts of the Trace Viewer's front end (left side) and back end (right side), as well as how they exchange information.
 
-![Trace viewer architecture diagram](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-viewer-architecture.PNG)
+![Trace viewer architecture diagram](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-viewer-architecture.PNG)
 Source: [EclipseCon 2021 Presentation](https://www.eclipsecon.org/sites/default/files/slides/EclipseCon2021-TraceCompassCloud.pdf) (slide 18), Bernd Hufmann
 
 ## Gitpod: Open the Trace Viewer extension
 
 When the project is opened in Gitpod, it should build automatically and then pop a notification saying a service (i.e. the example application) is now available.
 
-![gitpod-service-ready-notification](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/gitpod-service-ready-notification-0.0.2.PNG)
+![gitpod-service-ready-notification](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/gitpod-service-ready-notification-0.0.2.PNG)
 
 ### Open via Remote Explorer
 
@@ -301,7 +301,7 @@ If there is no notification, you can open the application directly in the **Remo
    * Via the Command palette or Open View menu (type "view remote explorer")
 2. Once in the **Remote Explorer**, select "Open Browser" for the port 3000. By default, the application is hosted on port 3000.
 
-![Open Browser](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-open-browser.png)
+![Open Browser](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-open-browser.png)
 
 ## Tests
 

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -4,6 +4,6 @@ The Trace Viewer base package contains trace management utilities for managing t
 
 ## Additional Information
 
-- [Theia Trace Viewer Extension](https://github.com/theia-ide/theia-trace-extension)
-- [Trace Server Protocol](https://github.com/theia-ide/trace-server-protocol)
+- [Theia Trace Viewer Extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension)
+- [Trace Server Protocol](https://github.com/eclipse-cdt-cloud/trace-server-protocol)
 - [Reference Trace Server - Download (Eclipse Trace Compass)](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/)

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -4,6 +4,6 @@ The Trace Viewer react-components package contains views and utilities for visua
 
 ## Additional Information
 
-- [Theia Trace Viewer Extension](https://github.com/theia-ide/theia-trace-extension)
-- [Trace Server Protocol](https://github.com/theia-ide/trace-server-protocol)
+- [Theia Trace Viewer Extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension)
+- [Trace Server Protocol](https://github.com/eclipse-cdt-cloud/trace-server-protocol)
 - [Reference Trace Server - Download (Eclipse Trace Compass)](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/)

--- a/theia-extensions/viewer-prototype/README.md
+++ b/theia-extensions/viewer-prototype/README.md
@@ -4,10 +4,10 @@ The Theia trace viewer extension is providing a trace viewing front-end to Trace
 
 ## Additional Information
 
-- [Theia Trace Viewer Extension](https://github.com/theia-ide/theia-trace-extension)
-- [Trace Server Protocol](https://github.com/theia-ide/trace-server-protocol)
+- [Theia Trace Viewer Extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension)
+- [Trace Server Protocol](https://github.com/eclipse-cdt-cloud/trace-server-protocol)
 - [Reference Trace Server - Download (Eclipse Trace Compass)](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/)
 
 ## Screenshots
 
-![Trace Viewer Screenshot](https://raw.githubusercontent.com/theia-ide/theia-trace-extension/master/doc/images/theia-trace-extension-0.0.2.png)
+![Trace Viewer Screenshot](https://raw.githubusercontent.com/eclipse-cdt-cloud/theia-trace-extension/master/doc/images/theia-trace-extension-0.0.3.png)


### PR DESCRIPTION
The repository has been moved to the Eclipse cdt-cloud project and is now located under the eclipse-cdt-cloud GitHub organization. Replace theia-ide with eclipse-cdt-cloud references in all relevant README.md files. 

Fix incorrect links in the README.md files.

Change links to inline references for better re-use references and for better readability of source file of the root-level README.md. 

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>