### PR TITLE
Export datatree outputs to csv

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -16,6 +16,7 @@ export interface AbstractOutputProps {
     tooltipComponent: TooltipComponent | null;
     tooltipXYComponent: TooltipXYComponent | null;
     traceId: string;
+    traceName?: string;
     range: TimeRange;
     nbEvents: number;
     viewRange: TimeRange;
@@ -43,14 +44,15 @@ export interface AbstractOutputProps {
 export interface AbstractOutputState {
     outputStatus: string;
     styleModel?: OutputStyleModel;
-    optionsDropdownOpen?: boolean;
+    optionsDropdownOpen: boolean;
+    additionalOptions?: boolean;
 }
 
 export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends React.Component<P, S> {
 
     private readonly DEFAULT_HANDLE_WIDTH = 30;
 
-    private mainOutputContainer: React.RefObject<HTMLDivElement>;
+    protected mainOutputContainer: React.RefObject<HTMLDivElement>;
 
     private optionsMenuRef: React.RefObject<HTMLDivElement>;
 
@@ -77,7 +79,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             data-for="tooltip-component">
             <div
                 id={this.props.traceId + this.props.outputDescriptor.id + 'handle'}
-                className={this.state.optionsDropdownOpen !== undefined ? 'widget-handle-with-options' : 'widget-handle'}
+                className={this.state.additionalOptions ? 'widget-handle-with-options' : 'widget-handle'}
                 style={{ width: this.getHandleWidth(), height: this.props.style.height }}
             >
                 {this.renderTitleBar()}
@@ -96,7 +98,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             <button className='remove-component-button' onClick={this.closeComponent}>
                 <FontAwesomeIcon icon={faTimes} />
             </button>
-            {this.state.optionsDropdownOpen !== undefined && <div className='options-menu-container'>
+            {this.state.additionalOptions !== undefined && <div className='options-menu-container'>
                 <button title="Show View Options" className='options-menu-button' onClick={this.openOptionsMenu}>
                     <FontAwesomeIcon icon={faBars} />
                 </button>
@@ -142,6 +144,12 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     abstract resultsAreEmpty(): boolean;
 
     protected showOptions(): React.ReactNode {
+        return <React.Fragment>
+            {this.state.additionalOptions && this.showAdditionalOptions()}
+        </React.Fragment>;
+    }
+
+    protected showAdditionalOptions(): React.ReactNode {
         return <></>;
     }
 
@@ -173,8 +181,8 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         });
     }
 
-    private closeOptionsMenu(event: Event): void {
-        if (event.target instanceof Node && this.optionsMenuRef.current?.contains(event.target)) {
+    protected closeOptionsMenu(event?: Event): void {
+        if (event && event.target instanceof Node && this.optionsMenuRef.current?.contains(event.target)) {
             return;
         }
         this.closeOptionsDropDown();

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -67,7 +67,8 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             outputStatus: ResponseStatus.RUNNING,
             tableColumns: [],
             optionsDropdownOpen: false,
-            showToggleColumns: false
+            showToggleColumns: false,
+            additionalOptions: true
         };
 
         this.frameworkComponents = {
@@ -703,7 +704,13 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         </React.Fragment>;
     }
 
-    protected showOptions(): React.ReactNode {
+    protected closeOptionsDropDown(): void {
+        this.setState({
+            showToggleColumns: false
+        });
+    }
+
+    protected showAdditionalOptions(): React.ReactNode {
         return <React.Fragment>
             <ul>
                 <li className='drop-down-list-item' key={0} onClick={() => {
@@ -713,11 +720,4 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             {this.state.showToggleColumns && <div className='toggle-columns-table'>{this.renderToggleColumnsTable()}</div>}
         </React.Fragment>;
     }
-
-    protected closeOptionsDropDown(): void {
-        this.setState({
-            showToggleColumns: false
-        });
-    }
-
 }

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -73,7 +73,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             markerCategoryEntries: [],
             collapsedNodes: [],
             columns: [],
-            collapsedMarkerNodes: []
+            collapsedMarkerNodes: [],
+            optionsDropdownOpen: false
         };
         this.selectedMarkerCategories = this.props.markerCategories;
         this.onToggleCollapse = this.onToggleCollapse.bind(this);

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -76,6 +76,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     private readonly DEFAULT_COMPONENT_LEFT: number = 0;
     private readonly SCROLLBAR_PADDING: number = 12;
     private readonly DEFAULT_CHART_OFFSET = 200;
+    private readonly MIN_COMPONENT_HEIGHT: number = 2;
 
     private unitController: TimeGraphUnitController;
     private tooltipComponent: React.RefObject<TooltipComponent>;
@@ -422,6 +423,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     tooltipComponent: this.tooltipComponent.current,
                     tooltipXYComponent: this.tooltipXYComponent.current,
                     traceId: this.state.experiment.UUID,
+                    traceName: this.props.experiment.name,
                     outputDescriptor: output,
                     markerCategories: this.props.markerCategoriesMap.get(output.id),
                     markerSetId: this.props.markerSetId,
@@ -501,6 +503,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     y: 1,
                     w: 1,
                     h: this.DEFAULT_COMPONENT_HEIGHT,
+                    minH: this.MIN_COMPONENT_HEIGHT,
                 });
             } else {
                 newNonTimeScaleLayouts.push({
@@ -509,6 +512,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     y: 1,
                     w: 1,
                     h: this.DEFAULT_COMPONENT_HEIGHT,
+                    minH: this.MIN_COMPONENT_HEIGHT,
                 });
             }
         }

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -112,7 +112,8 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
             columns: [{title: 'Name', sortable: true}],
             allMax: 0,
             allMin: 0,
-            cursor: 'default'
+            cursor: 'default',
+            optionsDropdownOpen: false
         };
 
         this.afterChartDraw = this.afterChartDraw.bind(this);

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -35,6 +35,58 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+.title-bar-label:hover {
+    background-color: var(--theia-list-hoverBackground); 
+}
+.remove-component-button:hover {
+    cursor: pointer;
+    background-color: var(--theia-list-hoverBackground); 
+}
+.share-component-container {
+    align-self: start;
+    justify-self: center;
+    position: relative;
+    display: inline-block;
+}
+.share-component-button {
+    background: none;
+    border: none;
+    color: var(--theia-ui-font-color0)
+}
+.share-component-button:hover {
+    cursor: pointer;
+    background-color: var(--theia-list-hoverBackground); 
+}
+.share-component-drop-down {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    padding: 0;
+    z-index: 2;
+    min-width: 180px;
+    background: var(--theia-menu-background);
+    color: var(--theia-menu-foreground);
+    font-size: var(--theia-ui-font-size1);
+    box-shadow: 0px 1px 6px var(--theia-widget-shadow);
+    border: 1px solid var(--theia-menu-border);
+}
+.share-component-drop-down > ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    display: table;
+    width: 100%;
+}
+.drop-down-list-item {
+    padding: 8px 12px;
+    background-color: var(--theia-menu-background);
+    color: var(--theia-menu-foreground);
+}
+.drop-down-list-item:hover {
+    background: var(--theia-menu-selectionBackground);
+    color: var(--theia-menu-selectionForeground);
+    opacity: 1;
+}
 .remove-component-button {
     background: none;
     border: none;


### PR DESCRIPTION
Export datatree-output-component to csv
<img width="777" alt="Screen Shot 2022-05-17 at 1 15 33 AM" src="https://user-images.githubusercontent.com/92893187/168742131-6c4e789a-bef9-4265-8465-c18f30e2cee2.png">
- Expanded options menu to show 'Export to CSV' in datatree-output-component. Aim is to add 'Export to CSV' options to table-output-component's options menu as well as pin/unpin option to abstract-output-component's (Base class) option menu
- Trace name given to downloaded file