### PR TITLE
Improve color scheme for zoom range of overview output

### DIFF
--- a/packages/react-components/src/components/utils/xy-output-component-utils.tsx
+++ b/packages/react-components/src/components/utils/xy-output-component-utils.tsx
@@ -26,6 +26,16 @@ export interface GetClosestPointParam {
     allMin: number,
 }
 
+export interface DrawSelectionParams {
+    ctx: CanvasRenderingContext2D | null,
+    chartArea: Chart.ChartArea | undefined | null,
+    startPixel: number,
+    endPixel: number,
+    isBarPlot: boolean,
+    props: AbstractOutputProps,
+    invertSelection: boolean
+}
+
 export interface XYPoint {
     x: number,
     y: number
@@ -112,17 +122,14 @@ function getDefaultChartOptions(params: XYChartFactoryParams): Chart.ChartOption
     return lineOptions;
 }
 
-export function drawSelection(ctx: CanvasRenderingContext2D | null,
-    chartArea: Chart.ChartArea | undefined | null,
-    startPixel: number,
-    endPixel: number,
-    isBarPlot: boolean,
-    props: AbstractOutputProps): void {
+export function drawSelection(params: DrawSelectionParams): void {
+    const { startPixel, endPixel, isBarPlot, chartArea, props, ctx, invertSelection} = params;
     const minPixel = Math.min(startPixel, endPixel);
     const maxPixel = Math.max(startPixel, endPixel);
     const initialPoint = isBarPlot ? 0 : chartArea?.left ?? 0;
     const chartHeight = parseInt(props.style.height.toString());
     const finalPoint = isBarPlot ? chartHeight : chartArea?.bottom ?? 0;
+
     if (ctx) {
         ctx.save();
 
@@ -143,7 +150,17 @@ export function drawSelection(ctx: CanvasRenderingContext2D | null,
 
         // Selection fill
         ctx.globalAlpha = 0.2;
-        ctx.fillRect(minPixel, 0, maxPixel - minPixel, finalPoint);
+        if (!invertSelection) {
+            ctx.fillRect(minPixel, 0, maxPixel - minPixel, finalPoint);
+        }
+        else {
+            const leftSideWidth = - minPixel;
+            const rightSideWidth = (chartArea?.right ? chartArea.right : 0) - maxPixel;
+
+            ctx.fillRect(minPixel, 0, leftSideWidth, finalPoint);
+            ctx.fillRect(maxPixel, 0, rightSideWidth, finalPoint);
+        }
+
         ctx.restore();
     }
 }

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -10,7 +10,7 @@ import { TraceOverviewSelectionDialogComponent } from './trace-overview-selectio
 
 const COLOR = {
     SELECTION_RANGE: '#259fd8',
-    VIEW_RANGE: '#ffa500',
+    VIEW_RANGE: '#cccccc'
 };
 
 type XYOutputOverviewState = AbstractXYOutputState & {
@@ -106,7 +106,15 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutpu
                 ctx.strokeStyle = COLOR.VIEW_RANGE;
                 ctx.fillStyle = COLOR.VIEW_RANGE;
 
-                drawSelection(ctx, chartArea, startPixel, endPixel, this.isBarPlot, this.props);
+                drawSelection({
+                    ctx: ctx,
+                    chartArea: chartArea,
+                    startPixel: startPixel,
+                    endPixel: endPixel,
+                    isBarPlot: this.isBarPlot,
+                    props: this.props,
+                    invertSelection: true
+                });
             }
 
             if (this.props.selectionRange) {
@@ -115,7 +123,15 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutpu
                 ctx.strokeStyle = COLOR.SELECTION_RANGE;
                 ctx.fillStyle = COLOR.SELECTION_RANGE;
 
-                drawSelection(ctx, chartArea, selectionRangeStart, selectionRangeEnd, this.isBarPlot, this.props);
+                drawSelection({
+                    ctx: ctx,
+                    chartArea: chartArea,
+                    startPixel: selectionRangeStart,
+                    endPixel: selectionRangeEnd,
+                    isBarPlot: this.isBarPlot,
+                    props: this.props,
+                    invertSelection: false
+                });
             }
 
             if (this.clickedMouseButton === MouseButton.RIGHT) {
@@ -124,7 +140,15 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYoutpu
                 const endPixel = this.positionXMove;
                 ctx.strokeStyle = COLOR.VIEW_RANGE;
                 ctx.fillStyle = COLOR.VIEW_RANGE;
-                drawSelection(ctx, chartArea, startPixel, endPixel, this.isBarPlot, this.props);
+                drawSelection({
+                    ctx: ctx,
+                    chartArea: chartArea,
+                    startPixel: startPixel,
+                    endPixel: endPixel,
+                    isBarPlot: this.isBarPlot,
+                    props: this.props,
+                    invertSelection: true
+                });
             }
         }
     }


### PR DESCRIPTION
Currently, the zoom range is shown in the trace overview using an orange overlay. When the users want to select a range (indicated by a blue overlay), these two layers overlap and make it hard to distinguish them. This commit improves the color scheme for the zoom range by 1) remove the orange overlay of the zoom range and 2) use a grey overlay to indicate the part of the trace that is not zoomed.

Fixes #857.

Signed-off-by: Hoang Thuan Pham <hoang.pham@calian.ca>