### PR TITLE
Persist state of view after pin/unpin

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -26,9 +26,11 @@ export declare interface SignalManager {
     fireTraceServerStartedSignal(): void;
     fireUndoSignal(): void;
     fireRedoSignal(): void;
-    firePinView(output: OutputDescriptor): void;
-    fireUnPinView(): void;
     fireOpenOverviewOutputSignal(): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    firePinView(output: OutputDescriptor, payload?: any): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fireUnPinView(output: OutputDescriptor, payload?: any): void;
 }
 
 export const Signals = {
@@ -123,11 +125,13 @@ export class SignalManager extends EventEmitter implements SignalManager {
     fireRedoSignal(): void {
         this.emit(Signals.REDO);
     }
-    firePinView(output: OutputDescriptor): void {
-        this.emit(Signals.PIN_VIEW, output);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    firePinView(output: OutputDescriptor, payload?: any): void {
+        this.emit(Signals.PIN_VIEW, output, payload);
     }
-    fireUnPinView(): void {
-        this.emit(Signals.UNPIN_VIEW);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    fireUnPinView(output: OutputDescriptor, payload?: any): void {
+        this.emit(Signals.UNPIN_VIEW, output, payload);
     }
     fireOpenOverviewOutputSignal(): void {
         this.emit(Signals.OPEN_OVERVIEW_OUTPUT);

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -41,6 +41,8 @@ export interface AbstractOutputProps {
     onTouchEnd?: VoidFunction;
     setChartOffset?: (chartOffset: number) => void;
     pinned?: boolean
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    persistChartState?: any;
 }
 
 export interface AbstractOutputState {
@@ -120,7 +122,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
 
     private closeComponent() {
         if (this.props.pinned) {
-            signalManager().fireUnPinView();
+            signalManager().fireUnPinView(this.props.outputDescriptor);
         }
         this.props.onOutputRemove(this.props.outputDescriptor.id);
     }
@@ -150,7 +152,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
 
     abstract resultsAreEmpty(): boolean;
 
-    private showOptions(): React.ReactNode {
+    protected showOptions(): React.ReactNode {
         return <React.Fragment>
             <ul>
                 {this.props.pinned === undefined && <li className='drop-down-list-item' onClick={() => this.pinView()}>Pin View</li>}
@@ -168,12 +170,18 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         return;
     }
 
-    protected pinView(): void {
-        signalManager().firePinView(this.props.outputDescriptor);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    protected pinView(payload?: any): void {
+        signalManager().firePinView(this.props.outputDescriptor, payload);
     }
 
-    protected unPinView(): void {
-        signalManager().fireUnPinView();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    protected unPinView(payload?: any): void {
+        if (payload) {
+            signalManager().fireUnPinView(this.props.outputDescriptor, payload);
+        } else {
+            signalManager().fireUnPinView(this.props.outputDescriptor);
+        }
     }
 
     protected renderAnalysisFailed(): React.ReactFragment {

--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -17,7 +17,6 @@ import { BIMath } from 'timeline-chart/lib/bigint-utils';
 import { XYChartFactoryParams, xyChartFactory, GetClosestPointParam, getClosestPointForScatterPlot } from './utils/xy-output-component-utils';
 import { ChartOptions } from 'chart.js';
 import { Line, Scatter } from 'react-chartjs-2';
-import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { getAllExpandedNodeIds } from './utils/filter-tree/utils';
 import { throttle } from 'lodash';
 
@@ -98,8 +97,6 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
     protected positionXMove = 0;
     protected startPositionMouseRightClick = BigInt(0);
 
-    // Event handlers
-    protected onSelectionChanged = (payload: { [key: string]: string; }) => this.doHandleSelectionChangedSignal(payload);
     protected endSelection = (event: MouseEvent): void => {
         if (this.clickedMouseButton === MouseButton.RIGHT) {
            this.applySelectionZoom();
@@ -136,7 +133,6 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         this.divRef = React.createRef();
         this.chartRef = React.createRef();
 
-        signalManager().on(Signals.SELECTION_CHANGED, this.onSelectionChanged);
         this.afterChartDraw = this.afterChartDraw.bind(this);
     }
 
@@ -184,20 +180,6 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
             }
         });
         this.setState({checkedSeries: newList});
-    }
-
-    private doHandleSelectionChangedSignal(payload: { [key: string]: string }) {
-        const offset = this.props.viewRange.getOffset() || BigInt(0);
-        const startTimestamp = payload['startTimestamp'];
-        const endTimestamp = payload['endTimestamp'];
-        if (startTimestamp !== undefined && endTimestamp !== undefined) {
-            const selectionRangeStart = BigInt(startTimestamp) - offset;
-            const selectionRangeEnd = BigInt(endTimestamp) - offset;
-            this.props.unitController.selectionRange = {
-                start: selectionRangeStart,
-                end: selectionRangeEnd
-            };
-        }
     }
 
     private updateRange(rangeStart: bigint, rangeEnd: bigint): void {
@@ -264,7 +246,6 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
 
     componentWillUnmount(): void {
         super.componentWillUnmount();
-        signalManager().off(Signals.SELECTION_CHANGED, this.onSelectionChanged);
     }
 
     async fetchTree(): Promise<ResponseStatus> {

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -35,7 +35,8 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
             collapsedNodes: [],
             orderedNodes: [],
             columns: [{title: 'Name', sortable: true}],
-            optionsDropdownOpen: false
+            optionsDropdownOpen: false,
+            additionalOptions: true
         };
     }
 

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -427,7 +427,22 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             const payload = { startTimestamp, endTimestamp, load };
             this.prevStartTimestamp = BigInt(startTimestamp);
             this.eventSignal = true;
+            this.handleSelectionRangeUpdate(payload);
             signalManager().fireSelectionChangedSignal(payload);
+        }
+    }
+
+    private handleSelectionRangeUpdate(payload: { [key: string]: string; }) {
+        const offset = this.props.viewRange.getOffset() || BigInt(0);
+        const startTimestamp = payload['startTimestamp'];
+        const endTimestamp = payload['endTimestamp'];
+        if (startTimestamp !== undefined && endTimestamp !== undefined) {
+            const selectionRangeStart = BigInt(startTimestamp) - offset;
+            const selectionRangeEnd = BigInt(endTimestamp) - offset;
+            this.props.unitController.selectionRange = {
+                start: selectionRangeStart,
+                end: selectionRangeEnd
+            };
         }
     }
 

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -22,7 +22,7 @@ import { TspDataProvider } from './data-providers/tsp-data-provider';
 import { ReactTimeGraphContainer } from './utils/timegraph-container-component';
 import { OutputElementStyle } from 'tsp-typescript-client/lib/models/styles';
 import { EntryTree } from './utils/filter-tree/entry-tree';
-import { listToTree, getAllExpandedNodeIds, getIndexOfNode } from './utils/filter-tree/utils';
+import { listToTree, getAllExpandedNodeIds, getIndexOfNode, validateNumArray } from './utils/filter-tree/utils';
 import hash from 'traceviewer-base/lib/utils/value-hash';
 import ColumnHeader from './utils/filter-tree/column-header';
 import { TimeGraphAnnotationComponent } from 'timeline-chart/lib/components/time-graph-annotation';
@@ -77,9 +77,9 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             timegraphTree: [],
             markerCategoryEntries: [],
             markerLayerData: undefined,
-            collapsedNodes: [],
+            collapsedNodes: validateNumArray(this.props.persistChartState?.collapsedNodes) ? this.props.persistChartState.collapsedNodes as number[] : [],
             columns: [],
-            collapsedMarkerNodes: [],
+            collapsedMarkerNodes: validateNumArray(this.props.persistChartState?.collapsedMarkerNodes) ? this.props.persistChartState.collapsedMarkerNodes as number[] : [],
             optionsDropdownOpen: false,
             dataRows: []
         };
@@ -912,4 +912,23 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         this.chartLayer.selectAndReveal(rowIndex);
     }
 
+    protected showOptions(): React.ReactNode {
+        return <React.Fragment>
+            <ul>
+                {this.props.pinned === undefined &&
+                    <li className='drop-down-list-item'
+                        onClick={() => this.pinView({ collapsedNodes: this.state.collapsedNodes,
+                                                    collapsedMarkerNodes: this.state.collapsedMarkerNodes })}>
+                        Pin View
+                    </li>}
+                {this.props.pinned === true &&
+                <li className='drop-down-list-item'
+                    onClick={() => this.unPinView({ collapsedNodes: this.state.collapsedNodes,
+                                                    collapsedMarkerNodes: this.state.collapsedMarkerNodes })}>
+                    Unpin View
+                </li>}
+            </ul>
+            {this.state.additionalOptions && this.showAdditionalOptions()}
+        </React.Fragment>;
+    }
 }

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -285,12 +285,9 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private doHandleSelectionChangedSignal(payload: { [key: string]: string }) {
-        const offset = this.props.viewRange.getOffset() || BigInt(0);
         const startTimestamp = payload['startTimestamp'];
         const endTimestamp = payload['endTimestamp'];
         if (startTimestamp !== undefined && endTimestamp !== undefined) {
-            const selectionRangeStart = BigInt(startTimestamp) - offset;
-            const selectionRangeEnd = BigInt(endTimestamp) - offset;
             const foundElement = this.findElement(payload);
 
             // Scroll vertically
@@ -302,12 +299,6 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     this.pendingSelection = foundElement;
                 }
             }
-
-            // Scroll horizontally
-            this.props.unitController.selectionRange = {
-                start: selectionRangeStart,
-                end: selectionRangeEnd
-            };
             this.chartCursors.maybeCenterCursor();
         }
     }

