### PR TITLE
Export table views to csv

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -23,6 +23,8 @@ export declare interface SignalManager {
     fireMarkerSetsFetchedSignal(): void;
     fireMarkerCategoryClosedSignal(payload: { traceViewerId: string, markerCategory: string }): void;
     fireTraceServerStartedSignal(): void;
+    fireCSVRowExportSignal(row: string): void;
+    fireFileCreateSignal(payload: { fileName: string, path?: string }): void;
 }
 
 export const Signals = {
@@ -46,6 +48,8 @@ export const Signals = {
     MARKERSETS_FETCHED: 'markersets fetched',
     MARKER_CATEGORY_CLOSED: 'marker category closed',
     TRACE_SERVER_STARTED: 'trace server started',
+    CSV_ROW_EXPORT: 'CSV row exported',
+    FILE_CREATED: 'File Created'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -105,6 +109,12 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireTraceServerStartedSignal(): void {
         this.emit(Signals.TRACE_SERVER_STARTED);
+    }
+    fireCSVRowExportSignal(row: string): void{
+        this.emit(Signals.CSV_ROW_EXPORT, row);
+    }
+    fireFileCreateSignal(payload: { fileName: string, path?: string }): void {
+        this.emit(Signals.FILE_CREATED, payload);
     }
 }
 

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -16,6 +16,7 @@ export interface AbstractOutputProps {
     tooltipComponent: TooltipComponent | null;
     tooltipXYComponent: TooltipXYComponent | null;
     traceId: string;
+    traceName?: string;
     range: TimeRange;
     nbEvents: number;
     viewRange: TimeRange;
@@ -43,14 +44,15 @@ export interface AbstractOutputProps {
 export interface AbstractOutputState {
     outputStatus: string;
     styleModel?: OutputStyleModel;
-    optionsDropdownOpen?: boolean;
+    optionsDropdownOpen: boolean;
+    additionalOptions?: boolean;
 }
 
 export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends React.Component<P, S> {
 
     private readonly DEFAULT_HANDLE_WIDTH = 30;
 
-    private mainOutputContainer: React.RefObject<HTMLDivElement>;
+    protected mainOutputContainer: React.RefObject<HTMLDivElement>;
 
     private optionsMenuRef: React.RefObject<HTMLDivElement>;
 
@@ -77,7 +79,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             data-for="tooltip-component">
             <div
                 id={this.props.traceId + this.props.outputDescriptor.id + 'handle'}
-                className={this.state.optionsDropdownOpen !== undefined ? 'widget-handle-with-options' : 'widget-handle'}
+                className={this.state.additionalOptions ? 'widget-handle-with-options' : 'widget-handle'}
                 style={{ width: this.getHandleWidth(), height: this.props.style.height }}
             >
                 {this.renderTitleBar()}
@@ -96,7 +98,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             <button className='remove-component-button' onClick={this.closeComponent}>
                 <FontAwesomeIcon icon={faTimes} />
             </button>
-            {this.state.optionsDropdownOpen !== undefined && <div className='options-menu-container'>
+            {this.state.additionalOptions !== undefined && <div className='options-menu-container'>
                 <button title="Show View Options" className='options-menu-button' onClick={this.openOptionsMenu}>
                     <FontAwesomeIcon icon={faBars} />
                 </button>
@@ -142,6 +144,12 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     abstract resultsAreEmpty(): boolean;
 
     protected showOptions(): React.ReactNode {
+        return <React.Fragment>
+            {this.state.additionalOptions && this.showAdditionalOptions()}
+        </React.Fragment>;
+    }
+
+    protected showAdditionalOptions(): React.ReactNode {
         return <></>;
     }
 
@@ -173,8 +181,8 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         });
     }
 
-    private closeOptionsMenu(event: Event): void {
-        if (event.target instanceof Node && this.optionsMenuRef.current?.contains(event.target)) {
+    protected closeOptionsMenu(event?: Event): void {
+        if (event && event.target instanceof Node && this.optionsMenuRef.current?.contains(event.target)) {
             return;
         }
         this.closeOptionsDropDown();

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -35,7 +35,8 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
             collapsedNodes: [],
             orderedNodes: [],
             columns: [{title: 'Name', sortable: true}],
-            optionsDropdownOpen: false
+            optionsDropdownOpen: false,
+            additionalOptions: true
         };
     }
 
@@ -229,7 +230,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
         }
     }
 
-    protected showExportMenu(): React.ReactNode {
+    protected showAdditionalOptions(): React.ReactNode {
         return <React.Fragment>
             <ul>
                 <li className='drop-down-list-item' key={0} onClick={() => this.exportOutput()}>Export to csv</li>

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -35,6 +35,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
             collapsedNodes: [],
             orderedNodes: [],
             columns: [{title: 'Name', sortable: true}],
+            optionsDropdownOpen: false
         };
     }
 
@@ -187,5 +188,52 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
         if (this.props.selectionRange && this.props.selectionRange !== prevProps.selectionRange) {
             this._debouncedFetchSelectionData();
         }
+    }
+
+    private async exportOutput(): Promise<void> {
+        const focusContainer = document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'focusContainer');
+        if (focusContainer) {
+            const table = focusContainer.querySelector('div:nth-child(2) > table');
+            if (table) {
+                const rows = table.querySelectorAll('tr');
+
+                const csvArray = [];
+                for (let i = 0; i < rows.length; i++) {
+                    const row = [];
+                    const cols = rows[i].querySelectorAll('td, th');
+                    for (let j = 0; j < cols.length - 1; j++) {
+                        let data;
+                        const content = cols[j].textContent;
+                        if (content) {
+                            data = content.replace(/\s*\|/g, '');
+                        } else {
+                            data = content;
+                        }
+                        row.push(data);
+                    }
+                    csvArray.push(row.join(','));
+                }
+                const tableString = csvArray.join('\n');
+
+                const link = document.createElement('a');
+                link.setAttribute('href', `data:text/csv;charset=utf-8,${encodeURIComponent(tableString)}`);
+                link.setAttribute('download', this.props.traceName ?? 'export');
+
+                link.style.display = 'none';
+                document.body.appendChild(link);
+
+                link.click();
+
+                document.body.removeChild(link);
+            }
+        }
+    }
+
+    protected showExportMenu(): React.ReactNode {
+        return <React.Fragment>
+            <ul>
+                <li className='drop-down-list-item' key={0} onClick={() => this.exportOutput()}>Export to csv</li>
+            </ul>
+        </React.Fragment>;
     }
 }

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -769,6 +769,8 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
 
         let fetchLinesRemainder = totalLinesToFetch;
 
