### PR TITLE
Move the ticks of the time axis to below the time values

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -475,7 +475,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             {timeScaleChartExists &&
                 <>
                     <div style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING }}>
-                        <TimeAxisComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth }}
+                        <TimeAxisComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth, verticalAlign: 'bottom' }}
                             addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />
                     </div>
                 </>

--- a/packages/react-components/src/components/utils/__tests__/time-axis-component.test.tsx
+++ b/packages/react-components/src/components/utils/__tests__/time-axis-component.test.tsx
@@ -19,11 +19,11 @@ describe('Time axis component', () => {
       naviBackgroundColor: 0xf4f7fb,
       chartBackgroundColor: 0xf4f7fb,
       cursorColor: 0x259fd8,
-      lineColor: 0x757575
+      lineColor: 0x757575,
     }
 
-    const wrapper = mount(<TimeAxisComponent unitController={unitController} style={style} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null}/>);
-    expect(wrapper.contains(<TimeAxisComponent unitController={unitController} style={style} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null}/>));
+    const wrapper = mount(<TimeAxisComponent unitController={unitController} style={{...style, verticalAlign: 'bottom' }} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null}/>);
+    expect(wrapper.contains(<TimeAxisComponent unitController={unitController} style={{...style, verticalAlign: 'bottom' }} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null}/>));
   });
 
   it('creates canvas', () => {
@@ -40,7 +40,7 @@ describe('Time axis component', () => {
       lineColor: 0x757575
     }
 
-    const wrapper = mount(<TimeAxisComponent unitController={unitController} style={style} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null}/>);
+    const wrapper = mount(<TimeAxisComponent unitController={unitController} style={{...style, verticalAlign: 'bottom' }} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null}/>);
     expect(wrapper.find('canvas')).toHaveLength(1);
   });
 });

--- a/packages/react-components/src/components/utils/time-axis-component.tsx
+++ b/packages/react-components/src/components/utils/time-axis-component.tsx
@@ -10,7 +10,8 @@ interface TimeAxisProps {
         width: number,
         chartBackgroundColor: number,
         cursorColor: number,
-        lineColor: number
+        lineColor: number,
+        verticalAlign: string
     };
     addWidgetResizeHandler: (handler: () => void) => void;
     removeWidgetResizeHandler: (handler: () => void) => void;
@@ -37,7 +38,8 @@ export class TimeAxisComponent extends React.Component<TimeAxisProps> {
     protected getAxisLayer(): TimeGraphAxis {
         const timeAxisLayer = new TimeGraphAxis('timeGraphAxis', {
             color: this.props.style.chartBackgroundColor,
-            lineColor: this.props.style.lineColor
+            lineColor: this.props.style.lineColor,
+            verticalAlign: this.props.style.verticalAlign
         });
         return timeAxisLayer;
     }


### PR DESCRIPTION
Currently, the ticks of the time axis are displayed above the time values, which do not make sense UI-wise since graphs are displayed under the time axis. This commit moves the ticks to under the time labels by specifying the tickPosition configuration parameter of the TimeAxisComponent.

Resolve [Issue 775](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/755). Need to be merged after [Issue 203](https://github.com/eclipse-cdt-cloud/timeline-chart/issues/203) is resolved.