--- a/packages/react-components/src/components/utils/filter-tree/utils.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/utils.tsx
@@ -62,3 +62,13 @@ export const getIndexOfNode = (id: number, nodes: TreeNode[], collapsedNodes: nu
     const ids = getAllExpandedNodeIds(nodes, collapsedNodes);
     return ids.findIndex(eId => eId === id);
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const validateNumArray = (arr: any | undefined): boolean => {
+    if (arr && Array.isArray(arr)) {
+        return (arr.length > 0 &&
+            arr.every( value => typeof value === 'number')
+        );
+    }
+    return false;
+};

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -7,6 +7,7 @@ import { BIMath } from 'timeline-chart/lib/bigint-utils';
 import { scaleLinear } from 'd3-scale';
 import { AbstractXYOutputComponent, AbstractXYOutputState, FLAG_PAN_LEFT, FLAG_PAN_RIGHT, FLAG_ZOOM_IN, FLAG_ZOOM_OUT, MouseButton } from './abstract-xy-output-component';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { validateNumArray } from './utils/filter-tree/utils';
 
 export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputProps, AbstractXYOutputState> {
     private mousePanningStart = BigInt(0);
@@ -18,8 +19,8 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
             outputStatus: ResponseStatus.RUNNING,
             selectedSeriesId: [],
             xyTree: [],
-            checkedSeries: [],
-            collapsedNodes: [],
+            checkedSeries: validateNumArray(this.props.persistChartState?.checkedSeries) ? this.props.persistChartState.checkedSeries as number[] : [],
+            collapsedNodes: validateNumArray(this.props.persistChartState?.collapsedNodes) ? this.props.persistChartState.collapsedNodes as number[] : [],
             orderedNodes: [],
             xyData: {},
             columns: [{title: 'Name', sortable: true}],
@@ -371,5 +372,26 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
 
     protected getZoomTime(): bigint {
         return this.getTimeForX(this.positionXMove);
+    }
+
+    protected showOptions(): React.ReactNode {
+        return <React.Fragment>
+            <ul>
+                {this.props.pinned === undefined &&
+                    <li className='drop-down-list-item'
+                        onClick={() => this.pinView({ checkedSeries: this.state.checkedSeries,
+                                                    collapsedNodes: this.state.collapsedNodes })}
+                    >
+                        Pin View
+                    </li>}
+                {this.props.pinned === true &&
+                    <li className='drop-down-list-item'
+                        onClick={() => this.unPinView({ checkedSeries: this.state.checkedSeries,
+                                                    collapsedNodes: this.state.collapsedNodes })}>
+                        Unpin View
+                    </li>}
+            </ul>
+            {this.state.additionalOptions && this.showAdditionalOptions()}
+        </React.Fragment>;
     }
 }


### PR DESCRIPTION
- This is an improvement of the feature in PR #739 
- When a view is pinned/unpinned it is re-rerendered onto the layout as it is moving to a different container. This re-rendering does not happen when dragging views since they are re-arranged in the same container. So when a view is pinned/unpinned, the charts lose their state and the user has to redo the selections.
- This patch tries to persist the state of the view that's being pinned and unpinned. Luckily, we are able to pass the state of the chart as a payload when firing the signal to pin/unpin a view.
- This is being used by the xy-charts to pass the checkedSeries and collapsedNodes of the tree, and the timegraph-charts to pass the collapsedNodes and collapsedMarkerNodes.
- By doing so we ensure that the chart state stays the same and the user does not have to re-do their selections
- Unfortunately I could not find a way to persist the scroll position of the tree or the order of tree columns of the xy chart. If there are any suggestions I'll try them out.
- The xy-output-component currently does not support data-provider styles and randomly assigns series colors. Therefore, sometimes after pin/unpin I've noticed minor changes in the overall color scheme. We'll be working on implementing data-provider styles for xy in the near future, so I'm assuming this issue would not pose as a blocker.

Fixes #762

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>