### PR TITLE
Fix overview opened in all trace tabs when using the toolbar button

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -26,7 +26,7 @@ export declare interface SignalManager {
     fireTraceServerStartedSignal(): void;
     fireUndoSignal(): void;
     fireRedoSignal(): void;
-    fireOpenOverviewOutputSignal(): void;
+    fireOpenOverviewOutputSignal(traceId: string): void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     firePinView(output: OutputDescriptor, payload?: any): void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -135,8 +135,8 @@ export class SignalManager extends EventEmitter implements SignalManager {
     fireUnPinView(output: OutputDescriptor, payload?: any): void {
         this.emit(Signals.UNPIN_VIEW, output, payload);
     }
-    fireOpenOverviewOutputSignal(): void {
-        this.emit(Signals.OPEN_OVERVIEW_OUTPUT);
+    fireOpenOverviewOutputSignal(traceId: string): void {
+        this.emit(Signals.OPEN_OVERVIEW_OUTPUT, traceId);
     }
     fireOverviewOutputSelectedSignal(payload: { traceId: string, outputDescriptor: OutputDescriptor}): void {
         this.emit(Signals.OVERVIEW_OUTPUT_SELECTED, payload);

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -53,7 +53,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             },
             execute: (widget: Widget) => {
                 if (widget instanceof TraceViewerWidget && !widget.isTraceOverviewOpened()) {
-                    signalManager().fireOpenOverviewOutputSignal();
+                    widget.openOverview();
                 }
             }
         });

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -65,7 +65,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     private selectedMarkerSetId = '';
 
     private onOutputAdded = (payload: OutputAddedSignalPayload): Promise<void> => this.doHandleOutputAddedSignal(payload);
-    private onTraceOverviewOpened = (): Promise<void> => this.doHandleTraceOverviewOpenedSignal();
+    private onTraceOverviewOpened = (traceId: string): Promise<void> => this.doHandleTraceOverviewOpenedSignal(traceId);
     private onTraceOverviewOutputSelected = (payload: {traceId: string, outputDescriptor: OutputDescriptor}): Promise<void> => this.doHandleTraceOverviewOutputSelected(payload);
     private onExperimentSelected = (experiment: Experiment): Promise<void> => this.doHandleExperimentSelectedSignal(experiment);
     private onCloseExperiment = (UUID: string): void => this.doHandleCloseExperimentSignal(UUID);
@@ -132,7 +132,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
 
         // Load the trace overview by default
         if (this.loadTraceOverview){
-            this.doHandleTraceOverviewOpenedSignal();
+            this.doHandleTraceOverviewOpenedSignal(this.openedExperiment?.UUID);
         }
     }
 
@@ -426,8 +426,8 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         }
     }
 
-    private async doHandleTraceOverviewOpenedSignal(): Promise<void> {
-        if (this.openedExperiment){
+    private async doHandleTraceOverviewOpenedSignal(traceId: string | undefined): Promise<void> {
+        if (this.openedExperiment && this.openedExperiment.UUID === traceId){
             this.loadOverviewOutputDescriptor();
             this.shell.activateWidget(this.openedExperiment.UUID);
         }
@@ -567,6 +567,12 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         }
 
         return false;
+    }
+
+    openOverview(): void {
+        if (this.openedExperiment?.UUID) {
+            signalManager().fireOpenOverviewOutputSignal(this.openedExperiment.UUID);
+        }
     }
 
     private async loadOverviewOutputDescriptor(): Promise<void> {


### PR DESCRIPTION
Currently, the trace overview open signal is broadcasted to all opened traces which causes the overview to open in all trace tabs. This commit adds a traceId parameter to the function that opens the trace overview, so that the trace viewer can check and only open the overview for the current active trace tab.

Fixes #856.

Signed-off-by: Hoang Thuan Pham <hoang.pham@calian.ca>