### PR TITLE
Workaround rate limitation issues with open-vsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "rebuild:electron": "yarn --cwd examples/electron theia rebuild:electron --cacheRoot ../..",
     "start:browser": "yarn rebuild:browser && yarn --cwd examples/browser start",
     "start:electron": "yarn rebuild:electron && yarn --cwd examples/electron start",
-    "download:plugins": "theia download:plugins -p=true",
+    "download:plugins": "theia download:plugins -p=true --parallel=false",
     "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/tuxology/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz",
     "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz",
     "start:server": "./trace-compass-server/tracecompass-server",


### PR DESCRIPTION
Download the plug-ins sequentially instead of parallel. This should avoid the failure "Download:plugins fails with 429".

see discussion:
https://community.theia-ide.org/t/download-plugins-fails-with-429/2659

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>