### PR TITLE
Add configurable default view for the trace overview

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "vscode-builtin-vb": "https://open-vsx.org/api/vscode/vb/1.50.0/file/vscode.vb-1.50.0.vsix",
     "vscode-builtin-icon-theme-seti": "https://open-vsx.org/api/vscode/vscode-theme-seti/1.50.0/file/vscode.vscode-theme-seti-1.50.0.vsix",
     "vscode-builtin-xml": "https://open-vsx.org/api/vscode/xml/1.50.0/file/vscode.xml-1.50.0.vsix",
-    "vscode-builtin-yaml": "https://open-vsx.org/api/vscode/yaml/1.50.0/file/vscode.yaml-1.50.0.vsix",
     "vscode-editorconfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.14.4/file/EditorConfig.EditorConfig-0.14.4.vsix",
     "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.7/file/llvm-vs-code-extensions.vscode-clangd-0.1.7.vsix"
   }

--- a/theia-extensions/viewer-prototype/src/browser/trace-overview-binding.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-overview-binding.ts
@@ -1,0 +1,13 @@
+import { interfaces } from 'inversify';
+import { PreferenceService, createPreferenceProxy, PreferenceContribution } from '@theia/core/lib/browser';
+import { OverviewPreferences, OverviewSchema } from './trace-overview-preference';
+
+export function bindTraceOverviewPreferences(bind: interfaces.Bind): void {
+    bind(OverviewPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createPreferenceProxy(preferences, OverviewSchema);
+    }).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({
+        schema: OverviewSchema,
+    });
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-overview-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-overview-preference.ts
@@ -1,0 +1,35 @@
+import { PreferenceProxy, PreferenceSchema, PreferenceScope } from '@theia/core/lib/browser';
+
+export const TRACE_OVERVIEW_DEFAULT_VIEW_KEY = 'trace Viewer.trace Overview.defaultView';
+export const DEFAULT_OVERVIEW_OUTPUT_NAME = 'Histogram';
+
+export function getSwitchToDefaultViewErrorMessage(preferredName: string, defaultName: string): string {
+    return `The ${preferredName} view cannot be opened as the trace overview. ` +
+    `Opening ${defaultName} instead. ` +
+    'Please set the Default View preference (Ctrl + ,) of the Trace Overview to an XY view, ' +
+    'or make sure the name is spelled correctly.';
+}
+
+export function getOpenTraceOverviewFailErrorMessage(): string {
+    return 'An error has occurred while opening the trace overview.';
+}
+
+export const OverviewSchema: PreferenceSchema = {
+    scope: PreferenceScope.Folder,
+    type: 'object',
+    properties: {
+        [TRACE_OVERVIEW_DEFAULT_VIEW_KEY]: {
+            type: 'string',
+            default: DEFAULT_OVERVIEW_OUTPUT_NAME,
+            description: 'Specify the name of the view that will be used as the default view for the Trace Overview. ' +
+            'Use the same name displayed in the Available Views list. E.g: For the Histogram view, enter Histogram.'
+        }
+    },
+};
+
+interface OverviewContribution {
+    [TRACE_OVERVIEW_DEFAULT_VIEW_KEY]: string
+}
+
+export const OverviewPreferences = Symbol('OverviewPreferences');
+export type OverviewPreferences = PreferenceProxy<OverviewContribution>;

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -22,6 +22,7 @@ import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
 import { BackendFileService, backendFileServicePath } from '../../common/backend-file-service';
 import { ChartShortcutsDialog, ChartShortcutsDialogProps } from '../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 import { TraceServerConnectionStatusService } from '../trace-server-status';
+import { bindTraceOverviewPreferences } from '../trace-overview-binding';
 
 export default new ContainerModule(bind => {
     bind(TraceServerUrlProviderImpl).toSelf().inSingletonScope();
@@ -68,6 +69,8 @@ export default new ContainerModule(bind => {
         return connection.createProxy<TraceServerConfigService>(traceServerPath);
     }).inSingletonScope();
     bindTraceServerPreferences(bind);
+
+    bindTraceOverviewPreferences(bind);
 
     bind(BackendFileService).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);


### PR DESCRIPTION
Currently, the trace overview default view is hard-coded in the trace viewer. With this commit, the default view for the trace extension can be set as a Preference setting in Theia. By default, the default view is Histogram, but that can be changed for each Theia build using the package.json file.

Fixes #840.

Signed-off-by: Hoang Thuan Pham <hoang.pham@calian.ca>