### PR TITLE
Display data as it is made available

### DIFF
--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -83,10 +83,13 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
 
     protected async waitAnalysisCompletion(): Promise<void> {
         let outputStatus = this.state.outputStatus;
-        const timeout = 500;
+        let factor = 1.0;
+        const maxFactor = 10;
         while (this.state && outputStatus === ResponseStatus.RUNNING) {
             outputStatus = await this.fetchTree();
+            const timeout = 500 * factor;
             await new Promise(resolve => setTimeout(resolve, timeout));
+            factor = factor > maxFactor ? factor: factor + 1;
         }
     }
 

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -41,29 +41,32 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
             </React.Fragment>;
         }
         return <React.Fragment>
-            {this.state.outputStatus === ResponseStatus.COMPLETED ?
+            <div
+                id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
+                className='xy-main'
+                tabIndex={0}
+                onKeyDown={event => this.onKeyDown(event)}
+                onKeyUp={event => this.onKeyUp(event)}
+                onWheel={event => this.onWheel(event)}
+                onMouseMove={event => this.onMouseMove(event)}
+                onContextMenu={event => event.preventDefault()}
+                onMouseLeave={event => this.onMouseLeave(event)}
+                onMouseDown={event => this.onMouseDown(event)}
+                style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
+                ref={this.divRef}
+            >
+                {this.isBarPlot ? this.drawD3Chart() : this.chooseChart()}
+            </div>
+            {(this.state.outputStatus === ResponseStatus.RUNNING) &&
                 <div
                     id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
-                    className='xy-main'
-                    tabIndex={0}
-                    onKeyDown={event => this.onKeyDown(event)}
-                    onKeyUp={event => this.onKeyUp(event)}
-                    onWheel={event => this.onWheel(event)}
-                    onMouseMove={event => this.onMouseMove(event)}
-                    onContextMenu={event => event.preventDefault()}
-                    onMouseLeave={event => this.onMouseLeave(event)}
-                    onMouseDown={event => this.onMouseDown(event)}
-                    style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
-                    ref={this.divRef}
+                    className='analysis-running-overflow'
+                    style={{ width: this.getChartWidth() }}
                 >
-                    {this.isBarPlot ? this.drawD3Chart() : this.chooseChart()}
-                </div> :
-                <div
-                    id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
-                    className='analysis-running'
-                >
-                    <i className='fa fa-refresh fa-spin' style={{ marginRight: '5px' }} />
-                    <span>Analysis running</span>
+                    <div>
+                        <i className='fa fa-refresh fa-spin' style={{ marginRight: '5px' }} />
+                        <span>Analysis running</span>
+                    </div>
                 </div>
             }
         </React.Fragment>;

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -18,7 +18,7 @@ type XYOutputOverviewState = AbstractXYOutputState & {
     showModal: boolean
 };
 
-type XYoutputOverviewProps = AbstractOutputProps & {
+type XYOutputOverviewProps = AbstractOutputProps & {
     experiment: Experiment;
 };
 
@@ -27,13 +27,13 @@ type XYoutputOverviewProps = AbstractOutputProps & {
  * It will only be setting these properties.
  */
 
-export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutputOverviewProps, XYOutputOverviewState> {
+export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutputOverviewProps, XYOutputOverviewState> {
     private initialViewRangeStartPosition = 0;
     private initialViewRangeEndPosition = 0;
     private viewRangeMoveStartOffsetX = 0;
     private keyMapping: Map<string, XY_OUTPUT_KEY_ACTIONS>;
 
-    constructor(props: XYoutputOverviewProps) {
+    constructor(props: XYOutputOverviewProps) {
         super(props);
         this.state = {
             outputStatus: ResponseStatus.RUNNING,
@@ -66,29 +66,31 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutpu
             </React.Fragment>;
         }
         return <React.Fragment>
-            {this.state.outputStatus === ResponseStatus.COMPLETED ?
+            <div
+                id={this.getOutputComponentDomId() + 'focusContainer'}
+                className='xy-main'
+                tabIndex={0}
+                onKeyDown={event => this.onKeyDown(event)}
+                onKeyUp={event => this.onKeyUp(event)}
+                onWheel={event => this.onWheel(event)}
+                onMouseMove={event => this.onMouseMove(event)}
+                onContextMenu={event => event.preventDefault()}
+                onMouseLeave={event => this.onMouseLeave(event)}
+                onMouseDown={event => this.onMouseDown(event)}
+                style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
+                ref={this.divRef}
+            >
+                {this.chooseChart()}
+            </div>
+            {(this.state.outputStatus === ResponseStatus.RUNNING) &&
                 <div
-                    id={this.getOutputComponentDomId() + 'focusContainer'}
-                    className='xy-main'
-                    tabIndex={0}
-                    onKeyDown={event => this.onKeyDown(event)}
-                    onKeyUp={event => this.onKeyUp(event)}
-                    onWheel={event => this.onWheel(event)}
-                    onMouseMove={event => this.onMouseMove(event)}
-                    onContextMenu={event => event.preventDefault()}
-                    onMouseLeave={event => this.onMouseLeave(event)}
-                    onMouseDown={event => this.onMouseDown(event)}
-                    style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
-                    ref={this.divRef}
+                    className='analysis-running-overflow'
+                    style={{ width: this.getChartWidth() }}
                 >
-                    {this.chooseChart()}
-                </div> :
-                <div
-                    id={this.getOutputComponentDomId() + 'focusContainer'}
-                    className='analysis-running'
-                >
-                    <i className='fa fa-refresh fa-spin' style={{ marginRight: '5px' }} />
-                    <span>Analysis running</span>
+                    <div>
+                        <i className='fa fa-refresh fa-spin' style={{ marginRight: '5px' }} />
+                        <span> Analysis running </span>
+                    </div>
                 </div>
             }
         </React.Fragment>;

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -160,6 +160,20 @@ canvas {
     margin: auto;
 }
 
+.analysis-running-overflow {
+    font-size: 24px;
+    display: flex;
+    position: absolute;
+    top: 0;
+    height: 100%;
+}
+
+.analysis-running-overflow div {
+    margin: auto;
+    padding: 5px;
+    border-radius: 5px;
+}
+
 .chart-message {
     font-size: 20px;
     text-align: center;


### PR DESCRIPTION
Changes the overview chart and the timegraph chart to display data as it is being loaded.

Changes are more notable in the overview. For the timegraph chart, even though the "analysis running" message was replaced by the direct display of data being loaded, its duration is normally short.

To see its effect, one should set the overview to open the "CPU Usage" analysis (set on preferences), because the "CPU Usage" displays a chart before having the user to select any series.

The effect is evident when a new large trace that makes several calls to the `fetchTree` endpoint is opened. After it is loaded, the result of the calls is cached and all charts open quickly.

Other charts like the "Disk I/O View" do not show the data as it is being loaded because they need the user to make a selection first. Therefore, on those charts, the "analysis running" message was kept on display while loading.

Fixes #816

https://user-images.githubusercontent.com/88502808/199540228-7a116efe-9a03-4d4e-8e15-e8dbfbbaa4fa.mp4

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>