### PR TITLE
Refactor rendering available views

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -29,6 +29,7 @@ export declare interface SignalManager {
     firePinView(output: OutputDescriptor): void;
     fireUnPinView(): void;
     fireOpenOverviewOutputSignal(): void;
+    fireSelectOverviewOutputSignal(): void;
 }
 
 export const Signals = {
@@ -56,7 +57,8 @@ export const Signals = {
     TRACE_SERVER_STARTED: 'trace server started',
     PIN_VIEW: 'view pinned',
     UNPIN_VIEW: 'view unpinned',
-    OPEN_OVERVIEW_OUTPUT: 'open overview output'
+    OPEN_OVERVIEW_OUTPUT: 'open overview output',
+    SELECT_OVERVIEW_OUTPUT: 'select overview output'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -131,6 +133,9 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireOpenOverviewOutputSignal(): void {
         this.emit(Signals.OPEN_OVERVIEW_OUTPUT);
+    }
+    fireSelectOverviewOutputSignal(): void {
+        this.emit(Signals.SELECT_OVERVIEW_OUTPUT);
     }
 }
 

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -101,14 +101,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             <button className='remove-component-button' onClick={this.closeComponent}>
                 <FontAwesomeIcon icon={faTimes} />
             </button>
-            {(this.props.pinned !== false || this.state.additionalOptions) && <div className='options-menu-container'>
-                <button title="Show View Options" className='options-menu-button' onClick={this.openOptionsMenu}>
-                    <FontAwesomeIcon icon={faBars} />
-                </button>
-                {this.state.optionsDropdownOpen && <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
-                    {this.showOptions()}
-                </div>}
-            </div>}
+            {this.showOptionsMenu()}
             <div className='title-bar-label' title={outputTooltip} onClick={() => this.setFocus()}>
                 {outputName}
                 <i id={this.getOutputComponentDomId() + 'handleSpinner'} className='fa fa-refresh fa-spin'
@@ -149,6 +142,19 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     abstract renderMainArea(): React.ReactNode;
 
     abstract resultsAreEmpty(): boolean;
+
+    protected showOptionsMenu(): React.ReactNode {
+        return <React.Fragment>
+            {(this.props.pinned !== false || this.state.additionalOptions) && <div className='options-menu-container'>
+                <button title="Show View Options" className='options-menu-button' onClick={this.openOptionsMenu}>
+                    <FontAwesomeIcon icon={faBars} />
+                </button>
+                {this.state.optionsDropdownOpen && <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
+                    {this.showOptions()}
+                </div>}
+            </div>}
+        </React.Fragment>;
+    }
 
     private showOptions(): React.ReactNode {
         return <React.Fragment>

--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -367,7 +367,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
     protected chooseChart(): JSX.Element {
 
         const param: XYChartFactoryParams = {
-            viewRange: this.props.viewRange,
+            viewRange: this.getDisplayedRange(),
             allMax: this.state.allMax,
             allMin: this.state.allMin,
             isScatterPlot: this.isScatterPlot

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -541,12 +541,10 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                 let onOutputRemove;
                 let responseType;
                 if (isOverview) {
-                    isPinned = false;
                     onOutputRemove = this.props.onOverviewRemove;
                     responseType = 'OVERVIEW';
                 }
                 else {
-                    isPinned =  this.state.pinnedView ? (this.state.pinnedView === output) : undefined;
                     onOutputRemove = this.props.onOutputRemove;
                     responseType = output.type;
                 }
@@ -570,7 +568,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     outputWidth: this.state.style.width,
                     backgroundTheme: this.state.backgroundTheme,
                     setChartOffset: this.setChartOffset,
-                    pinned: isPinned
+                    pinned: this.state.pinnedView ? (this.state.pinnedView === output) : undefined
                 };
                 switch (responseType) {
                     case 'OVERVIEW':

--- a/packages/react-components/src/components/trace-overview-component.tsx
+++ b/packages/react-components/src/components/trace-overview-component.tsx
@@ -8,11 +8,6 @@ export class TraceOverviewComponent extends React.Component<AbstractOutputProps>
     }
 
     render(): JSX.Element {
-        if (this.props.outputDescriptor.id === 'org.eclipse.tracecompass.internal.tmf.core.histogram.HistogramDataProvider')
-        {
-            return <XYOutputOverviewComponent {...this.props}></XYOutputOverviewComponent>;
-        }
-
-        return <div>No overview for this view is available</div>;
+        return <XYOutputOverviewComponent key={this.props.outputDescriptor.id} {...this.props}></XYOutputOverviewComponent>;
     }
 }

--- a/packages/react-components/src/components/utils/available-views-component.tsx
+++ b/packages/react-components/src/components/utils/available-views-component.tsx
@@ -1,0 +1,107 @@
+import { ListRowProps, AutoSizer, List } from 'react-virtualized';
+import React from 'react';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+
+export interface AvailableViewsComponentProps {
+    availableViewListKey: number,
+    outputDescriptors: OutputDescriptor[],
+    onContextMenuEvent?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>, output: OutputDescriptor | undefined) => void,
+    onOutputClicked: (event: React.MouseEvent<HTMLDivElement>) => void
+}
+
+export interface AvailableViewsComponentState {
+    lastSelectedOutputIndex: number;
+}
+
+export class AvailableViewsComponent  extends React.Component<AvailableViewsComponentProps, AvailableViewsComponentState>{
+    static LIST_MARGIN = 2;
+    static LINE_HEIGHT = 16;
+    static ROW_HEIGHT = (2 * AvailableViewsComponent.LINE_HEIGHT) + AvailableViewsComponent.LIST_MARGIN;
+
+    protected handleOutputClicked = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOutputClicked(e);
+
+    constructor(props: AvailableViewsComponentProps){
+        super(props);
+        this.state = { lastSelectedOutputIndex: -1 };
+    }
+
+    render(): React.ReactNode {
+        let outputsRowCount = 0;
+        const outputs = this.props.outputDescriptors;
+        if (outputs) {
+            outputsRowCount = outputs.length;
+        }
+        const totalHeight = this.getTotalHeight();
+        return (
+            <div className='trace-explorer-views'>
+                <div className='trace-explorer-panel-content disable-select' style={{height: totalHeight}}>
+                    <AutoSizer>
+                        {({ width }) =>
+                            <List
+                                key={this.props.availableViewListKey}
+                                height={totalHeight}
+                                width={width}
+                                rowCount={outputsRowCount}
+                                rowHeight={AvailableViewsComponent.ROW_HEIGHT}
+                                rowRenderer={this.renderRowOutputs}
+                            />
+                        }
+                    </AutoSizer>
+                </div>
+            </div>
+        );
+    }
+
+    protected renderRowOutputs = (props: ListRowProps): React.ReactNode => this.doRenderRowOutputs(props);
+
+    private doRenderRowOutputs(props: ListRowProps): React.ReactNode {
+        let outputName = '';
+        let outputDescription = '';
+        let output: OutputDescriptor | undefined;
+        const outputDescriptors = this.props.outputDescriptors;
+        if (outputDescriptors && outputDescriptors.length && props.index < outputDescriptors.length) {
+            output = outputDescriptors[props.index];
+            outputName = output.name;
+            outputDescription = output.description;
+        }
+        let traceContainerClassName = 'outputs-list-container';
+        if (props.index === this.state.lastSelectedOutputIndex) {
+            traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
+        }
+        return <div className={traceContainerClassName}
+            title={outputName + ':\n' + outputDescription}
+            id={`${traceContainerClassName}-${props.index}`}
+            key={props.key}
+            style={props.style}
+            onClick={this.handleOutputClicked}
+            onContextMenu={event => { this.doHandleContextMenuEvent(event, output); }}
+            data-id={`${props.index}`}
+        >
+            <h4 className='outputs-element-name'>
+                {outputName}
+            </h4>
+            <div className='outputs-element-description child-element'>
+                {outputDescription}
+            </div>
+        </div>;
+    }
+
+    private doHandleContextMenuEvent(event: React.MouseEvent<HTMLDivElement, MouseEvent>, output: OutputDescriptor | undefined) {
+        if (this.props.onContextMenuEvent)
+            {this.props.onContextMenuEvent(event, output);}
+    }
+
+    private doHandleOutputClicked(e: React.MouseEvent<HTMLDivElement>) {
+        const index = Number(e.currentTarget.getAttribute('data-id'));
+        this.setState({ lastSelectedOutputIndex: index });
+
+        this.props.onOutputClicked(e);
+    }
+
+    protected getTotalHeight(): number {
+        let totalHeight = 0;
+        const outputDescriptors = this.props.outputDescriptors;
+        outputDescriptors?.forEach(() => totalHeight += AvailableViewsComponent.ROW_HEIGHT);
+        return totalHeight;
+    }
+}

--- a/packages/react-components/src/components/utils/trace-overview-selection-dialog-component.tsx
+++ b/packages/react-components/src/components/utils/trace-overview-selection-dialog-component.tsx
@@ -1,0 +1,117 @@
+import { ListRowProps, AutoSizer, List } from 'react-virtualized';
+import {  DialogProps } from '@theia/core/lib/browser/dialogs';
+import React from 'react';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { Message } from '@theia/core/lib/browser/widgets';
+import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
+
+export class TraceOverviewSelectionDialog{
+    static async showOpenDialog(outputDescriptors: OutputDescriptor[]): Promise<OutputDescriptor | undefined> {
+        const dialogProps: DialogProps = {
+            title: 'Select overview source'
+        };
+        const dialog = new TraceOverviewSelectionDialogComponent(dialogProps, outputDescriptors);
+        const returnedValue = await dialog.open();
+
+        return returnedValue;
+    }
+}
+
+class TraceOverviewSelectionDialogComponent extends ReactDialog<OutputDescriptor | undefined>{
+
+    static ID = 'trace-overview-selection-dialog';
+    static LABEL = 'Available Views';
+    static LIST_MARGIN = 2;
+    static LINE_HEIGHT = 16;
+    static ROW_HEIGHT = (2 * TraceOverviewSelectionDialogComponent.LINE_HEIGHT) + TraceOverviewSelectionDialogComponent.LIST_MARGIN;
+
+    private outputDescriptors: OutputDescriptor[];
+    private selectedOutput: OutputDescriptor | undefined;
+
+    protected handleOutputClicked = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOutputClicked(e);
+
+    constructor(props: DialogProps, output: OutputDescriptor[]){
+        super(props);
+        this.outputDescriptors = output;
+        this.appendCloseButton('Cancel');
+    }
+
+    protected override onCloseRequest(msg: Message): void {
+        super.onCloseRequest(msg);
+        this.accept();
+    }
+
+    get value(): OutputDescriptor | undefined {
+        return this.selectedOutput;
+    }
+
+    render(): React.ReactNode{
+        const key = Number(true);
+        let outputsRowCount = 0;
+        if (this.outputDescriptors) {
+            outputsRowCount = this.outputDescriptors.length;
+        }
+        const totalHeight = this.getTotalHeight();
+
+        return (
+            <div style={{ height: (totalHeight + 'px') }}>
+                <AutoSizer>
+                    {({ width }) =>
+                        <List
+                            key={key}
+                            height={totalHeight}
+                            width={width}
+                            rowCount={outputsRowCount}
+                            rowHeight={TraceOverviewSelectionDialogComponent.ROW_HEIGHT}
+                            rowRenderer={this.renderRowOutputs}
+                        />
+                    }
+                </AutoSizer>
+            </div>
+        );
+    }
+
+    protected renderRowOutputs = (props: ListRowProps): React.ReactNode => this.doRenderRowOutputs(props);
+
+    private doRenderRowOutputs(props: ListRowProps): React.ReactNode {
+        let outputName = '';
+        let outputDescription = '';
+        let output: OutputDescriptor | undefined;
+        const outputDescriptors = this.outputDescriptors;
+        if (outputDescriptors && outputDescriptors.length && props.index < outputDescriptors.length) {
+            output = outputDescriptors[props.index];
+            outputName = output.name;
+            outputDescription = output.description;
+        }
+        const traceContainerClassName = 'outputs-list-container';
+        return <div
+            className={traceContainerClassName}
+            title={outputName + ':\n' + outputDescription}
+            id={`${traceContainerClassName}-${props.index}`}
+            key={props.key}
+            onClick={this.handleOutputClicked}
+            style={{cursor: 'pointer'}}
+            data-id={`${props.index}`}
+        >
+            <h4 className='outputs-element-name'>
+                {outputName}
+            </h4>
+            <div className='outputs-element-description child-element'>
+                {outputDescription}
+            </div>
+        </div>;
+    }
+
+    private doHandleOutputClicked(e: React.MouseEvent<HTMLDivElement>) {
+        const index = Number(e.currentTarget.getAttribute('data-id'));
+        this.selectedOutput = this.outputDescriptors[index];
+        this.accept();
+    }
+
+    protected getTotalHeight(): number {
+        let totalHeight = 0;
+        const outputDescriptors = this.outputDescriptors;
+        outputDescriptors?.forEach(() => totalHeight += TraceOverviewSelectionDialogComponent.ROW_HEIGHT);
+        return totalHeight;
+    }
+}

--- a/packages/react-components/src/components/utils/trace-overview-selection-dialog-component.tsx
+++ b/packages/react-components/src/components/utils/trace-overview-selection-dialog-component.tsx
@@ -1,9 +1,9 @@
-import { ListRowProps, AutoSizer, List } from 'react-virtualized';
 import {  DialogProps } from '@theia/core/lib/browser/dialogs';
 import React from 'react';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Message } from '@theia/core/lib/browser/widgets';
 import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
