### PR TITLE
Implement datatree-output-component csv export in electron

### DIFF
--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -218,7 +218,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
 
                 const link = document.createElement('a');
                 link.setAttribute('href', `data:text/csv;charset=utf-8,${encodeURIComponent(tableString)}`);
-                link.setAttribute('download', (this.props.traceName ?? 'export') + ' - ' + this.props.outputDescriptor.name);
+                link.setAttribute('download', (this.props.traceName ?? 'export') + ' - ' + this.props.outputDescriptor.name + '.csv');
 
                 link.style.display = 'none';
                 document.body.appendChild(link);


### PR DESCRIPTION
Make 'export to csv' option work as expected in both browser and electron

Fixes #824

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>