### PR TITLE
Fix issues with server status indicator

### DIFF
--- a/packages/react-components/style/trace-explorer.css
+++ b/packages/react-components/style/trace-explorer.css
@@ -286,7 +286,19 @@
     justify-content: flex-end !important;
 }
 
-#trace\.viewer\.serverCheck {
-    cursor: default;
-    color: green;
+.server-status-header {
+    background: var(--theia-sideBarSectionHeader-background);
+    line-height: var(--theia-view-container-title-height);
+    z-index: 10;
+    color: var(--theia-sideBarSectionHeader-foreground);
+    margin-bottom: 2px;
+    padding-left: 23px;
+    overflow: hidden;
+}
+
+#server-status-id {
+    float: right;
+    margin-top: 4px;
+    margin-bottom: 2px;
+    margin-right: 3px;
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
@@ -8,7 +8,7 @@ import { OpenTraceCommand } from '../../trace-viewer/trace-viewer-commands';
 export class TraceExplorerPlaceholderWidget extends ReactWidget {
 
     static ID = 'trace-explorer-placeholder-widget';
-    static LABEL = 'Trace Exploerer Placeholder Widget';
+    static LABEL = 'Trace Explorer Placeholder Widget';
 
     state = {
         loading: false

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
@@ -1,0 +1,31 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { ReactWidget } from '@theia/core/lib/browser';
+import * as React from 'react';
+import { CommandService } from '@theia/core';
+
+@injectable()
+export class TraceExplorerServerStatusWidget extends ReactWidget {
+
+    static ID = 'trace-explorer-server-status-widget';
+    static LABEL = 'Trace Explorer Server Status Widget';
+
+    private constructor() {
+        super();
+    }
+
+    @inject(CommandService) protected readonly commandService!: CommandService;
+
+    @postConstruct()
+    init(): void {
+        this.id = TraceExplorerServerStatusWidget.ID;
+        this.title.label = TraceExplorerServerStatusWidget.LABEL;
+        this.update();
+    }
+
+    render(): React.ReactNode {
+        return <div className='server-status-header'>
+            <span className='theia-header'>Server Status </span>
+            <i id='server-status-id' className='fa fa-times-circle-o fa-lg' title='Trace Viewer Critical Error: Trace Server Offline' style={{color: 'red', marginLeft: '5px'}}/>
+        </div>;
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -4,6 +4,7 @@ import { ViewContainer, BaseWidget, Message, PanelLayout } from '@theia/core/lib
 import { TraceExplorerTooltipWidget } from './trace-explorer-sub-widgets/trace-explorer-tooltip-widget';
 import { TraceExplorerOpenedTracesWidget } from './trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget';
 import { TraceExplorerPlaceholderWidget } from './trace-explorer-sub-widgets/trace-explorer-placeholder-widget';
+import { TraceExplorerServerStatusWidget } from './trace-explorer-sub-widgets/trace-explorer-server-status-widget';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { OpenedTracesUpdatedSignalPayload } from 'traceviewer-base/src/signals/opened-traces-updated-signal-payload';
 import { TraceServerConnectionStatusService } from '../trace-server-status';
@@ -18,6 +19,7 @@ export class TraceExplorerWidget extends BaseWidget {
     @inject(TraceExplorerOpenedTracesWidget) protected readonly openedTracesWidget!: TraceExplorerOpenedTracesWidget;
     @inject(TraceExplorerTooltipWidget) protected readonly tooltipWidget!: TraceExplorerTooltipWidget;
     @inject(TraceExplorerPlaceholderWidget) protected readonly placeholderWidget!: TraceExplorerPlaceholderWidget;
+    @inject(TraceExplorerServerStatusWidget) protected readonly serverStatusWidget!: TraceExplorerServerStatusWidget;
     @inject(ViewContainer.Factory) protected readonly viewContainerFactory!: ViewContainer.Factory;
     @inject(TraceServerConnectionStatusService) protected readonly connectionStatusService: TraceServerConnectionStatusService;
 
@@ -43,6 +45,7 @@ export class TraceExplorerWidget extends BaseWidget {
         child.bind(TraceExplorerViewsWidget).toSelf();
         child.bind(TraceExplorerOpenedTracesWidget).toSelf();
         child.bind(TraceExplorerPlaceholderWidget).toSelf();
+        child.bind(TraceExplorerServerStatusWidget).toSelf();
         child.bind(TraceExplorerTooltipWidget).toSelf();
         child.bind(TraceExplorerWidget).toSelf().inSingletonScope();
         return child;
@@ -63,6 +66,7 @@ export class TraceExplorerWidget extends BaseWidget {
         this.traceViewsContainer.addWidget(this.tooltipWidget);
         this.toDispose.push(this.traceViewsContainer);
         const layout = this.layout = new PanelLayout();
+        layout.addWidget(this.serverStatusWidget);
         layout.addWidget(this.placeholderWidget);
         layout.addWidget(this.traceViewsContainer);
         this.node.tabIndex = 0;

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-status.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-status.ts
@@ -9,11 +9,7 @@ export class TraceServerConnectionStatusService {
 
     private constructor() {
         this.connectionStatusListener = ((status: boolean) => {
-            if (status) {
-                this.renderSuccess();
-            } else {
-                this.renderFailure();
-            }
+            TraceServerConnectionStatusService.renderStatus(status);
         });
     }
 
@@ -25,19 +21,12 @@ export class TraceServerConnectionStatusService {
         RestClient.removeConnectionStatusListener(this.connectionStatusListener);
     }
 
-    private renderSuccess(): void {
-        if (document.getElementById('trace.viewer.serverCheck')) {
-            document.getElementById('trace.viewer.serverCheck')!.className = 'fa fa-check-circle-o fa-lg';
-            document.getElementById('trace.viewer.serverCheck')!.title = 'Server health and latency are good. No known issues';
-            document.getElementById('trace.viewer.serverCheck')!.style.color = 'green';
-        }
-    }
-
-    private renderFailure(): void {
-        if (document.getElementById('trace.viewer.serverCheck')) {
-            document.getElementById('trace.viewer.serverCheck')!.className = 'fa fa-times-circle-o fa-lg';
-            document.getElementById('trace.viewer.serverCheck')!.title = 'Trace Viewer Critical Error: Trace Server Offline';
-            document.getElementById('trace.viewer.serverCheck')!.style.color = 'red';
+    static renderStatus(status: boolean): void {
+        if (document.getElementById('server-status-id')) {
+            document.getElementById('server-status-id')!.className = status ? 'fa fa-check-circle-o fa-lg' : 'fa fa-times-circle-o fa-lg';
+            document.getElementById('server-status-id')!.title = status ?
+                'Server health and latency are good. No known issues' : 'Trace Viewer Critical Error: Trace Server Offline';
+            document.getElementById('server-status-id')!.style.color = status ? 'green' : 'red';
         }
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -12,6 +12,7 @@ import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { ChartShortcutsDialog } from './../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
+import { TraceServerConnectionStatusService } from '../trace-server-status';
 
 interface TraceViewerWidgetOpenerOptions extends WidgetOpenerOptions {
     traceUUID: string;
@@ -183,6 +184,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                     } else {
                         this.messageService.info('Trace server started.');
                     }
+                    TraceServerConnectionStatusService.renderStatus(true);
                     signalManager().fireTraceServerStartedSignal();
                 } catch (error) {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -208,6 +210,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                 try {
                     await this.traceServerConfigService.stopTraceServer();
                     this.messageService.info('Trace server terminated successfully.');
+                    TraceServerConnectionStatusService.renderStatus(false);
                 } catch (err) {
                     this.messageService.error('Failed to stop the trace server.');
                 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
@@ -54,12 +54,6 @@ export namespace TraceViewerToolbarCommands {
         iconClass: 'fa fa-info-circle fa-lg',
     };
 
-    export const SERVER_CHECK: Command = {
-        id: 'trace.viewer.serverCheck',
-        label: 'Server health and latency are good. No known issues',
-        iconClass: 'fa fa-check-circle-o fa-lg',
-    };
-
     export const OPEN_OVERVIEW_OUTPUT: Command = {
         id: 'trace.viewer.traceOverview',
         label: 'Show trace overview',

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -10,7 +10,6 @@ import { TspClientProvider } from '../tsp-client-provider-impl';
 import { TraceViewerWidget } from './trace-viewer';
 import { OpenTraceCommand } from './trace-viewer-commands';
 import { TraceViewerToolbarCommands, TraceViewerToolbarMenus } from './trace-viewer-toolbar-commands';
-import { TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 
 @injectable()
 export class TraceViewerToolbarContribution implements TabBarToolbarContribution, CommandContribution {
@@ -145,17 +144,6 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             execute: () => {
                 this.chartShortcuts.open();
             }
-        });
-        registry.registerCommand(
-            TraceViewerToolbarCommands.SERVER_CHECK, {
-            isVisible: (w: Widget) => {
-                if (w instanceof TraceExplorerWidget) {
-                    return true;
-                }
-                return false;
-            },
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            execute: () => {}
         });
     }
 
@@ -305,12 +293,6 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             command: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.id,
             tooltip: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.label,
             priority: 10,
-        });
-        registry.registerItem({
-            id: TraceViewerToolbarCommands.SERVER_CHECK.id,
-            command: TraceViewerToolbarCommands.SERVER_CHECK.id,
-            tooltip: TraceViewerToolbarCommands.SERVER_CHECK.label,
-            priority: 11,
         });
     }
 }


### PR DESCRIPTION
I found the following issues with the current server status indicator:
1) Status indicator is incorrect when the trace-viewer is started without connection to the server:
![Screen Shot 2022-07-08 at 2 52 35 PM](https://user-images.githubusercontent.com/92893187/178064894-1d3d8cc7-c392-43a4-a539-10e5278468a4.png)

2) Status indicator is incorrect when toggling the trace-viewer left-hand panel (trace-explorer-widget):
![Screen Recording 2022-07-08 at 2 53 50 PM](https://user-images.githubusercontent.com/92893187/178065174-225d5380-f813-44f5-9e88-6838807e5f9f.gif)

When looking into the code, the connectionStatusListener defined in PR #671 works as expected, but it is not always able to modify the indicator through JavaScript. This might be because the indicator is not an icon but a Theia Command. Registering a toolbar command allowed us to place the icon in Trace Explorer widget's title bar, but the statusListener fails to always update the icon. A better contribution point would be to place the icon as a child of the Trace Explorer widget. The following is how the status indicator looks like in this patch:
![Screen Shot 2022-07-08 at 2 56 24 PM copy](https://user-images.githubusercontent.com/92893187/178072654-6d5047b9-59d1-46d9-b54f-f9b41c57a52e.png)

I would like some suggestions on the UI and possible alternatives on how to present the status indicator

fixes #763


Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>