+        signalManager().fireFileCreateSignal({fileName: this.props.traceName ?? 'export'});
+
         while (fetchLinesRemainder > 0 && this.mainOutputContainer.current) {
             let curLinesToFetch = bufferSize;
 
@@ -806,7 +808,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
 
             for (let i=0;i<lines.length;i++) {
                 // Stores each csv row data
-                const csvrow = [];
+                const csvrow: Array<string> = [];
                 for (let j=0;j<lines[i].cells.length;j++) {
                     // Get the text data of each cell of
                     // a row and push it to csvrow
@@ -818,7 +820,8 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                     }
                 }
                 // Combine each column value with comma
-                csv_data.push(csvrow.join(','));
+                signalManager().fireCSVRowExportSignal(csvrow.join(','));
+                // csv_data.push(csvrow.join(','));
             }
             fetchIndex += curLinesToFetch;
         }
@@ -828,11 +831,13 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         }
 
         // combine each row data with new line character
-        const tableString = csv_data.join('\n');
-        const csvBlob = URL.createObjectURL(new Blob([tableString], { type: 'text/csv' }));
+        // const tableString = csv_data.join('\n');
+        signalManager().fireCSVRowExportSignal('\n');
+
+        // const csvBlob = URL.createObjectURL(new Blob([tableString], { type: 'text/csv' }));
 
         const link = document.createElement('a');
-        link.setAttribute('href', csvBlob);
+        link.setAttribute('href', '/trace-viewer/download/csv' + (this.props.traceName ?? 'export'));
 
         link.setAttribute('download', this.props.traceName ?? 'export');
         link.style.display = 'none';

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -73,7 +73,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             markerCategoryEntries: [],
             collapsedNodes: [],
             columns: [],
