### PR TITLE
Add new command open-trace-with-path to open a trace with the given path

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
@@ -29,3 +29,16 @@ export const OpenTraceWithRootPathCommand: Command = {
     id: 'open-trace-with-root-path',
     label: 'Open Trace With Root Path'
 };
+
+/**
+ * A command to open a trace in the trace viewer.
+ *
+ * The command takes two parameters:
+ *
+ * path: a string containing the path to a trace
+ * options: an optional TraceViewerWidgetOpenerOptions
+ */
+export const OpenTraceWithPathCommand: Command = {
+    id: 'open-trace-with-path',
+    label: 'Open Trace With Path'
+};

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
@@ -33,10 +33,9 @@ export const OpenTraceWithRootPathCommand: Command = {
 /**
  * A command to open a trace in the trace viewer.
  *
- * The command takes two parameters:
+ * The command takes a parameter:
  *
  * path: a string containing the path to a trace
- * options: an optional TraceViewerWidgetOpenerOptions
  */
 export const OpenTraceWithPathCommand: Command = {
     id: 'open-trace-with-path',

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -188,7 +188,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
         });
         registry.registerCommand(OpenTraceWithPathCommand, {
             isVisible: () => false,
-            execute: (path: string, options: TraceViewerWidgetOpenerOptions) => path && this.open(new URI(path), options),
+            execute: (path: string) => path && this.open(new URI(path)),
         });
         registry.registerCommand(OpenTraceWithRootPathCommand, {
             isVisible: () => false,

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -5,7 +5,15 @@ import URI from '@theia/core/lib/common/uri';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-import { OpenTraceCommand, StartServerCommand, StopServerCommand, TraceViewerCommand, KeyboardShortcutsCommand, OpenTraceWithRootPathCommand } from './trace-viewer-commands';
+import {
+  OpenTraceCommand,
+  StartServerCommand,
+  StopServerCommand,
+  TraceViewerCommand,
+  KeyboardShortcutsCommand,
+  OpenTraceWithRootPathCommand,
+  OpenTraceWithPathCommand,
+} from './trace-viewer-commands';
 import { PortBusy, TraceServerConfigService } from '../../common/trace-server-config';
 import { TracePreferences, TRACE_PATH, TRACE_ARGS } from '../trace-server-preference';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
@@ -177,6 +185,10 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(OpenTraceCommand, {
             execute: () => this.launchTraceServer()
+        });
+        registry.registerCommand(OpenTraceWithPathCommand, {
+            isVisible: () => false,
+            execute: (path: string, options: TraceViewerWidgetOpenerOptions) => path && this.open(new URI(path), options),
         });
         registry.registerCommand(OpenTraceWithRootPathCommand, {
             isVisible: () => false,


### PR DESCRIPTION
This new command takes a path to a trace directory and opens the trace in the trace viewer.

The use case is we have an extension that collects traces from target hardware, when that trace collection is complete we want to open it in the UI. Adding this new command allows us to open the trace in the viewer by passing the path to the new trace.

The alternative we considered was, in our extension, connecting to the trace server and issuing a tspClient.openTrace and then tspClient.createExperiment. While this does load the trace on the server, we still need a way for the UI to refresh. Rather the providing a new command to refresh the UI we propose this new command as it also saves us from duplicating all the work to interact with the tspClient.