### PR TITLE
Show/Hide events table columns

### DIFF
--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -11,12 +11,16 @@
 }
 
 .widget-handle {
-    background-color: var(--theia-layout-color4);
+    background: var(--theia-editor-background);
     display: grid;
     grid-template-rows: 25px 1fr;
+    position: relative;
 }
-.widget-handle :hover {
-    background-color: var(--theia-list-hoverBackground); 
+.widget-handle-with-options {
+    background: var(--theia-editor-background);
+    display: grid;
+    grid-template-rows: 25px 25px 1fr;
+    position: relative;
 }
 .title-bar-label {
     text-align: center;
@@ -39,12 +43,36 @@
     justify-self: center;
     color: var(--theia-ui-font-color0)
 }
+.title-bar-label:hover {
+    background-color: var(--theia-list-hoverBackground); 
+}
+.remove-component-button:hover {
+    cursor: pointer;
+    background-color: var(--theia-list-hoverBackground); 
+}
+
+.options-menu-container {
+    align-self: start;
+    justify-self: center;
+    position: relative;
+    display: inline-block;
+}
+.options-menu-button {
+    background: none;
+    border: none;
+    color: var(--theia-ui-font-color0)
+}
+.options-menu-button:hover {
+    cursor: pointer;
+    background-color: var(--theia-list-hoverBackground); 
+}
 
 .main-output-container {
     display: flex;
     overflow: hidden;
     position: relative;
     z-index: -1;
+    background: var(--theia-editor-background);
 }
 
 .disable-select {
@@ -247,4 +275,49 @@ canvas {
 
 .hoverClass:hover {
     border: 1px solid black;
+}
+
+.options-menu-drop-down {
+    position: absolute;
+    top: 0%;
+    left: 100%;
+    padding: 0;
+    z-index: 2;
+    min-width: 180px;
+    background: var(--theia-menu-background);
+    color: var(--theia-menu-foreground);
+    font-size: var(--theia-ui-font-size1);
+    box-shadow: 0px 1px 6px var(--theia-widget-shadow);
+    border: 1px solid var(--theia-menu-border);
+}
+.options-menu-drop-down > ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    display: table;
+    width: 100%;
+}
+.drop-down-list-item {
+    padding: 8px 12px;
+    background-color: var(--theia-menu-background);
+    color: var(--theia-menu-foreground);
+}
+.drop-down-list-item:hover {
+    background: var(--theia-menu-selectionBackground);
+    color: var(--theia-menu-selectionForeground);
+    opacity: 1;
+}
+.toggle-columns-table {
+    height: 150px;
+    overflow: scroll;
+    z-index: 999 !important;
+    background: var(--theia-menu-background);
+    color: var(--theia-menu-foreground);
+    font-size: var(--theia-ui-font-size1);
+    box-shadow: 0px 1px 6px var(--theia-widget-shadow);
+    border: 1px solid var(--theia-tree-inactiveIndentGuidesStroke);
+}
+
+.react-grid-item:hover {
+    z-index: 10;
 }


### PR DESCRIPTION
- Added an optional 'Options menu button' in AbstractOutputComponent's Title Bar:
<img width="137" alt="Screen Shot 2022-04-14 at 3 47 48 PM" src="https://user-images.githubusercontent.com/92893187/163472738-d5629849-005c-4b40-bd3f-078441fc518e.png">

- Events table implements this button to open a dropdown list that allows users to toggle visibility of multiple columns
<img width="543" alt="Screen Shot 2022-04-14 at 3 47 14 PM" src="https://user-images.githubusercontent.com/92893187/163472666-39595f2e-50a3-4ae5-b686-ef39c5e5487d.png">

