### PR TITLE
trace-viewer: Remove onAfterShow causing event loop

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -284,13 +284,6 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         }
     }
 
-    onAfterShow(msg: Message): void {
-        super.onAfterShow(msg);
-        if (this.openedExperiment) {
-            signalManager().fireTraceViewerTabActivatedSignal(this.openedExperiment);
-        }
-    }
-
     onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         if (this.openedExperiment) {


### PR DESCRIPTION
Before this change, opening two traces then moving one in its own panel
caused an infinite focus loop between these two. That event loop seemed
to have been caused by onAfterShow firing an extra event during that
move action.

Removing that overriding method in TraceViewerWidget fixes that event
loop, lending the moved trace tab in focus as expected (in its own
panel). No evidence of requiring that method in other cases was found.

Fixes #736.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>