### PR TITLE
Update bigint dependencies in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9623,7 +9623,7 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-"json-bigint@github:sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473":
+json-bigint@sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473:
   version "1.0.0"
   resolved "https://codeload.github.com/sidorares/json-bigint/tar.gz/2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
   dependencies:


### PR DESCRIPTION
Without this change the yarn.lock is being updated at every build and it makes publishing to NPM fail.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>