### PR TITLE
Toggle the filter tree for the trace overview

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -252,7 +252,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         });
     }
 
-    private closeOptionsMenu(event: Event): void {
+    protected closeOptionsMenu(event: Event): void {
         if (event && event.target instanceof Node && this.optionsMenuRef.current?.contains(event.target)) {
             return;
         }

--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -2,7 +2,11 @@ import { AbstractOutputComponent, AbstractOutputProps, AbstractOutputState } fro
 import * as React from 'react';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 
-export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends AbstractOutputComponent<P, S> {
+export type AbstractTreeOutputState = AbstractOutputState & {
+    showTree: boolean
+};
+
+export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractTreeOutputState> extends AbstractOutputComponent<P, S> {
 
     private readonly DEFAULT_Y_AXIS_WIDTH = 40;
     private readonly DEFAULT_SASH_WIDTH = 4;
@@ -19,11 +23,11 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
 
     renderMainArea(): React.ReactNode {
         return <React.Fragment>
-            <div ref={this.treeRef} className='output-component-tree disable-select'
+            {this.state.showTree && <div ref={this.treeRef} className='output-component-tree disable-select'
                 style={{ width: this.getTreeWidth(), height: this.props.style.height }}
             >
                 {this.renderTree()}
-            </div>
+            </div>}
             <div className='output-component-y-axis' style={{
                 height: this.props.style.height,
                 backgroundColor: '#' + this.props.style.chartBackgroundColor.toString(16)
@@ -47,7 +51,7 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
         this.sashDownOffset = this.props.style.chartOffset;
         window.addEventListener('mousemove', this.onSashMove);
         window.addEventListener('mouseup', this.onSashUp);
-}
+    }
 
     private onSashMove(ev: MouseEvent): void {
         if (this.sashDownX !== -1 && this.props?.setChartOffset) {
@@ -107,6 +111,10 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
     }
 
     public getChartWidth(): number {
-        return Math.max(0, this.props.outputWidth - this.props.style.chartOffset);
+        if (this.state.showTree) {
+            return Math.max(0, this.props.outputWidth - this.props.style.chartOffset);
+        } else {
+            return Math.max(0, this.props.outputWidth);
+        }
     }
 }

--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AbstractOutputProps, AbstractOutputState } from './abstract-output-component';
-import { AbstractTreeOutputComponent } from './abstract-tree-output-component';
+import { AbstractOutputProps } from './abstract-output-component';
+import { AbstractTreeOutputComponent, AbstractTreeOutputState } from './abstract-tree-output-component';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper';
 import { Entry } from 'tsp-typescript-client/lib/models/entry';
@@ -44,7 +44,7 @@ export enum MouseButton {
     RIGHT = 2
 }
 
-export type AbstractXYOutputState = AbstractOutputState & {
+export type AbstractXYOutputState = AbstractTreeOutputState & {
     selectedSeriesId: number[];
     xyTree: Entry[];
     checkedSeries: number[];

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -14,8 +14,8 @@ import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import { TimeGraphEntry } from 'tsp-typescript-client/lib/models/timegraph';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
-import { AbstractOutputProps, AbstractOutputState } from './abstract-output-component';
-import { AbstractTreeOutputComponent } from './abstract-tree-output-component';
+import { AbstractOutputProps } from './abstract-output-component';
+import { AbstractTreeOutputComponent, AbstractTreeOutputState } from './abstract-tree-output-component';
 import { StyleProperties } from './data-providers/style-properties';
 import { StyleProvider } from './data-providers/style-provider';
 import { TspDataProvider } from './data-providers/tsp-data-provider';
@@ -35,7 +35,7 @@ type TimegraphOutputProps = AbstractOutputProps & {
     removeWidgetResizeHandler: (handler: () => void) => void;
 };
 
-type TimegraphOutputState = AbstractOutputState & {
+type TimegraphOutputState = AbstractTreeOutputState & {
     timegraphTree: TimeGraphEntry[];
     markerCategoryEntries: Entry[];
     markerLayerData: { rows: TimelineChart.TimeGraphRowModel[], range: TimelineChart.TimeGraphRange, resolution: number } | undefined;
@@ -84,7 +84,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             columns: [],
             collapsedMarkerNodes: validateNumArray(this.props.persistChartState?.collapsedMarkerNodes) ? this.props.persistChartState.collapsedMarkerNodes as number[] : [],
             optionsDropdownOpen: false,
-            dataRows: []
+            dataRows: [],
+            showTree: true
         };
         this.selectedMarkerCategories = this.props.markerCategories;
         this.onToggleCollapse = this.onToggleCollapse.bind(this);

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -27,7 +27,8 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
             allMax: 0,
             allMin: 0,
             cursor: 'default',
-            optionsDropdownOpen: false
+            optionsDropdownOpen: false,
+            showTree: true
         };
     }
 

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -5,8 +5,6 @@ import { drawSelection } from './utils/xy-output-component-utils';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
 import { AbstractXYOutputState, MouseButton } from './abstract-xy-output-component';
 import { AbstractXYOutputComponent, FLAG_PAN_LEFT, FLAG_PAN_RIGHT, FLAG_ZOOM_IN, FLAG_ZOOM_OUT, XY_OUTPUT_KEY_ACTIONS } from './abstract-xy-output-component';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCog } from '@fortawesome/free-solid-svg-icons';
 import { Experiment } from 'tsp-typescript-client';
 import { TraceOverviewSelectionDialogComponent } from './trace-overview-selection-dialog-component';
 
@@ -51,7 +49,8 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutpu
             cursor: 'default',
             shiftKey: false,
             optionsDropdownOpen: false,
-            showModal: false
+            showModal: false,
+            showTree: true
         };
         this.keyMapping = this.getKeyActionMap();
         this.afterChartDraw = this.afterChartDraw.bind(this);
@@ -346,21 +345,24 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutpu
         return this.props.outputDescriptor.name + ' overview';
     }
 
-    protected showOptionsMenu(): React.ReactNode {
+    protected showOptions(): React.ReactNode {
         return <React.Fragment>
-            {<div className='options-menu-container'>
-                <button title="Select overview output source" className='options-menu-button'
-                onClick={()=>{this.openOverviewOutputSelector();}}>
-                    <FontAwesomeIcon icon={faCog} />
-                </button>
-                <TraceOverviewSelectionDialogComponent
-                    isOpen={this.state.showModal}
-                    title="Select overview output source"
-                    tspClient={this.props.tspClient}
-                    traceID={this.props.traceId}
-                    onCloseDialog={this.closeOverviewOutputSelector}
-                ></TraceOverviewSelectionDialogComponent>
-            </div>}
+            <ul>
+                <li className='drop-down-list-item' onClick={() => this.openOverviewOutputSelector()}>
+                    <div className='drop-down-list-item-text'>Select source output</div>
+                </li>
+                <li className='drop-down-list-item' onClick={() => this.toggleTree()}>
+                    <div className='drop-down-list-item-text'>Toggle filter tree</div>
+                </li>
+            </ul>
+            <TraceOverviewSelectionDialogComponent
+                isOpen={this.state.showModal}
+                title="Select overview output source"
+                tspClient={this.props.tspClient}
+                traceID={this.props.traceId}
+                onCloseDialog={this.closeOverviewOutputSelector}
+            ></TraceOverviewSelectionDialogComponent>
+            {this.state.additionalOptions && this.showAdditionalOptions()}
         </React.Fragment>;
     }
 
@@ -370,5 +372,14 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutpu
 
     private openOverviewOutputSelector() {
         this.setState({showModal: true});
+    }
+
+    private toggleTree() {
+        this.setState({
+            showTree: !this.state.showTree,
+            optionsDropdownOpen: false
+        }, () => {
+            document.removeEventListener('click', this.closeOptionsMenu);
+        });
     }
 }


### PR DESCRIPTION
This commit creates a hamburger menu for the trace overview that will allow users to toggle the filter tree and select a different output view. The hamburger menu replaces the existing cog icon that is used for output source selection. A new state property is added to the AbstractTreeOutputComponent that allows showing and hiding the filter tree. The overview then toggles this state property.

Fix #787