### PR TITLE
Fixes large tables on high-dpi monitors

### DIFF
--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -41,7 +41,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     private fetchColumns = true;
     private columnArray = new Array<any>();
     private pagination = true;
-    private paginationPageSize = 500000;
+    private paginationPageSize = 250000;
     private paginationTotalPages = 0;
     private showIndexColumn = false;
     private frameworkComponents: any;


### PR DESCRIPTION
Ag-grid says tables with too many rows have problems because of the limitation of a div's size, which is defined by the browser (see https://www.ag-grid.com/javascript-data-grid/massive-row-count/).

In order to check what the limitation is, one has to set `debugFlag=true` in `table-output-component.tsx` and watch the console when a large table is loaded. Doing so in a computer with a small monitor (1920 x 1200 px, dpi scale = 1) heralds:

`AG Grid.RowContainerHeightService: maxDivHeight = 32,000,000`

If each row has a height of 32 px, that means the table will start presenting selection issues below the millionth row. In fact, we observed problems precisely with tables that large.

A browser on a larger monitor (5120 x 2880 px, dpi scale = 2) heralds instead:

`AG Grid.RowContainerHeightService: maxDivHeight = 16,000,000`

The same row height of 32 px will have the table misbehaving after 500,000 rows, which is what was observed.

All this is a consequence of the particular solution Ag-grid adopted to deal with large tables, a technique they call "stretching" and is explained in the link above.

To circumvent this issue, this PR changes the number of rows a page is allowed to have from 500,000 to 250,000.

Fixes https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/862.

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca