### PR TITLE
Add configurable default view for the trace overview

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-overview-binding.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-overview-binding.ts
@@ -1,0 +1,13 @@
+import { interfaces } from 'inversify';
+import { PreferenceService, createPreferenceProxy, PreferenceContribution } from '@theia/core/lib/browser';
+import { OverviewPreferences, OverviewSchema } from './trace-overview-preference';
+
+export function bindTraceOverviewPreferences(bind: interfaces.Bind): void {
+    bind(OverviewPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createPreferenceProxy(preferences, OverviewSchema);
+    }).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({
+        schema: OverviewSchema,
+    });
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-overview-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-overview-preference.ts
@@ -1,0 +1,35 @@
+import { PreferenceProxy, PreferenceSchema, PreferenceScope } from '@theia/core/lib/browser';
+
+export const TRACE_OVERVIEW_DEFAULT_VIEW_KEY = 'trace Viewer.trace Overview.defaultView';
+export const DEFAULT_OVERVIEW_OUTPUT_NAME = 'Histogram';
+
+export function getSwitchToDefaultViewErrorMessage(preferredName: string, defaultName: string): string {
+    return `The ${preferredName} view cannot be opened as the trace overview. ` +
+    `Opening ${defaultName} instead. ` +
+    'Please set the Default View preference (Ctrl + ,) of the Trace Overview to an XY view, ' +
+    'or make sure the name is spelled correctly.';
+}
+
+export function getOpenTraceOverviewFailErrorMessage(): string {
+    return 'An error has occurred while opening the trace overview.';
+}
+
+export const OverviewSchema: PreferenceSchema = {
+    scope: PreferenceScope.Folder,
+    type: 'object',
+    properties: {
+        [TRACE_OVERVIEW_DEFAULT_VIEW_KEY]: {
+            type: 'string',
+            default: DEFAULT_OVERVIEW_OUTPUT_NAME,
+            description: 'Specify the name of the view that will be used as the default view for the Trace Overview. ' +
+            'Use the same name displayed in the Available Views list. E.g: For the Histogram view, enter Histogram.'
+        }
+    },
+};
+
+interface OverviewContribution {
+    [TRACE_OVERVIEW_DEFAULT_VIEW_KEY]: string
+}
+
+export const OverviewPreferences = Symbol('OverviewPreferences');
+export type OverviewPreferences = PreferenceProxy<OverviewContribution>;

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -22,6 +22,7 @@ import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
 import { BackendFileService, backendFileServicePath } from '../../common/backend-file-service';
 import { ChartShortcutsDialog, ChartShortcutsDialogProps } from '../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 import { TraceServerConnectionStatusService } from '../trace-server-status';
+import { bindTraceOverviewPreferences } from '../trace-overview-binding';
 
 export default new ContainerModule(bind => {
     bind(TraceServerUrlProviderImpl).toSelf().inSingletonScope();
@@ -68,6 +69,8 @@ export default new ContainerModule(bind => {
         return connection.createProxy<TraceServerConfigService>(traceServerPath);
     }).inSingletonScope();
     bindTraceServerPreferences(bind);
+
+    bindTraceOverviewPreferences(bind);
 
     bind(BackendFileService).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);


### PR DESCRIPTION
Currently, the trace overview default view is hard-coded in the trace viewer. This commit allows users/developers to set an XY view as the default view for the trace overview (using its name).

Users can set the default view for the trace overview using the Preference UI (File > Preferences > Open Settings or Ctrl + ,).

Developers can also set the default view for a specific Theia build by adding the "trace Viewer.trace Overview.defaultView" property to the "preferences" object in the package.json file (see snippet below - similar to `trace-viewer.port`) of the build and indicate the name of the default view.

https://github.com/eclipse-cdt-cloud/theia-trace-extension/blob/38d4e175718746f368e2ba2e3669e76bdcd40ec9/examples/browser/package.json#L5-L15

Fixes #840.