### PR TITLE
Fix theia-trace-extension table vertical scrollbar

### DIFF
--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -51,6 +51,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     private selectEndIndex = -1;
     private filterModel: Map<string, string> = new Map<string, string>();
     private dataSource: IDatasource;
+    private tableSize = 0;
 
     static defaultProps: Partial<TableOutputProps> = {
         cacheBlockSize: 200,
@@ -83,13 +84,13 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                     this.fetchColumns = false;
                     await this.init();
                 }
-                const rowsThisPage = await this.fetchSearchTableLines(params.startRow, params.endRow - params.startRow);
+                const rowsThisPage = await this.fetchTableLines(params.startRow, params.endRow - params.startRow);
                 for (let i = 0; i < rowsThisPage.length; i++) {
                     const item = rowsThisPage[i];
                     const itemCopy = cloneDeep(item);
                     rowsThisPage[i] = itemCopy;
                 }
-                params.successCallback(rowsThisPage, this.props.nbEvents);
+                params.successCallback(rowsThisPage, this.tableSize);
             }
         };
         this.onEventClick = this.onEventClick.bind(this);
@@ -476,7 +477,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
 
     }
 
-    private async fetchSearchTableLines(fetchIndex: number, linesToFetch: number) {
+    private async fetchTableLines(fetchIndex: number, linesToFetch: number) {
         const traceUUID = this.props.traceId;
         const tspClient = this.props.tspClient;
         const outputId = this.props.outputDescriptor.id;
@@ -487,6 +488,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         if (!tspClientResponse.isOk() || !lineResponse) {
             return new Array<any>();
         }
+        this.tableSize = lineResponse.model.size;
         return this.modelToRow(lineResponse.model);
     }
 


### PR DESCRIPTION
During the developpment of the segment store table data provider this issue was found.
![image](https://user-images.githubusercontent.com/107507176/178286396-7c31087d-6e67-4190-be36-4e875eeb643d.png)
In fact the vertical scrollbar was not adjusted to show the real size of the table.
In this PR, the issue is resolved by setting the size of the table to be the same as the number of elements displayed in the table.
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/107507176/178287667-95465a93-88c9-4d12-b6e5-2efc4491936b.png)

