### PR TITLE
Use new TSP APIs for XY entries to check for default entries

### DIFF
--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -10,7 +10,7 @@ import { scaleLinear } from 'd3-scale';
 import { axisLeft } from 'd3-axis';
 import { select } from 'd3-selection';
 import { EntryTree } from './utils/filter-tree/entry-tree';
-import { XYSeries } from 'tsp-typescript-client/lib/models/xy';
+import { XyEntry, XYSeries } from 'tsp-typescript-client/lib/models/xy';
 import * as React from 'react';
 import { flushSync } from 'react-dom';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
@@ -265,11 +265,21 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
                 } else {
                     columns.push({title: 'Name', sortable: true});
                 }
-                this.setState({
-                    outputStatus: treeResponse.status,
-                    xyTree: treeResponse.model.entries,
-                    columns
-                });
+                if (treeResponse.status === ResponseStatus.COMPLETED) {
+                    const checkedSeries = this.getAllCheckedIds(treeResponse.model.entries);
+                    this.setState({
+                        outputStatus: treeResponse.status,
+                        xyTree: treeResponse.model.entries,
+                        checkedSeries,
+                        columns
+                    });
+                } else {
+                    this.setState({
+                        outputStatus: treeResponse.status,
+                        xyTree: treeResponse.model.entries,
+                        columns
+                    });
+                }
             } else {
                 this.setState({
                     outputStatus: treeResponse.status
@@ -281,6 +291,16 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
             outputStatus: ResponseStatus.FAILED
         });
         return ResponseStatus.FAILED;
+    }
+
+    getAllCheckedIds(entries: Array<XyEntry>): Array<number> {
+        const checkedSeries: number[] = [];
+        for (const entry of entries) {
+            if (entry.isDefault) {
+                checkedSeries.push(entry.id);
+            }
+        }
+        return checkedSeries;
     }
 
     renderTree(): React.ReactNode | undefined {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14401,9 +14401,9 @@ tslib@^2.2.0, tslib@^2.3.1:
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsp-typescript-client@next:
-  version "0.4.0-next.7f692ba.0"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.7f692ba.0.tgz#7f4ae3710d583a58b65769f59f5c204d6da9f7a1"
-  integrity sha512-XAc5cbKskjmyg2oN2QIvIF488j37y1IDdYeZFMN3aPN12RWfG8oqyfYtJhr2NFHd6to7CmTphYJNYlUuChni3A==
+  version "0.4.0-next.30e85df.0"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.30e85df.0.tgz#aa38ef3382e74813c5235035b2d60a5a5ff4fdc2"
+  integrity sha512-N90mJB2yXQJeuAhyCYGz9Ph3Fcn5z5jwHkUPbqucrEdiR00gCO4PX+5dxHyzktvEHDvVLFylvKjyiVR4mkKFQA==
   dependencies:
     json-bigint sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473
     node-fetch "^2.5.0"


### PR DESCRIPTION
If 'isDefault' flag is set for an XY entry, then check it in the tree and fetch its XY data to fill the XY graph once the analysis is complete.

- Fixes #786 
- Requires to build: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/pull/70
- Corresponding: TSP specitication: https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/85
- Contributes to https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/786

Example back-end implementation:
- https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/199322
- https://git.eclipse.org/r/c/tracecompass/org.eclipse.tracecompass/+/199323/1
- https://git.eclipse.org/r/c/tracecompass/org.eclipse.tracecompass/+/199324

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>