### PR TITLE
Fix rendering of message about unsupported output type

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -48,7 +48,7 @@ export interface AbstractOutputProps {
 export interface AbstractOutputState {
     outputStatus: string;
     styleModel?: OutputStyleModel;
-    optionsDropdownOpen: boolean;
+    optionsDropdownOpen?: boolean;
     additionalOptions?: boolean;
 }
 
@@ -151,7 +151,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
                 <button title="Show View Options" className='options-menu-button' onClick={this.openOptionsMenu}>
                     <FontAwesomeIcon icon={faBars} />
                 </button>
-                {this.state.optionsDropdownOpen && <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
+                {this.state?.optionsDropdownOpen && <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
                     {this.showOptions()}
                 </div>}
             </div>}

--- a/packages/react-components/src/components/null-output-component.tsx
+++ b/packages/react-components/src/components/null-output-component.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ResponseStatus } from 'tsp-typescript-client';
 import { AbstractOutputComponent, AbstractOutputProps, AbstractOutputState } from './abstract-output-component';
 
 type NullOutputState = AbstractOutputState & {
@@ -10,25 +11,22 @@ type NullOutputProps = AbstractOutputProps & {
 export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps, NullOutputState> {
     constructor(props: NullOutputProps) {
         super(props);
+        this.state = {
+            outputStatus: ResponseStatus.COMPLETED
+        };
     }
 
     renderMainArea(): React.ReactNode {
-        const treeWidth = Math.min(this.getMainAreaWidth(), this.props.style.chartOffset - this.getHandleWidth());
-        const chartWidth = this.getMainAreaWidth() - treeWidth;
         return <React.Fragment>
-            <div className='output-component-tree disable-select'
-                style={{ width: treeWidth, height: this.props.style.height }}
-            >
-                {''}
-            </div>
-            <div className='output-component-chart' style={{ fontSize: 24, width: chartWidth, height: this.props.style.height, backgroundColor: '#3f3f3f', }}>
-                {'Not implemented yet!'}
+            <div className='message-main-area'>
+                Not implemented yet!
+                <br />
             </div>
         </React.Fragment>;
     }
 
     resultsAreEmpty(): boolean {
-        return true;
+        return false;
     }
 
     setFocus(): void {


### PR DESCRIPTION
Fixes #808

Note: To test change the Trace Compass server back-end to return an unknown provider type in an output descriptor. This is how it will look like:

![image](https://user-images.githubusercontent.com/413424/185440762-8fc3ec67-c8b5-413c-af3b-df3ec04b2a31.png)

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>