### PR TITLE
Refactor available views component

### DIFF
--- a/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
+++ b/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
@@ -32,12 +32,10 @@ export class TraceOverviewSelectionDialogComponent extends AbstractDialogCompone
                 Loading available outputs...
             </div>);
         }
-
-        const key = Number(true);
         return (
             <div id="trace-overview-selection-dialog-content-container">
                 <AvailableViewsComponent
-                    availableViewListKey={key}
+                    traceID={this.props.traceID}
                     onOutputClicked={e => {this.doHandleOutputClicked(e);}}
                     outputDescriptors={this.state.outputDescriptors}
                     listRowWidth='95%'


### PR DESCRIPTION
Currently, the trace-overview-selection-dialog-component and the trace-explorer-views-widget have some common code. This
commit refactors the common code by creating the reusable available-view-component. The prior two components will then call the later component and thus use the same code.