### PR TITLE
TableOutputComponent: Fix these search selection related cases

### DIFF
--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -632,7 +632,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                 this.selectEndIndex = this.selectStartIndex;
             }
             if (this.selectEndIndex !== -1 && this.selectStartIndex === -1) {
-                this.selectStartIndex = this.selectStartIndex;
+                this.selectStartIndex = this.selectEndIndex;
             }
 
             let currRowIndex = 0;

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -641,6 +641,10 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                     currRowIndex = Math.max(this.selectStartIndex, this.selectEndIndex) + 1;
                 } else {
                     currRowIndex = Math.min(this.selectStartIndex, this.selectEndIndex) - 1;
+                    if (currRowIndex < 0) {
+                        // no backward search if already at index 0
+                        return;
+                    }
                 }
             } else if (direction === Direction.PREVIOUS) {
                 // no backward search if there is no selection

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -43,6 +43,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     private frameworkComponents: any;
     private gridApi: GridApi | undefined = undefined;
     private gridRedrawn = false;
+    private gridSearched = false;
     private columnApi: ColumnApi | undefined = undefined;
     private prevStartTimestamp = -BigInt(2 ** 63);
     private startTimestamp = BigInt(2 ** 63);
@@ -609,6 +610,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             });
             this.gridApi.redrawRows();
         }
+        this.gridSearched = true;
         this.gridRedrawn = false;
     }
 
@@ -637,6 +639,11 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             while (this.gridRedrawn) {
                 // wait for grid to be done being redrawn -elsewhere (before assuming it)
                 await new Promise(cb => setTimeout(cb, msBetweenChecks));
+            }
+            if (this.gridSearched) {
+                // reset the selection once, upon new search filter just applied
+                this.selectStartIndex = this.selectEndIndex = -1;
+                this.gridSearched = false;
             }
 
             // make sure that both index are either both -1 or both have a valid number

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -595,6 +595,10 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         }
         if (this.gridApi) {
             this.gridApi.forEachNode(rowNode => {
+                if (!rowNode.data) {
+                    // hitting Enter early in Search field(s) can lead here
+                    return;
+                }
                 let isMatched = true;
                 this.filterModel.forEach((value, key) => {
                     if ((rowNode.data[key].search(new RegExp(value)) === -1)) {

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -674,7 +674,8 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                     // non-contiguous row found, stop searching in cache
                     currRowIndexFound = false;
                 }
-                if (currRowIndexFound && !isFound && rowNode.rowIndex && rowNode.data && rowNode.data['isMatched']) {
+                // only checking 'rowNode.rowIndex' below makes its '=== 0' case false:
+                if (currRowIndexFound && !isFound && (rowNode.rowIndex || rowNode.rowIndex === 0) && rowNode.data && rowNode.data['isMatched']) {
                     this.gridApi?.ensureIndexVisible(rowNode.rowIndex);
                     this.selectStartIndex = this.selectEndIndex = rowNode.rowIndex;
                     if (this.timestampCol) {

--- a/packages/react-components/src/components/table-renderer-components.tsx
+++ b/packages/react-components/src/components/table-renderer-components.tsx
@@ -84,7 +84,7 @@ export class SearchFilterRenderer extends React.Component<SearchFilterRendererPr
 
         this.debouncedChangeHandler = debounce((colName, inputVal) => {
             this.props.onFilterChange(colName, inputVal);
-        }, 500);
+        }, 10);
 
         this.onInputBoxChanged = this.onInputBoxChanged.bind(this);
         this.onMouseEnterHandler = this.onMouseEnterHandler.bind(this);


### PR DESCRIPTION
This PR is made of these commits with more details in their respective commit messages:

1. Fix findMatchedEvent row 0 case.
2. Fix backward search upon index 0.
3. Fix selectStartIndex assigned to itself.
4. Wait for search before selecting.
5. Fix exception upon early Enter.
6. Reset navigating selection if new search.
7. Separate search and matching.
8. **Decrease debounce ms by 50x.**

**The latter (PR's head) commit** formally fixes #859.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>