### PR TITLE
Zoom into selection range using z

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -434,6 +434,10 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                 this.zoomButton(false);
                 break;
             }
+            case 'z': {
+                this.zoomToSelected();
+                break;
+            }
         }
     }
 
@@ -455,6 +459,13 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     break;
                 }
             }
+        }
+    }
+
+    private zoomToSelected(): void {
+        const newZoom = this.unitController.selectionRange;
+        if (newZoom) {
+            this.unitController.viewRange = newZoom;
         }
     }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
@@ -45,6 +45,12 @@ export class TimeGraphShortcutsTable extends React.Component {
                                     <span className='monaco-keybinding-key'><i className='fa fa-arrow-down' /></span>
                                 </td>
                             </tr>
+                            <tr>
+                                <td>Zoom to selected</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Z</span>
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
Allows user to press z to zoom to current selection.
Adds relevant information to keyboard shortcut menu.

Fixes: #427 

Signed-off-by: Will Yang <william.yang@ericsson.com>