### PR TITLE
Add Events Table Shortcuts to the Keyboard Shortcuts Menu

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component.tsx
@@ -6,6 +6,7 @@ import { Message } from '@theia/core/lib/browser/widgets/widget';
 import { EssentialShortcutsTable } from './essential-shortcuts-table';
 import { ZoomPanShortcutsTable } from './zoom-pan-shortcuts-table';
 import { TimeGraphShortcutsTable } from './time-graph-navigation-shortcuts-table';
+import { EventsTableShortcutsTable } from './events-table-shortcuts-table';
 import { SelectShortcutsTable } from './select-shortcuts-table';
 
 @injectable()
@@ -36,6 +37,7 @@ export class ChartShortcutsDialog extends ReactDialog<void> {
                 <EssentialShortcutsTable />
                 <ZoomPanShortcutsTable />
                 <TimeGraphShortcutsTable />
+                <EventsTableShortcutsTable />
                 <SelectShortcutsTable />
             </div>
         );

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/events-table-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/events-table-shortcuts-table.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+export class EventsTableShortcutsTable extends React.Component {
+
+    render(): React.ReactNode {
+        return <React.Fragment>
+            <span className='shortcuts-table-header'>TABLE NAVIGATION</span>
+            <div className='shortcuts-table-row'>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>Cell Navigation</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-up' /></span>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-down' /></span>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-left' /></span>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-right' /></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Page Up</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Page Up</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Page Down</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Page Down</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Multi-select</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Shift</span>
+                                    <span className='monaco-keybinding-key'>Click</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>Shift</span>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-up' /></span>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-down' /></span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>Deselect row(s)</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Ctrl</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>meta</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Go to first row</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Home</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Go to last row</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>End</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Select current row</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Click</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>Space</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </React.Fragment>;
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -137,7 +137,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             isVisible: (w: Widget) => {
                 if (w instanceof TraceViewerWidget) {
                     const traceWidget = w as TraceViewerWidget;
-                    return traceWidget.isTimeRelatedChartOpened() || traceWidget.isTraceOverviewOpened();
+                    return traceWidget.isTimeRelatedChartOpened() || traceWidget.isTraceOverviewOpened() || traceWidget.isTableRelatedChartOpened();
                 }
                 return false;
             },

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -550,6 +550,11 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         return timeRelatedOutputs.length > 0;
     }
 
+    isTableRelatedChartOpened(): boolean {
+        const tableRelatedOutputs = this.outputDescriptors.filter(output => output.type === 'TABLE');
+        return tableRelatedOutputs.length > 0;
+    }
+
     isTraceOverviewOpened(): boolean {
         if (this.overviewOutputDescriptor){
             return true;


### PR DESCRIPTION
Helps fix #742

- The requested shortcuts described in #742 are implemented by default in all ag-grid tables: https://www.ag-grid.com/react-data-grid/keyboard-navigation/
- I added these shortcuts to the Keyboard Shortcuts menu to make them discoverable. I also added the following keyboard/mouse interactions:
        - Select Multiple rows: 'Shift + click' or 'Shift + arrow up/down'
        - Deselect rows: 'ctrl or meta key'
- In table-output-component I also noticed that 'space' is registered as a key interaction to replace multi-select with a single row, but was not sure how to describe it in the shortcuts menu as a user can single-click or use ctrl to remove multi-select
- Here's how the shortcuts menu looks now:
![Screen Shot 2022-08-10 at 12 15 02 PM](https://user-images.githubusercontent.com/92893187/183975398-0c0a6b5b-4e4d-451d-8d65-ab5309f1a715.png)

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>