### PR TITLE
0007 queryable properties goto min max

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -32,6 +32,7 @@ export declare interface SignalManager {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fireUnPinView(output: OutputDescriptor, payload?: any): void;
     fireOverviewOutputSelectedSignal(payload: { traceId: string, outputDescriptor: OutputDescriptor}): void;
+    fireDatatreeOutputOpenContextMenu(payload: { xPos: number, yPos: number, nodeId: number, cellIndex: number, outputId: string}): void;
 }
 
 export const Signals = {
@@ -60,7 +61,8 @@ export const Signals = {
     PIN_VIEW: 'view pinned',
     UNPIN_VIEW: 'view unpinned',
     OPEN_OVERVIEW_OUTPUT: 'open overview output',
-    OVERVIEW_OUTPUT_SELECTED: 'overview output selected'
+    OVERVIEW_OUTPUT_SELECTED: 'overview output selected',
+    DATATREE_OUTPUT_OPEN_CONTEXT_MENU: 'datatree output open context menu'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -140,6 +142,9 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireOverviewOutputSelectedSignal(payload: { traceId: string, outputDescriptor: OutputDescriptor}): void {
         this.emit(Signals.OVERVIEW_OUTPUT_SELECTED, payload);
+    }
+    fireDatatreeOutputOpenContextMenu(payload: { xPos: number, yPos: number, nodeId: number, cellIndex: number, outputId: string}): void {
+        this.emit(Signals.DATATREE_OUTPUT_OPEN_CONTEXT_MENU, payload);
     }
 }
 

--- a/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
@@ -21,6 +21,7 @@ interface EntryTreeProps {
     showHeader: boolean;
     headers: ColumnHeader[];
     className: string;
+    outputDescriptorId?: string;
 }
 
 export class EntryTree extends React.Component<EntryTreeProps> {

--- a/packages/react-components/src/components/utils/filter-tree/table-body.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-body.tsx
@@ -13,6 +13,7 @@ interface TableBodyProps {
     onRowClick: (id: number) => void;
     onClose: (id: number) => void;
     onToggleCheck: (id: number) => void;
+    outputDescriptorId?: string;
 }
 
 export class TableBody extends React.Component<TableBodyProps> {

--- a/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { TreeNode } from './tree-node';
+import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 
 interface TableCellProps {
     node: TreeNode;
     index: number;
     onRowClick: (id: number) => void;
     selectedRow?: number;
+    outputDescriptorId?: string;
 }
 
 export class TableCell extends React.Component<TableCellProps> {
@@ -20,13 +22,31 @@ export class TableCell extends React.Component<TableCellProps> {
         }
     };
 
+    private onContextMenu = (e: React.MouseEvent) => {
+        e.preventDefault();
+        if (this.props.outputDescriptorId) {
+            signalManager().fireDatatreeOutputOpenContextMenu({
+                xPos: e.clientX,
+                yPos: e.clientY,
+                nodeId: this.props.node.id,
+                cellIndex: this.props.index,
+                outputId: this.props.outputDescriptorId
+            })
+        }
+    }
+
     render(): React.ReactNode {
         const { node, selectedRow, index } = this.props;
         const content = node.labels[index];
         const className = (selectedRow === node.id) ? 'selected' : '';
 
         return (
-            <td key={this.props.index+'-td-'+this.props.node.id} onClick={this.onClick} className={className}>
+            <td 
+                key={this.props.index+'-td-'+this.props.node.id}
+                onClick={this.onClick}
+                className={className}
+                onContextMenu={this.onContextMenu}
+            >
                 <span>
                     {this.props.children}
                     {content}

--- a/packages/react-components/src/components/utils/filter-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-row.tsx
@@ -16,6 +16,7 @@ interface TableRowProps {
     onClose: (id: number) => void;
     onToggleCheck: (id: number) => void;
     onRowClick: (id: number) => void;
+    outputDescriptorId?: string;
 }
 
 export class TableRow extends React.Component<TableRowProps> {
@@ -69,6 +70,7 @@ export class TableRow extends React.Component<TableRowProps> {
                 node={node}
                 onRowClick={onRowClick}
                 selectedRow={selectedRow}
+                outputDescriptorId={this.props.outputDescriptorId}
             >
                 { (index === 0) ? this.renderToggleCollapse() : undefined }
                 { (index === 0) ? this.renderCheckbox() : undefined }
@@ -99,7 +101,9 @@ export class TableRow extends React.Component<TableRowProps> {
 
         return (
             <React.Fragment>
-                <tr>{this.renderRow()}</tr>
+                <tr>
+                    {this.renderRow()}
+                </tr>
                 {children}
             </React.Fragment>
         );

--- a/packages/react-components/src/components/utils/filter-tree/table.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table.tsx
@@ -22,6 +22,7 @@ interface TableProps {
     showHeader: boolean;
     headers: ColumnHeader[];
     className: string;
+    outputDescriptorId?: string;
 }
 
 export class Table extends React.Component<TableProps> {

--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -24,6 +24,7 @@ interface FilterTreeProps {
     showHeader: boolean;
     headers: ColumnHeader[];
     className: string;
+    outputDescriptorId?: string;
 }
 
 interface FilterTreeState {
@@ -270,6 +271,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             showHeader={this.props.showHeader}
             headers={this.props.headers}
             className={this.props.className}
+            outputDescriptorId={this.props.outputDescriptorId}
         />;
 
     render(): JSX.Element | undefined {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -65,7 +65,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
 
     private onOutputAdded = (payload: OutputAddedSignalPayload): Promise<void> => this.doHandleOutputAddedSignal(payload);
     private onTraceOverviewOpened = (): Promise<void> => this.doHandleTraceOverviewOpenedSignal();
-    private onTraceOverviewOutputSelected = (payload: {traceId: string, outputDescriptor: OutputDescriptor}): Promise<void> => this.doHandleTraceOverviewOutputSelected(payload);
+    private onTraceOverviewOutputSelected = (payload: { traceId: string, outputDescriptor: OutputDescriptor }): Promise<void> => this.doHandleTraceOverviewOutputSelected(payload);
     private onExperimentSelected = (experiment: Experiment): Promise<void> => this.doHandleExperimentSelectedSignal(experiment);
     private onCloseExperiment = (UUID: string): void => this.doHandleCloseExperimentSignal(UUID);
     private onMarkerCategoryClosedSignal = (payload: { traceViewerId: string, markerCategory: string }) => this.doHandleMarkerCategoryClosedSignal(payload);
@@ -129,7 +129,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         this.node.tabIndex = 0;
 
         // Load the trace overview by default
-        if (this.loadTraceOverview){
+        if (this.loadTraceOverview) {
             this.doHandleTraceOverviewOpenedSignal();
         }
     }
@@ -165,11 +165,11 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
 
         // This will show a progress dialog with "Cancel" option
         this.messageService.showProgress({
-                text: 'Open traces',
-                options: {
-                    cancelable: true
-                }
-            },
+            text: 'Open traces',
+            options: {
+                cancelable: true
+            }
+        },
             () => {
                 cancellation.cancel();
             })
@@ -289,7 +289,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
                 this.outputDescriptors = persistedState.outputs;
             }
 
-            if (persistedState.storedOverviewOutput){
+            if (persistedState.storedOverviewOutput) {
                 this.overviewOutputDescriptor = persistedState.storedOverviewOutput;
             }
         }
@@ -367,7 +367,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
             const exist = this.outputDescriptors.find(output => output.id === payload.getOutputDescriptor().id);
             if (!exist) {
                 const output = payload.getOutputDescriptor();
-                this.outputDescriptors =  this.outputDescriptors.concat(output);
+                this.outputDescriptors = this.outputDescriptors.concat(output);
                 await this.fetchAnnotationCategories(output);
                 this.update();
             } else {
@@ -385,7 +385,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
                         event.stopPropagation();
                         titleHandle?.classList.remove('animate__animated', 'animate__pulse');
                         resolve('Animation ended');
-                    }, {once: true});
+                    }, { once: true });
                 });
             }
         }
@@ -407,7 +407,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     protected async doHandleExperimentSelectedSignal(experiment: Experiment): Promise<void> {
         if (this.openedExperiment && this.openedExperiment.UUID === experiment.UUID) {
             // Update the trace UUID so that the overview can be opened
-            if (this.loadTraceOverview){
+            if (this.loadTraceOverview) {
                 const defaultOutputDescriptor = await this.getDefaultTraceOverviewOutputDescriptor();
                 this.updateOverviewOutputDescriptor(defaultOutputDescriptor);
             }
@@ -425,16 +425,16 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     }
 
     private async doHandleTraceOverviewOpenedSignal(): Promise<void> {
-        if (this.openedExperiment){
+        if (this.openedExperiment) {
             this.loadOverviewOutputDescriptor();
             this.shell.activateWidget(this.openedExperiment.UUID);
         }
     }
 
-    private async doHandleTraceOverviewOutputSelected(payload: {traceId: string, outputDescriptor: OutputDescriptor}): Promise<void> {
-        if (this.openedExperiment && payload && payload.traceId === this.openedExperiment.UUID && payload.outputDescriptor){
-                await this.updateOverviewOutputDescriptor(payload.outputDescriptor);
-                this.shell.activateWidget(this.openedExperiment.UUID);
+    private async doHandleTraceOverviewOutputSelected(payload: { traceId: string, outputDescriptor: OutputDescriptor }): Promise<void> {
+        if (this.openedExperiment && payload && payload.traceId === this.openedExperiment.UUID && payload.outputDescriptor) {
+            await this.updateOverviewOutputDescriptor(payload.outputDescriptor);
+            this.shell.activateWidget(this.openedExperiment.UUID);
         }
     }
 
@@ -560,7 +560,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     }
 
     isTraceOverviewOpened(): boolean {
-        if (this.overviewOutputDescriptor){
+        if (this.overviewOutputDescriptor) {
             return true;
         }
 
@@ -590,7 +590,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
      * Get the output descriptor for the trace over view
      */
     protected async getAvailableTraceOverviewOutputDescriptor(): Promise<OutputDescriptor[] | undefined> {
-        if (this.openedExperiment){
+        if (this.openedExperiment) {
             const descriptors = await this.experimentManager.getAvailableOutputs(this.openedExperiment.UUID);
             const overviewOutputDescriptors = descriptors?.filter(output => output.type === 'TREE_TIME_XY');
             return overviewOutputDescriptors;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,7 +2729,7 @@
   resolved "https://registry.yarnpkg.com/@stroncium/procfs/-/procfs-1.2.1.tgz#6b9be6fd20fb0a4c20e99a8695e083c699bb2b45"
   integrity sha512-X1Iui3FUNZP18EUvysTHxt+Avu2nlVzyf90YM8OYgP6SGzTzzX/0JgObfO1AQQDzuZtNNz29bVh8h5R97JrjxA==
 
-"@szhsin/react-menu@^3.2.0":
+"@szhsin/react-menu@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@szhsin/react-menu/-/react-menu-3.2.1.tgz#92bbf965175d08f1d430aa4924a8ccfdbbd69501"
   integrity sha512-HEStuXNYHxLcGByiWaxFcE+ZaZ5BPQd/NtwBcxmUvHdvAaCZngmZ2ZddWuDAYZval94Kpahi1ZH0/WSv3oFnFg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,6 +2729,14 @@
   resolved "https://registry.yarnpkg.com/@stroncium/procfs/-/procfs-1.2.1.tgz#6b9be6fd20fb0a4c20e99a8695e083c699bb2b45"
   integrity sha512-X1Iui3FUNZP18EUvysTHxt+Avu2nlVzyf90YM8OYgP6SGzTzzX/0JgObfO1AQQDzuZtNNz29bVh8h5R97JrjxA==
 
+"@szhsin/react-menu@^3.2.0":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@szhsin/react-menu/-/react-menu-3.2.1.tgz#92bbf965175d08f1d430aa4924a8ccfdbbd69501"
+  integrity sha512-HEStuXNYHxLcGByiWaxFcE+ZaZ5BPQd/NtwBcxmUvHdvAaCZngmZ2ZddWuDAYZval94Kpahi1ZH0/WSv3oFnFg==
+  dependencies:
+    prop-types "^15.7.2"
+    react-transition-state "^1.1.5"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -12753,6 +12761,11 @@ react-tooltip@^4.2.21:
   dependencies:
     prop-types "^15.7.2"
     uuid "^7.0.3"
+
+react-transition-state@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-transition-state/-/react-transition-state-1.1.5.tgz#22accee21d0011b1d0245be24b6262ae67f494c3"
+  integrity sha512-ITY2mZqc2dWG2eitJkYNdcSFW8aKeOlkL2A/vowRrLL8GH3J6Re/SpD/BLvQzrVOTqjsP0b5S9N10vgNNzwMUQ==
 
 react-virtualized@^9.20.0, react-virtualized@^9.21.0:
   version "9.22.3"


### PR DESCRIPTION
Changes:
- Added context menu listener to Entry-Tree component. Tree components can create context menu on cell or row
- Datatree-output-component supports Queryable property to create custom context menu with "Goto min/max" action
- This is still a WIP. Ignore lack of commenting and style - those will be added in forthcoming commits

Depends on:
https://github.com/eclipse-cdt-cloud/tsp-typescript-client/pull/66
https://git.eclipse.org/r/c/tracecompass/org.eclipse.tracecompass/+/196970
https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/196985

[Screen Recording 2022-11-15 at 3.21.40 PM.webm](https://user-images.githubusercontent.com/92893187/202028196-53c87a69-be7f-4765-9522-42a15a7ab16d.webm)