### PR TITLE
Add dialog to select output for trace overview

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -31,6 +31,7 @@ export declare interface SignalManager {
     firePinView(output: OutputDescriptor, payload?: any): void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fireUnPinView(output: OutputDescriptor, payload?: any): void;
+    fireOverviewOutputSelectedSignal(payload: { traceId: string, outputDescriptor: OutputDescriptor}): void;
 }
 
 export const Signals = {
@@ -58,7 +59,8 @@ export const Signals = {
     TRACE_SERVER_STARTED: 'trace server started',
     PIN_VIEW: 'view pinned',
     UNPIN_VIEW: 'view unpinned',
-    OPEN_OVERVIEW_OUTPUT: 'open overview output'
+    OPEN_OVERVIEW_OUTPUT: 'open overview output',
+    OVERVIEW_OUTPUT_SELECTED: 'overview output selected'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -135,6 +137,9 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireOpenOverviewOutputSignal(): void {
         this.emit(Signals.OPEN_OVERVIEW_OUTPUT);
+    }
+    fireOverviewOutputSelectedSignal(payload: { traceId: string, outputDescriptor: OutputDescriptor}): void {
+        this.emit(Signals.OVERVIEW_OUTPUT_SELECTED, payload);
     }
 }
 

--- a/packages/react-components/src/components/abstract-dialog-component.tsx
+++ b/packages/react-components/src/components/abstract-dialog-component.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactModal from 'react-modal';
+import '../../style/dialog-component-style.css';
+import '../../style/output-components-style.css';
+
+export interface DialogComponentProps {
+    title: string,
+    onCloseDialog: () => void,
+    isOpen: boolean
+}
+
+export abstract class AbstractDialogComponent<P extends DialogComponentProps, S> extends React.Component<P, S> {
+    constructor(props: P) {
+        super(props);
+    }
+
+    render(): React.ReactNode {
+        return <ReactModal isOpen={this.props.isOpen}
+        overlayClassName="dialog-overlay"
+        className="dialog"
+        ariaHideApp={false}
+        shouldFocusAfterRender={false}>
+            <div onClick={e => {e.preventDefault();}}>
+                <div className='dialog-header'>
+                    <div>{this.props.title}</div>
+                    <i className='dialog-header-close codicon codicon-close' onClick={this.props.onCloseDialog}></i>
+                </div>
+                <div className='dialog-body'>{this.renderDialogBody()}</div>
+                <div className='dialog-footer'>{this.renderFooter()}</div>
+            </div>
+        </ReactModal>;
+    }
+
+    protected abstract renderDialogBody(): React.ReactFragment;
+    protected abstract renderFooter(): React.ReactFragment;
+}

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -103,14 +103,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             <button className='remove-component-button' onClick={this.closeComponent}>
                 <FontAwesomeIcon icon={faTimes} />
             </button>
-            {(this.props.pinned !== false || this.state.additionalOptions) && <div className='options-menu-container'>
-                <button title="Show View Options" className='options-menu-button' onClick={this.openOptionsMenu}>
-                    <FontAwesomeIcon icon={faBars} />
-                </button>
-                {this.state.optionsDropdownOpen && <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
-                    {this.showOptions()}
-                </div>}
-            </div>}
+            {this.showOptionsMenu()}
             <div className='title-bar-label' title={outputTooltip} onClick={() => this.setFocus()}>
                 {outputName}
                 <i id={this.getOutputComponentDomId() + 'handleSpinner'} className='fa fa-refresh fa-spin'
@@ -151,6 +144,19 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     abstract renderMainArea(): React.ReactNode;
 
     abstract resultsAreEmpty(): boolean;
+
+    protected showOptionsMenu(): React.ReactNode {
+        return <React.Fragment>
+            {(this.props.pinned !== false || this.state.additionalOptions) && <div className='options-menu-container'>
+                <button title="Show View Options" className='options-menu-button' onClick={this.openOptionsMenu}>
+                    <FontAwesomeIcon icon={faBars} />
+                </button>
+                {this.state.optionsDropdownOpen && <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
+                    {this.showOptions()}
+                </div>}
+            </div>}
+        </React.Fragment>;
+    }
 
     protected showOptions(): React.ReactNode {
         return <React.Fragment>

--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -348,7 +348,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
     protected chooseChart(): JSX.Element {
 
         const param: XYChartFactoryParams = {
-            viewRange: this.props.viewRange,
+            viewRange: this.getDisplayedRange(),
             allMax: this.state.allMax,
             allMin: this.state.allMin,
             isScatterPlot: this.isScatterPlot

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -541,16 +541,13 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         rowHeight={rowHeight}
         draggableHandle={'.title-bar-label'}>
             {outputs.map(output => {
-                let isPinned;
                 let onOutputRemove;
                 let responseType;
                 if (isOverview) {
-                    isPinned = false;
                     onOutputRemove = this.props.onOverviewRemove;
                     responseType = 'OVERVIEW';
                 }
                 else {
-                    isPinned =  this.state.pinnedView ? (this.state.pinnedView.id === output.id) : undefined;
                     onOutputRemove = this.props.onOutputRemove;
                     responseType = output.type;
                 }
@@ -574,11 +571,13 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     outputWidth: this.state.style.width,
                     backgroundTheme: this.state.backgroundTheme,
                     setChartOffset: this.setChartOffset,
-                    pinned: isPinned
+                    pinned: this.state.pinnedView ? (this.state.pinnedView === output) : undefined
                 };
                 switch (responseType) {
                     case 'OVERVIEW':
-                        return <TraceOverviewComponent key={this.OVERVIEW_OUTPUT_GRID_LAYOUT_ID} {...outputProps}></TraceOverviewComponent>;
+                        return <TraceOverviewComponent key={this.OVERVIEW_OUTPUT_GRID_LAYOUT_ID}
+                        experiment={this.props.experiment}
+                        {...outputProps}></TraceOverviewComponent>;
                     case 'TIME_GRAPH':
                         if (this.chartPersistedState && this.chartPersistedState.output.id === output.id) {
                             outputProps.persistChartState = this.chartPersistedState.payload;

--- a/packages/react-components/src/components/trace-overview-component.tsx
+++ b/packages/react-components/src/components/trace-overview-component.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { AbstractOutputProps } from './abstract-output-component';
 import { XYOutputOverviewComponent } from './xy-output-overview-component';
 
-export class TraceOverviewComponent extends React.Component<AbstractOutputProps> {
-    constructor(props: AbstractOutputProps){
+type XYoutputOverviewProps = AbstractOutputProps & {
+    experiment: Experiment;
+};
+
+export class TraceOverviewComponent extends React.Component<XYoutputOverviewProps> {
+    constructor(props: XYoutputOverviewProps){
         super(props);
     }
 
     render(): JSX.Element {
-        if (this.props.outputDescriptor.id === 'org.eclipse.tracecompass.internal.tmf.core.histogram.HistogramDataProvider')
-        {
-            return <XYOutputOverviewComponent {...this.props}></XYOutputOverviewComponent>;
-        }
-
-        return <div>No overview for this view is available</div>;
+        return <XYOutputOverviewComponent key={this.props.outputDescriptor.id} {...this.props}></XYOutputOverviewComponent>;
     }
 }

--- a/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
+++ b/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { OutputDescriptor, TspClient } from 'tsp-typescript-client';
+import { AbstractDialogComponent, DialogComponentProps } from './abstract-dialog-component';
+import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
+import { AvailableViewsComponent } from './utils/available-views-component';
+
+export interface TraceOverviewSelectionComponentProps extends DialogComponentProps {
+    tspClient: TspClient,
+    traceID: string
+}
+
+export interface TraceOverviewSelectionComponentState {
+    outputDescriptors: OutputDescriptor[]
+}
+
+export class TraceOverviewSelectionDialogComponent extends AbstractDialogComponent<TraceOverviewSelectionComponentProps, TraceOverviewSelectionComponentState> {
+    private selectedOutput: OutputDescriptor | undefined;
+    protected handleOutputClicked = (selectedOutput: OutputDescriptor): void => this.doHandleOutputClicked(selectedOutput);
+
+    constructor(props: TraceOverviewSelectionComponentProps) {
+        super(props);
+        this.state = {
+            outputDescriptors: []
+        };
+
+        this.getAvailableOutputDescriptors();
+    }
+
+    protected renderDialogBody(): React.ReactFragment{
+        if (!this.state.outputDescriptors) {
+            return (<div>
+                Loading available outputs...
+            </div>);
+        }
+
+        const key = Number(true);
+        return (
+            <div id="trace-overview-selection-dialog-content-container">
+                <AvailableViewsComponent
+                    availableViewListKey={key}
+                    onOutputClicked={e => {this.doHandleOutputClicked(e);}}
+                    outputDescriptors={this.state.outputDescriptors}
+                    listRowWidth='95%'
+                    listRowPadding='10px'
+                ></AvailableViewsComponent>
+            </div>
+        );
+    }
+
+    protected renderFooter(): React.ReactFragment {
+        return (
+           <button className="theia-button secondary" onClick={this.props.onCloseDialog}>Close</button>
+        );
+    }
+
+    private async getAvailableOutputDescriptors() {
+        if (this.props.traceID){
+            const result = await this.props.tspClient.experimentOutputs(this.props.traceID);
+            const descriptors = result.getModel();
+            const overviewOutputDescriptors = descriptors?.filter(output => output.type === 'TREE_TIME_XY');
+            if (overviewOutputDescriptors) {
+                this.setState({
+                    outputDescriptors: overviewOutputDescriptors
+                });
+            }
+        }
+    }
+
+    private doHandleOutputClicked(selectedOutput: OutputDescriptor) {
+        signalManager().fireOverviewOutputSelectedSignal({
+            traceId: this.props.traceID,
+            outputDescriptor: selectedOutput
+        });
+        this.props.onCloseDialog();
+    }
+}

--- a/packages/react-components/src/components/utils/available-views-component.tsx
+++ b/packages/react-components/src/components/utils/available-views-component.tsx
@@ -1,0 +1,122 @@
+import { ListRowProps, AutoSizer, List } from 'react-virtualized';
+import React from 'react';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+
+export interface AvailableViewsComponentProps {
+    availableViewListKey: number,
+    outputDescriptors: OutputDescriptor[],
+    onContextMenuEvent?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>, output: OutputDescriptor | undefined) => void,
+    onOutputClicked: (selectedOutput: OutputDescriptor) => void,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    listRowWidth?: string,
+    listRowPadding?: string
+}
+
+export interface AvailableViewsComponentState {
+    lastSelectedOutputIndex: number;
+}
+
+export class AvailableViewsComponent  extends React.Component<AvailableViewsComponentProps, AvailableViewsComponentState>{
+    static LIST_MARGIN = 2;
+    static LINE_HEIGHT = 16;
+    static ROW_HEIGHT = (2 * AvailableViewsComponent.LINE_HEIGHT) + AvailableViewsComponent.LIST_MARGIN;
+
+    protected handleOutputClicked = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOutputClicked(e);
+
+    constructor(props: AvailableViewsComponentProps){
+        super(props);
+        this.state = { lastSelectedOutputIndex: -1 };
+    }
+
+    render(): React.ReactNode {
+        let outputsRowCount = 0;
+        const outputs = this.props.outputDescriptors;
+        if (outputs) {
+            outputsRowCount = outputs.length;
+        }
+        const totalHeight = this.getTotalHeight();
+        return (
+            <div>
+                <div className='trace-explorer-panel-content disable-select' style={{height: totalHeight}}>
+                    <AutoSizer>
+                        {({ width }) =>
+                            <List
+                                key={this.props.availableViewListKey}
+                                height={totalHeight}
+                                width={width}
+                                rowCount={outputsRowCount}
+                                rowHeight={AvailableViewsComponent.ROW_HEIGHT}
+                                rowRenderer={this.renderRowOutputs}
+                            />
+                        }
+                    </AutoSizer>
+                </div>
+            </div>
+        );
+    }
+
+    protected renderRowOutputs = (props: ListRowProps): React.ReactNode => this.doRenderRowOutputs(props);
+
+    private doRenderRowOutputs(props: ListRowProps): React.ReactNode {
+        let outputName = '';
+        let outputDescription = '';
+        let output: OutputDescriptor | undefined;
+        const outputDescriptors = this.props.outputDescriptors;
+        if (outputDescriptors && outputDescriptors.length && props.index < outputDescriptors.length) {
+            output = outputDescriptors[props.index];
+            outputName = output.name;
+            outputDescription = output.description;
+        }
+        let traceContainerClassName = 'outputs-list-container';
+        if (props.index === this.state.lastSelectedOutputIndex) {
+            traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
+        }
+
+        if (this.props.listRowWidth) {
+            props.style.width = this.props.listRowWidth;
+        }
+
+        if (this.props.listRowPadding) {
+            props.style.paddingLeft = this.props.listRowPadding;
+            props.style.paddingRight = this.props.listRowPadding;
+        }
+
+        return <div className={traceContainerClassName}
+            title={outputName + ':\n' + outputDescription}
+            id={`${traceContainerClassName}-${props.index}`}
+            key={props.key}
+            style={props.style}
+            onClick={this.handleOutputClicked}
+            onContextMenu={event => { this.doHandleContextMenuEvent(event, output); }}
+            data-id={`${props.index}`}
+        >
+            <div style={{width: '100%'}}>
+                <h4 className='outputs-element-name'>
+                    {outputName}
+                </h4>
+                <div className='outputs-element-description child-element'>
+                    {outputDescription}
+                </div>
+            </div>
+        </div>;
+    }
+
+    private doHandleContextMenuEvent(event: React.MouseEvent<HTMLDivElement, MouseEvent>, output: OutputDescriptor | undefined) {
+        if (this.props.onContextMenuEvent)
+            {this.props.onContextMenuEvent(event, output);}
+    }
+
+    private doHandleOutputClicked(e: React.MouseEvent<HTMLDivElement>) {
+        const index = Number(e.currentTarget.getAttribute('data-id'));
+        const selectedOutput = this.props.outputDescriptors[index];
+
+        this.props.onOutputClicked(selectedOutput);
+    }
+
+    protected getTotalHeight(): number {
+        let totalHeight = 0;
+        const outputDescriptors = this.props.outputDescriptors;
+        outputDescriptors?.forEach(() => totalHeight += AvailableViewsComponent.ROW_HEIGHT);
+        return totalHeight;
+    }
+}

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -5,6 +5,10 @@ import { drawSelection } from './utils/xy-output-component-utils';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
 import { AbstractXYOutputState, MouseButton } from './abstract-xy-output-component';
 import { AbstractXYOutputComponent, FLAG_PAN_LEFT, FLAG_PAN_RIGHT, FLAG_ZOOM_IN, FLAG_ZOOM_OUT, XY_OUTPUT_KEY_ACTIONS } from './abstract-xy-output-component';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCog } from '@fortawesome/free-solid-svg-icons';
+import { Experiment } from 'tsp-typescript-client';
+import { TraceOverviewSelectionDialogComponent } from './trace-overview-selection-dialog-component';
 
 const COLOR = {
     SELECTION_RANGE: '#259fd8',
@@ -12,7 +16,12 @@ const COLOR = {
 };
 
 type XYOutputOverviewState = AbstractXYOutputState & {
-    shiftKey: boolean
+    shiftKey: boolean,
+    showModal: boolean
+};
+
+type XYoutputOverviewProps = AbstractOutputProps & {
+    experiment: Experiment;
 };
 
 /**
@@ -20,13 +29,13 @@ type XYOutputOverviewState = AbstractXYOutputState & {
  * It will only be setting these properties.
  */
 
-export class XYOutputOverviewComponent extends AbstractXYOutputComponent<AbstractOutputProps, XYOutputOverviewState> {
+export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutputOverviewProps, XYOutputOverviewState> {
     private initialViewRangeStartPosition = 0;
     private initialViewRangeEndPosition = 0;
     private viewRangeMoveStartOffsetX = 0;
     private keyMapping: Map<string, XY_OUTPUT_KEY_ACTIONS>;
 
-    constructor(props: AbstractOutputProps) {
+    constructor(props: XYoutputOverviewProps) {
         super(props);
         this.state = {
             outputStatus: ResponseStatus.RUNNING,
@@ -41,10 +50,12 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<Abstrac
             allMin: 0,
             cursor: 'default',
             shiftKey: false,
-            optionsDropdownOpen: false
+            optionsDropdownOpen: false,
+            showModal: false
         };
         this.keyMapping = this.getKeyActionMap();
         this.afterChartDraw = this.afterChartDraw.bind(this);
+        this.closeOverviewOutputSelector = this.closeOverviewOutputSelector.bind(this);
     }
 
     renderChart(): React.ReactNode {
@@ -333,5 +344,31 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<Abstrac
 
     protected getTitleBarTooltip(): string {
         return this.props.outputDescriptor.name + ' overview';
+    }
+
+    protected showOptionsMenu(): React.ReactNode {
+        return <React.Fragment>
+            {<div className='options-menu-container'>
+                <button title="Select overview output source" className='options-menu-button'
+                onClick={()=>{this.openOverviewOutputSelector();}}>
+                    <FontAwesomeIcon icon={faCog} />
+                </button>
+                <TraceOverviewSelectionDialogComponent
+                    isOpen={this.state.showModal}
+                    title="Select overview output source"
+                    tspClient={this.props.tspClient}
+                    traceID={this.props.traceId}
+                    onCloseDialog={this.closeOverviewOutputSelector}
+                ></TraceOverviewSelectionDialogComponent>
+            </div>}
+        </React.Fragment>;
+    }
+
+    private closeOverviewOutputSelector(): void {
+        this.setState({showModal: false});
+    }
+
+    private openOverviewOutputSelector() {
+        this.setState({showModal: true});
     }
 }

--- a/packages/react-components/style/dialog-component-style.css
+++ b/packages/react-components/style/dialog-component-style.css
@@ -1,0 +1,64 @@
+.dialog-overlay{
+    z-index: 5000;
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    top: 0;
+    left: 0;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.3);
+    font-size: var(--theia-ui-font-size1);
+    padding: 2px;
+}
+
+.dialog-header{
+    background-color: var(--theia-statusBar-background);
+    color: var(--theia-statusBar-foreground);
+    padding: 5px;
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--theia-ui-font-size1);
+    min-height: 24px;
+    padding: 0 calc(var(--theia-ui-padding)*2);
+    align-items: center;
+    text-align: center;
+}
+
+.dialog-header-close{
+    display: inline-block;
+    cursor: pointer;
+}
+
+.dialog-body{
+    font-size: var(--theia-ui-font-size1);
+}
+
+.dialog-footer{
+    padding: calc(var(--theia-ui-padding)*2);
+    padding-top: 0px;
+    display: flex;
+    flex-direction: row;
+    align-content: right;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    min-height: 21px;
+}
+
+.dialog {
+    background-color: pink;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%,-50%);
+    -ms-transform: translate(-50%,-50%);
+    min-width: 400px;
+    min-height: 150px;
+    background-color: var(--theia-editorWidget-background);
+}
+
+#trace-overview-selection-dialog-content-container{
+    padding: calc(var(--theia-ui-padding)*2) 0px;
+}

--- a/packages/react-components/style/trace-explorer.css
+++ b/packages/react-components/style/trace-explorer.css
@@ -47,7 +47,7 @@
 
 .trace-list-container:hover,
 .outputs-list-container:hover {
-    background-color: var(--theia-list-hoverBackground);
+    background-color: var(--theia-menu-selectionBackground);
     cursor: pointer;
 }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -8,8 +8,8 @@ import { TraceExplorerOpenedTracesWidget } from '../trace-explorer/trace-explore
 import { ChartShortcutsDialog } from '../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { TraceViewerWidget } from './trace-viewer';
-import { OpenTraceCommand } from './trace-viewer-commands';
 import { TraceViewerToolbarCommands, TraceViewerToolbarMenus } from './trace-viewer-toolbar-commands';
+import { OpenTraceCommand } from './trace-viewer-commands';
 
 @injectable()
 export class TraceViewerToolbarContribution implements TabBarToolbarContribution, CommandContribution {


### PR DESCRIPTION
Currently, the trace overview only works with the Histogram output. This commit adds a dialog that allows users to select different outputs for the trace overview.

This resolves issue #775.