### PR TITLE
Toggle Open Trace File Picker with custom path

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
@@ -24,3 +24,8 @@ export const KeyboardShortcutsCommand: Command = {
     id: 'trace-viewer-keyboard-shortcuts',
     label: 'Trace Viewer Keyboard and Mouse Shortcuts'
 };
+
+export const OpenTraceWithRootPathCommand: Command = {
+    id: 'open-trace-with-root-path',
+    label: 'Open Trace With Root Path'
+};


### PR DESCRIPTION
Add the ability to open the trace file picker dialog with a custom root path if needed

Fixes #811

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>