### PR TITLE
Update package.json to cdt-cloud url/homepage

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia-trace-extension"
+    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension"
   },
   "theiaPluginsDir": "../plugins"
 }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia-trace-extension"
+    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia-trace-extension/issues"
+    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia-trace-extension",
+  "homepage": "https://github.com/eclipse-cdt-cloud/theia-trace-extension",
   "devDependencies": {
     "@theia/cli": "1.21.0",
     "jsonc-parser": "^3.0.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia-trace-extension"
+    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia-trace-extension/issues"
+    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia-trace-extension",
+  "homepage": "https://github.com/eclipse-cdt-cloud/theia-trace-extension",
   "files": [
     "lib",
     "src"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia-trace-extension"
+    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension"
   },
   "files": [
     "lib",

--- a/theia-extensions/viewer-prototype/package.json
+++ b/theia-extensions/viewer-prototype/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia-trace-extension"
+    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Update with the most up-to-date url the
package.json files in the project.

Probably was forgotten when migrating the
project to eclipse-cdt-cloud in github.

Signed-off-by: Francesco Robino <francesco.robino@ericsson.com>