-            collapsedMarkerNodes: []
+            collapsedMarkerNodes: [],
+            optionsDropdownOpen: false
         };
         this.selectedMarkerCategories = this.props.markerCategories;
         this.onToggleCollapse = this.onToggleCollapse.bind(this);

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -76,6 +76,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     private readonly DEFAULT_COMPONENT_LEFT: number = 0;
     private readonly SCROLLBAR_PADDING: number = 12;
     private readonly DEFAULT_CHART_OFFSET = 200;
+    private readonly MIN_COMPONENT_HEIGHT: number = 2;
 
     private unitController: TimeGraphUnitController;
     private tooltipComponent: React.RefObject<TooltipComponent>;
@@ -422,6 +423,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     tooltipComponent: this.tooltipComponent.current,
                     tooltipXYComponent: this.tooltipXYComponent.current,
                     traceId: this.state.experiment.UUID,
+                    traceName: this.props.experiment.name,
                     outputDescriptor: output,
                     markerCategories: this.props.markerCategoriesMap.get(output.id),
                     markerSetId: this.props.markerSetId,
@@ -501,6 +503,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     y: 1,
                     w: 1,
                     h: this.DEFAULT_COMPONENT_HEIGHT,
+                    minH: this.MIN_COMPONENT_HEIGHT,
                 });
             } else {
                 newNonTimeScaleLayouts.push({
@@ -509,6 +512,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     y: 1,
                     w: 1,
                     h: this.DEFAULT_COMPONENT_HEIGHT,
+                    minH: this.MIN_COMPONENT_HEIGHT,
                 });
             }
         }

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -112,7 +112,8 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
             columns: [{title: 'Name', sortable: true}],
             allMax: 0,
             allMin: 0,
