### PR TITLE
XY plots put zero at the bottom

### DIFF
--- a/packages/react-components/src/components/utils/xy-output-component-utils.tsx
+++ b/packages/react-components/src/components/utils/xy-output-component-utils.tsx
@@ -100,7 +100,7 @@ function getDefaultChartOptions(params: XYChartFactoryParams): Chart.ChartOption
                 display: false,
                 stacked: false,
                 ticks: {
-                    max: params.allMax,
+                    max: params.allMax > 0 ? params.allMax : 100,
                     min: params.allMin
                 }
             }]


### PR DESCRIPTION
In line charts when the view range only has 0 for y values the line is kept at the bottom

[Screen Recording 2022-07-19 at 10.50.38 AM.webm](https://user-images.githubusercontent.com/92893187/179798600-f015b8e5-341f-436c-a5e2-cda1a5b6cce9.webm)

fixes #780

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>