### PR TITLE
Improve filter text box discoverability

### DIFF
--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -968,6 +968,10 @@ Array [
   <div
     onChange={[Function]}
   >
+    <i
+      className="codicon codicon-filter"
+      id="input-filter-icon"
+    />
     <input
       id="input-filter-tree"
       placeholder="Filter"

--- a/packages/react-components/src/components/utils/filter-tree/filter.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/filter.tsx
@@ -38,6 +38,7 @@ export class Filter extends React.Component<FilterProps, FilterState> {
 
     render(): JSX.Element {
         return <div ref={this.ref} onChange={this.props.onChange}>
+            <i id="input-filter-icon" className='codicon codicon-filter'></i>
             <input
                 id="input-filter-tree"
                 type="text"

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -293,12 +293,21 @@ canvas {
     border: 0px; 
 }
 
+#input-filter-icon {
+    position: absolute;
+    top: 5px;
+    left: 8px;
+}
+
 #input-filter-tree {
     background-color: var(--theia-input-background);
-    border: none;
-    border-bottom: 1px solid var(--theia-input-foreground);
+    border-style: solid;
+    border-color: var(--theia-tree-inactiveIndentGuidesStroke);
+    border-radius: 15px;
     padding: 3px;
-    color: var(--theia-input-placeholder-foreground)
+    margin-bottom: 5px;
+    text-indent: 23px;
+    color: var(--theia-input-placeholder-foreground);
 }
 
 .ag-theme-balham{


### PR DESCRIPTION
This commit makes the text box for filter in the filter-tree more noticeable and recognizable as a text box by adding rounded borders and a filter-icon.

Resolve: [Issue #662](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/622)