-            cursor: 'default'
+            cursor: 'default',
+            optionsDropdownOpen: false
         };
 
         this.afterChartDraw = this.afterChartDraw.bind(this);

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -35,6 +35,58 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+.title-bar-label:hover {
+    background-color: var(--theia-list-hoverBackground); 
+}
+.remove-component-button:hover {
+    cursor: pointer;
+    background-color: var(--theia-list-hoverBackground); 
+}
+.share-component-container {
+    align-self: start;
+    justify-self: center;
+    position: relative;
+    display: inline-block;
+}
+.share-component-button {
+    background: none;
+    border: none;
+    color: var(--theia-ui-font-color0)
+}
+.share-component-button:hover {
+    cursor: pointer;
+    background-color: var(--theia-list-hoverBackground); 
+}
+.share-component-drop-down {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    padding: 0;
+    z-index: 2;
+    min-width: 180px;
+    background: var(--theia-menu-background);
+    color: var(--theia-menu-foreground);
+    font-size: var(--theia-ui-font-size1);
+    box-shadow: 0px 1px 6px var(--theia-widget-shadow);
+    border: 1px solid var(--theia-menu-border);
+}
+.share-component-drop-down > ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    display: table;
+    width: 100%;
+}
+.drop-down-list-item {
+    padding: 8px 12px;
+    background-color: var(--theia-menu-background);
+    color: var(--theia-menu-foreground);
+}
+.drop-down-list-item:hover {
+    background: var(--theia-menu-selectionBackground);
+    color: var(--theia-menu-selectionForeground);
+    opacity: 1;
+}
 .remove-component-button {
     background: none;
     border: none;

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -65,6 +65,8 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     private onExperimentSelected = (experiment: Experiment): void => this.doHandleExperimentSelectedSignal(experiment);
     private onCloseExperiment = (UUID: string): void => this.doHandleCloseExperimentSignal(UUID);
     private onMarkerCategoryClosedSignal = (payload: { traceViewerId: string, markerCategory: string }) => this.doHandleMarkerCategoryClosedSignal(payload);
+    private onCSVRowExportSignal = (row: string) => this.doHandleCSVRowExportSignal(row);
+    private onFileCreatedSignal = (payload: { fileName: string, path?: string }) => this.doHandleFileCreatedSignal(payload);
 
     @inject(TraceViewerWidgetOptions) protected readonly options: TraceViewerWidgetOptions;
     @inject(TspClientProvider) protected tspClientProvider: TspClientProvider;
@@ -126,6 +128,8 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         signalManager().on(Signals.EXPERIMENT_SELECTED, this.onExperimentSelected);
         signalManager().on(Signals.CLOSE_TRACEVIEWERTAB, this.onCloseExperiment);
         signalManager().on(Signals.MARKER_CATEGORY_CLOSED, this.onMarkerCategoryClosedSignal);
+        signalManager().on(Signals.CSV_ROW_EXPORT, this.onCSVRowExportSignal);
+        signalManager().on(Signals.FILE_CREATED, this.onFileCreatedSignal);
     }
 
     protected updateBackgroundTheme(): void {
@@ -138,6 +142,8 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         signalManager().off(Signals.OUTPUT_ADDED, this.onOutputAdded);
         signalManager().off(Signals.EXPERIMENT_SELECTED, this.onExperimentSelected);
         signalManager().off(Signals.CLOSE_TRACEVIEWERTAB, this.onCloseExperiment);
+        signalManager().off(Signals.CSV_ROW_EXPORT, this.onCSVRowExportSignal);
+        signalManager().off(Signals.FILE_CREATED, this.onFileCreatedSignal);
     }
 
     async initialize(): Promise<void> {
@@ -384,6 +390,16 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         if (traceViewerId === this.id) {
             this.updateMarkerCategoryState(markerCategory);
         }
+    }
+
+    private doHandleCSVRowExportSignal(row: string): void {
+        this.backendFileService.writeToFile(row);
+        return;
+    }
+
+    private doHandleFileCreatedSignal(payload: { fileName: string, path?: string }): void {
+        this.backendFileService.createFile(payload.fileName);
+        return;
     }
 
     private addMarkerSets(markerSets: MarkerSet[]) {

--- a/theia-extensions/viewer-prototype/src/common/backend-file-service.ts
+++ b/theia-extensions/viewer-prototype/src/common/backend-file-service.ts
@@ -5,4 +5,6 @@ export const BackendFileService = Symbol('BackendFileService');
 
 export interface BackendFileService {
     findTraces(uri: string, cancellationToken: CancellationToken): Promise<string[]>;
+    createFile(fileName: string): void;
+    writeToFile(data: string): void;
 }

--- a/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
+++ b/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
@@ -4,9 +4,11 @@ import { traceServerPath } from '../common/trace-server-config';
 import { TraceServerConfigService } from '../common/trace-server-config';
 import { BackendFileService, backendFileServicePath } from '../common/backend-file-service';
 import { BackendFileServiceImpl } from './backend-file-service-impl';
+import { BackendApplicationContribution } from '@theia/core/lib/node';
 
 export default new ContainerModule(bind => {
     bind(BackendFileService).to(BackendFileServiceImpl).inSingletonScope();
+    bind(BackendApplicationContribution).to(BackendFileServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx => new JsonRpcConnectionHandler<TraceServerConfigService>(
         traceServerPath,
         () => ctx.container.get<TraceServerConfigService>(TraceServerConfigService),


### PR DESCRIPTION
- Added an optional 'export button' to AbstractOutputComponent. This is used by statistics tables and events table to export them to csv:

![Screen Shot 2022-04-18 at 12 23 39 PM](https://user-images.githubusercontent.com/92893187/163847199-716b59d1-4d7d-4148-887b-aa9a117848b8.png)

![Screen Shot 2022-04-18 at 12 24 47 PM](https://user-images.githubusercontent.com/92893187/163847364-2735ff30-a88b-4fed-ab90-c1a717f914d1.png)

- For events table, we have to fetch all the table lines and then parse the response to csv format. For traces that have too many table lines we are splitting the work into smaller jobs. At the moment I'm incrementally fetching every 100000 lines. @PatrickTasse has suggested that in the future we should show a progress bar for such long jobs that allow the user to cancel. Also, should there be a limit set to how big of a table we can export? Some experiments (groups of traces) might have an events table with more than a million lines. For such tables should we show an alert message asking the user to make a smaller selection?
