### PR TITLE
Use specific rules for lib folders in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,13 @@
 *.tsbuildinfo
 .browser_modules/
 /.venv/
+/packages/base/lib/
 /packages/react-components/coverage/
+/packages/react-components/lib/
 TraceCompassTutorialTraces
 TraceCompassTutorialTraces.tgz
 examples/*
-lib/
 node_modules/
+theia-extensions/viewer-prototype/lib/
 trace-compass-server
 trace-compass-server.tar.gz


### PR DESCRIPTION
Currently there is a git rule to ignore all `lib/` folders in the project. But some sub-project might have lib folders that have to be commited.

One solution would be to add exceptions to the `.gitignore` file as in `!doc/lib/`. This would allow git to commit the "doc/lib/" folder, but for this to work the exception has to be added after the excluding rule, as in:

```
lib/
!doc/lib
```

If the exception comes before the rule, it is overruled. This is a problem because the sorting rule applied to .gitignore files automatically moves all exceptions (lines starting with "!") to the top of the file.

To avoid this problem for the case of the "lib/" folders, this PR replaces the `lib/` rule with more specific ones, so that no extra exception rules for lib folders are necessary.

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>