+import { AvailableViewsComponent } from './available-views-component';
 
 export class TraceOverviewSelectionDialog{
     static async showOpenDialog(outputDescriptors: OutputDescriptor[]): Promise<OutputDescriptor | undefined> {
@@ -18,12 +18,6 @@ export class TraceOverviewSelectionDialog{
 }
 
 class TraceOverviewSelectionDialogComponent extends ReactDialog<OutputDescriptor | undefined>{
-
-    static ID = 'trace-overview-selection-dialog';
-    static LABEL = 'Available Views';
-    static LIST_MARGIN = 2;
-    static LINE_HEIGHT = 16;
-    static ROW_HEIGHT = (2 * TraceOverviewSelectionDialogComponent.LINE_HEIGHT) + TraceOverviewSelectionDialogComponent.LIST_MARGIN;
 
     private outputDescriptors: OutputDescriptor[];
     private selectedOutput: OutputDescriptor | undefined;
@@ -47,59 +41,11 @@ class TraceOverviewSelectionDialogComponent extends ReactDialog<OutputDescriptor
 
     render(): React.ReactNode{
         const key = Number(true);
-        let outputsRowCount = 0;
-        if (this.outputDescriptors) {
-            outputsRowCount = this.outputDescriptors.length;
-        }
-        const totalHeight = this.getTotalHeight();
-
-        return (
-            <div style={{ height: (totalHeight + 'px') }}>
-                <AutoSizer>
-                    {({ width }) =>
-                        <List
-                            key={key}
-                            height={totalHeight}
-                            width={width}
-                            rowCount={outputsRowCount}
-                            rowHeight={TraceOverviewSelectionDialogComponent.ROW_HEIGHT}
-                            rowRenderer={this.renderRowOutputs}
-                        />
-                    }
-                </AutoSizer>
-            </div>
-        );
-    }
-
-    protected renderRowOutputs = (props: ListRowProps): React.ReactNode => this.doRenderRowOutputs(props);
-
-    private doRenderRowOutputs(props: ListRowProps): React.ReactNode {
-        let outputName = '';
-        let outputDescription = '';
-        let output: OutputDescriptor | undefined;
-        const outputDescriptors = this.outputDescriptors;
-        if (outputDescriptors && outputDescriptors.length && props.index < outputDescriptors.length) {
-            output = outputDescriptors[props.index];
-            outputName = output.name;
-            outputDescription = output.description;
-        }
-        const traceContainerClassName = 'outputs-list-container';
-        return <div
-            className={traceContainerClassName}
-            title={outputName + ':\n' + outputDescription}
-            id={`${traceContainerClassName}-${props.index}`}
-            key={props.key}
-            onClick={this.handleOutputClicked}
-            style={{cursor: 'pointer'}}
-            data-id={`${props.index}`}
-        >
-            <h4 className='outputs-element-name'>
-                {outputName}
-            </h4>
-            <div className='outputs-element-description child-element'>
-                {outputDescription}
-            </div>
-        </div>;
+        return <AvailableViewsComponent
+            availableViewListKey={key}
+            onOutputClicked={e => {this.doHandleOutputClicked(e);}}
+            outputDescriptors={this.outputDescriptors}
+        ></AvailableViewsComponent>;
     }
 
     private doHandleOutputClicked(e: React.MouseEvent<HTMLDivElement>) {
@@ -111,7 +57,7 @@ class TraceOverviewSelectionDialogComponent extends ReactDialog<OutputDescriptor
     protected getTotalHeight(): number {
         let totalHeight = 0;
         const outputDescriptors = this.outputDescriptors;
-        outputDescriptors?.forEach(() => totalHeight += TraceOverviewSelectionDialogComponent.ROW_HEIGHT);
+        outputDescriptors?.forEach(() => totalHeight += AvailableViewsComponent.ROW_HEIGHT);
         return totalHeight;
     }
 }

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -5,6 +5,9 @@ import { drawSelection } from './utils/xy-output-component-utils';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
 import { AbstractXYOutputState, MouseButton } from './abstract-xy-output-component';
 import { AbstractXYOutputComponent, FLAG_PAN_LEFT, FLAG_PAN_RIGHT, FLAG_ZOOM_IN, FLAG_ZOOM_OUT, XY_OUTPUT_KEY_ACTIONS } from './abstract-xy-output-component';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCog } from '@fortawesome/free-solid-svg-icons';
+import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 
 const COLOR = {
     SELECTION_RANGE: '#259fd8',
@@ -333,5 +336,15 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<Abstrac
 
     protected getTitleBarTooltip(): string {
         return this.props.outputDescriptor.name + ' overview';
+    }
+
+    protected showOptionsMenu(): React.ReactNode {
+        return <React.Fragment>
+            {<div className='options-menu-container'>
+                <button title="Select overview output source" className='options-menu-button' onClick={()=>{signalManager().fireSelectOverviewOutputSignal();}}>
+                    <FontAwesomeIcon icon={faCog} />
+                </button>
+            </div>}
+        </React.Fragment>;
     }
 }

--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { List, ListRowProps, AutoSizer } from 'react-virtualized';
 import { OutputAddedSignalPayload } from 'traceviewer-base/lib/signals/output-added-signal-payload';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
+import { AvailableViewsComponent } from '../components/utils/available-views-component';
 
 export interface ReactAvailableViewsProps {
     id: string,
@@ -20,10 +20,6 @@ export interface ReactAvailableViewsState {
 }
 
 export class ReactAvailableViewsWidget extends React.Component<ReactAvailableViewsProps, ReactAvailableViewsState> {
-    static LIST_MARGIN = 2;
-    static LINE_HEIGHT = 16;
-    static ROW_HEIGHT = (2 * ReactAvailableViewsWidget.LINE_HEIGHT) + ReactAvailableViewsWidget.LIST_MARGIN;
-
     private _forceUpdateKey = false;
     private _selectedExperiment: Experiment | undefined;
     private _experimentManager: ExperimentManager;
@@ -50,71 +46,11 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
     render(): React.ReactNode {
         this._forceUpdateKey = !this._forceUpdateKey;
         const key = Number(this._forceUpdateKey);
-        let outputsRowCount = 0;
-        const outputs = this.state.availableOutputDescriptors;
-        if (outputs) {
-            outputsRowCount = outputs.length;
-        }
-        const totalHeight = this.getTotalHeight();
-        return (
-            <div className='trace-explorer-views'>
-                <div className='trace-explorer-panel-content disable-select'>
-                    <AutoSizer>
-                        {({ width }) =>
-                            <List
-                                key={key}
-                                height={totalHeight}
-                                width={width}
-                                rowCount={outputsRowCount}
-                                rowHeight={ReactAvailableViewsWidget.ROW_HEIGHT}
-                                rowRenderer={this.renderRowOutputs}
-                            />
-                        }
-                    </AutoSizer>
-                </div>
-            </div>
-        );
-    }
-
-    protected renderRowOutputs = (props: ListRowProps): React.ReactNode => this.doRenderRowOutputs(props);
-
-    private doRenderRowOutputs(props: ListRowProps): React.ReactNode {
-        let outputName = '';
-        let outputDescription = '';
-        let output: OutputDescriptor | undefined;
-        const outputDescriptors = this.state.availableOutputDescriptors;
-        if (outputDescriptors && outputDescriptors.length && props.index < outputDescriptors.length) {
-            output = outputDescriptors[props.index];
-            outputName = output.name;
-            outputDescription = output.description;
-        }
-        let traceContainerClassName = 'outputs-list-container';
-        if (props.index === this.state.lastSelectedOutputIndex) {
-            traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
-        }
-        return <div className={traceContainerClassName}
-            title={outputName + ':\n' + outputDescription}
-            id={`${traceContainerClassName}-${props.index}`}
-            key={props.key}
-            style={props.style}
-            onClick={this.handleOutputClicked}
-            onContextMenu={event => { this.handleContextMenuEvent(event, output); }}
-            data-id={`${props.index}`}
-        >
-            <h4 className='outputs-element-name'>
-                {outputName}
-            </h4>
-            <div className='outputs-element-description child-element'>
-                {outputDescription}
-            </div>
-        </div>;
-    }
-
-    protected getTotalHeight(): number {
-        let totalHeight = 0;
-        const outputDescriptors = this.state.availableOutputDescriptors;
-        outputDescriptors?.forEach(() => totalHeight += ReactAvailableViewsWidget.ROW_HEIGHT);
-        return totalHeight;
+        return <AvailableViewsComponent availableViewListKey={key}
+            outputDescriptors={this.state.availableOutputDescriptors}
+            onContextMenuEvent={this.handleContextMenuEvent}
+            onOutputClicked={this.handleOutputClicked}
+            ></AvailableViewsComponent>;
     }
 
     protected handleOutputClicked = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOutputClicked(e);

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -8,9 +8,9 @@ import { TraceExplorerOpenedTracesWidget } from '../trace-explorer/trace-explore
 import { ChartShortcutsDialog } from '../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { TraceViewerWidget } from './trace-viewer';
-import { OpenTraceCommand } from './trace-viewer-commands';
 import { TraceViewerToolbarCommands, TraceViewerToolbarMenus } from './trace-viewer-toolbar-commands';
 import { TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
+import { OpenTraceCommand } from './trace-viewer-commands';
 
 @injectable()
 export class TraceViewerToolbarContribution implements TabBarToolbarContribution, CommandContribution {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -19,6 +19,7 @@ import { TraceExplorerContribution } from '../trace-explorer/trace-explorer-cont
 import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
 import { BackendFileService } from '../../common/backend-file-service';
 import { CancellationTokenSource } from '@theia/core';
+import { TraceOverviewSelectionDialog } from 'traceviewer-react-components/lib/components/utils/trace-overview-selection-dialog-component';
 import * as React from 'react';
 import 'animate.css';
 
@@ -44,7 +45,6 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     protected traceContextComponent: React.RefObject<TraceContextComponent>;
     protected persistedState?: PersistedState;
     protected loadTraceOverview = true;
-    protected overviewOutputTraceUUID: string | undefined;
 
     protected resizeHandlers: (() => void)[] = [];
     protected readonly addResizeHandler = (h: () => void): void => {
@@ -66,11 +66,13 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
 
     private onOutputAdded = (payload: OutputAddedSignalPayload): Promise<void> => this.doHandleOutputAddedSignal(payload);
     private onTraceOverviewOpened = (): Promise<void> => this.doHandleTraceOverviewOpenedSignal();
-    private onExperimentSelected = (experiment: Experiment): void => this.doHandleExperimentSelectedSignal(experiment);
+    private onSelectTraceOverviewOutput = (): Promise<void> => this.doHandleSelectTraceOverviewOutput();
+    private onExperimentSelected = (experiment: Experiment): Promise<void> => this.doHandleExperimentSelectedSignal(experiment);
     private onCloseExperiment = (UUID: string): void => this.doHandleCloseExperimentSignal(UUID);
     private onMarkerCategoryClosedSignal = (payload: { traceViewerId: string, markerCategory: string }) => this.doHandleMarkerCategoryClosedSignal(payload);
 
     private overviewOutputDescriptor: OutputDescriptor | undefined;
+    private prevOverviewOutputDescriptor: OutputDescriptor | undefined;
 
     @inject(TraceViewerWidgetOptions) protected readonly options: TraceViewerWidgetOptions;
     @inject(TspClientProvider) protected tspClientProvider: TspClientProvider;
@@ -104,7 +106,6 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
             this.experimentManager = this.tspClientProvider.getExperimentManager();
         });
         if (this.options.traceUUID) {
-            this.overviewOutputTraceUUID = this.options.traceUUID;
             const experiment = await this.experimentManager.updateExperiment(this.options.traceUUID);
             if (experiment) {
                 this.openedExperiment = experiment;
@@ -139,6 +140,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         signalManager().on(Signals.CLOSE_TRACEVIEWERTAB, this.onCloseExperiment);
         signalManager().on(Signals.MARKER_CATEGORY_CLOSED, this.onMarkerCategoryClosedSignal);
         signalManager().on(Signals.OPEN_OVERVIEW_OUTPUT, this.onTraceOverviewOpened);
+        signalManager().on(Signals.SELECT_OVERVIEW_OUTPUT, this.onSelectTraceOverviewOutput);
     }
 
     protected updateBackgroundTheme(): void {
@@ -152,6 +154,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         signalManager().off(Signals.EXPERIMENT_SELECTED, this.onExperimentSelected);
         signalManager().off(Signals.CLOSE_TRACEVIEWERTAB, this.onCloseExperiment);
         signalManager().off(Signals.OPEN_OVERVIEW_OUTPUT, this.onTraceOverviewOpened);
+        signalManager().off(Signals.SELECT_OVERVIEW_OUTPUT, this.onSelectTraceOverviewOutput);
     }
 
     async initialize(): Promise<void> {
@@ -398,11 +401,12 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         this.update();
     }
 
-    protected doHandleExperimentSelectedSignal(experiment: Experiment): void {
+    protected async doHandleExperimentSelectedSignal(experiment: Experiment): Promise<void> {
         if (this.openedExperiment && this.openedExperiment.UUID === experiment.UUID) {
             // Update the trace UUID so that the overview can be opened
             if (this.loadTraceOverview){
-                this.updateOverviewOutputDescriptor();
+                const defaultOutputDescriptor = await this.getDefaultTraceOverviewOutputDescriptor();
+                this.updateOverviewOutputDescriptor(defaultOutputDescriptor);
             }
 
             this.shell.activateWidget(this.openedExperiment.UUID);
@@ -419,19 +423,28 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
 
     private async doHandleTraceOverviewOpenedSignal(): Promise<void> {
         if (this.openedExperiment){
-            this.updateOverviewOutputDescriptor();
+            this.loadOverviewOutputDescriptor();
             this.shell.activateWidget(this.openedExperiment.UUID);
         }
     }
 
-    private async updateOverviewOutputDescriptor(): Promise<void> {
-        if (this.openedExperiment && !this.overviewOutputDescriptor) {
-            const overviewOutputDescriptor = await this.getTraceOverviewOutputDescriptor();
-            if (overviewOutputDescriptor) {
-                this.loadTraceOverview = false;
-                this.overviewOutputDescriptor = overviewOutputDescriptor;
-                this.update();
+    private async doHandleSelectTraceOverviewOutput(): Promise<void> {
+        if (this.openedExperiment){
+            const availableDescriptor = await this.getAvailableTraceOverviewOutputDescriptor();
+            if (availableDescriptor) {
+                const selectedDescriptor = await TraceOverviewSelectionDialog.showOpenDialog(availableDescriptor);
+                await this.updateOverviewOutputDescriptor(selectedDescriptor);
+                this.shell.activateWidget(this.openedExperiment.UUID);
             }
+        }
+    }
+
+    private async updateOverviewOutputDescriptor(outputDescriptor: OutputDescriptor | undefined): Promise<void> {
+        if (this.openedExperiment && outputDescriptor) {
+            this.loadTraceOverview = false;
+            this.prevOverviewOutputDescriptor = outputDescriptor; // Save the output for reopening
+            this.overviewOutputDescriptor = outputDescriptor;
+            this.update();
         }
     }
 
@@ -537,17 +550,33 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         return false;
     }
 
+    private async loadOverviewOutputDescriptor(): Promise<void> {
+        let selectedOutput: OutputDescriptor | undefined;
+        if (this.prevOverviewOutputDescriptor) {
+            selectedOutput = this.prevOverviewOutputDescriptor;
+        } else {
+            selectedOutput = await this.getDefaultTraceOverviewOutputDescriptor();
+        }
+
+        this.updateOverviewOutputDescriptor(selectedOutput);
+    }
+
     /**
      * Get the output descriptor for the trace over view
      */
-    protected async getTraceOverviewOutputDescriptor(): Promise<OutputDescriptor | undefined> {
+    protected async getDefaultTraceOverviewOutputDescriptor(): Promise<OutputDescriptor | undefined> {
+        const availableDescriptors = await this.getAvailableTraceOverviewOutputDescriptor();
+        return availableDescriptors?.find(output => output.id === TraceViewerWidget.DEFAULT_OVERVIEW_DATA_PROVIDER_ID);
+    }
+
+    /**
+     * Get the output descriptor for the trace over view
+     */
+    protected async getAvailableTraceOverviewOutputDescriptor(): Promise<OutputDescriptor[] | undefined> {
         if (this.openedExperiment){
             const descriptors = await this.experimentManager.getAvailableOutputs(this.openedExperiment.UUID);
-            if (descriptors){
-                // TODO: Dynamically decide which data provider to use
-                const overviewOutputDescriptor = descriptors.find(output => output.id === TraceViewerWidget.DEFAULT_OVERVIEW_DATA_PROVIDER_ID);
-                return overviewOutputDescriptor;
-            }
+            const overviewOutputDescriptors = descriptors?.filter(output => output.type === 'TREE_TIME_XY');
+            return overviewOutputDescriptors;
         }
     }
 }


### PR DESCRIPTION
Currently, the trace-explorer-views-widget shares the same code as the trace-overview-selection-component that renders the list 
of available outputs. This commit extracts the common code into a separate component that can be shared by both components.
