### PR TITLE
XY Chart refresh data model on resize

### DIFF
--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -218,7 +218,8 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         const viewRangeChanged = this.props.viewRange !== prevProps.viewRange;
         const checkedSeriesChanged = this.state.checkedSeries !== prevState.checkedSeries;
         const collapsedNodesChanged = this.state.collapsedNodes !== prevState.collapsedNodes;
-        const chartWidthChanged = this.props.style.width !== prevProps.style.width || this.props.style.chartOffset !== prevProps.style.chartOffset;
+        const chartWidthChanged = this.props.style.width !== prevProps.style.width || this.props.style.chartOffset !== prevProps.style.chartOffset
+                                || this.props.style.componentLeft !== prevProps.style.componentLeft;
         const outputStatusChanged = this.state.outputStatus !== prevState.outputStatus;
         const needToUpdate = viewRangeChanged || checkedSeriesChanged || collapsedNodesChanged || chartWidthChanged || outputStatusChanged;
 


### PR DESCRIPTION
xy chart updates data model when size of parent component (trace-context-component) is changed

[Screen Recording 2022-07-21 at 11.05.33 AM.webm](https://user-images.githubusercontent.com/92893187/180261591-0270e757-adf0-47e1-ba8e-3edf91792912.webm)

fixes #726

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>