### PR TITLE
xy-output-component: Deserialize for isScatterPlot

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,8 @@
             "name": "Attach to Chrome",
             "port": 9222,
             "sourceMaps": true,
-            "webRoot": "${workspaceRoot}/examples/browser"
+            "webRoot": "${workspaceRoot}/examples/browser",
+            "urlFilter": "http://localhost:3000/*"
         },
         {
             "type": "firefox",

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -986,10 +986,16 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         const tspClientResponse = await this.props.tspClient.fetchXY(this.props.traceId, this.props.outputDescriptor.id, xyDataParameters);
         const xyDataResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && xyDataResponse) {
+            const series = xyDataResponse.model.series;
+            if (series.length !== 0 && series[0].style) {
+                // Rely on type set for the first series to conclude for all series, if many.
+                // This is because support for per-series (potentially varying) type is lacking across-
+                this.isScatterPlot = series[0].style.values['series-type'] === 'scatter';
+            }
             if (this.isScatterPlot) {
-                this.buildScatterData(xyDataResponse.model.series);
+                this.buildScatterData(series);
             } else {
-                this.buildXYData(xyDataResponse.model.series);
+                this.buildXYData(series);
             }
         }
         if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -986,10 +986,10 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         const tspClientResponse = await this.props.tspClient.fetchXY(this.props.traceId, this.props.outputDescriptor.id, xyDataParameters);
         const xyDataResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && xyDataResponse) {
-            if (!this.isScatterPlot) {
-                this.buildXYData(xyDataResponse.model.series);
-            } else {
+            if (this.isScatterPlot) {
                 this.buildScatterData(xyDataResponse.model.series);
+            } else {
+                this.buildXYData(xyDataResponse.model.series);
             }
         }
         if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -1001,13 +1001,12 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
     private buildScatterData(seriesObj: XYSeries[]) {
         const dataSetArray = new Array<any>();
         let xValues: bigint[] = [];
-        let yValues: number[] = [];
-        let pairs: xyPair[] = [];
         const offset = this.props.viewRange.getOffset() ?? BigInt(0);
         seriesObj.forEach(series => {
             const color = this.getSeriesColor(series.seriesName);
             xValues = series.xValues;
-            yValues = series.yValues;
+            const yValues: number[] = series.yValues;
+            let pairs: xyPair[] = [];
 
             xValues.forEach((value, index) => {
                 const adjusted = Number(value - offset);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13980,9 +13980,9 @@ tslib@^2.2.0, tslib@^2.3.1:
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsp-typescript-client@next:
-  version "0.4.0-next.d59ed63.0"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.d59ed63.0.tgz#db12249b6f694339d7cd024baedcb126a1c2df95"
-  integrity sha512-RJ9eCiqtTdEjHF7G+14Ub0vyJsPnGzUuFSViWgesSY9JEADrGUm+NwnDEWT3uK7lmk/U8BmqAZ7tro4uSFUDZw==
+  version "0.4.0-next.5dd021b.0"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.5dd021b.0.tgz#1c37f0b3f5fb0dbb1febed8f2cccafa3482812d8"
+  integrity sha512-IgnT5N/4Deq6RtS2PGqvrY3TcgcuYp3Ap73GburEdVBAXDSOssUtzdrZoB+beS/5PyKI0DjVu53mM/YCkOYDzQ==
   dependencies:
     json-bigint sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473
     node-fetch "^2.5.0"


### PR DESCRIPTION
1. Reverse negative if statement.
2. Rescope yValues/pairs locally.
3. Deserialize for isScatterPlot.
4. Add urlFilter to the attach-chrome config.

Each commit message should have their necessary details.