### PR TITLE
Reduce timeline-chart cache by reducing worldRangeFactor to 0.25

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -188,6 +188,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             const nanos = zeroPad(theNumber % BigInt(1000));
             return seconds + '.' + millis + ' ' + micros + ' ' + nanos;
         };
+        this.unitController.worldRenderFactor = 0.25;
         this.historyHandler = new UnitControllerHistoryHandler(this.unitController);
         if (this.props.persistedState?.currentTimeSelection) {
             const { start, end } = this.props.persistedState.currentTimeSelection;


### PR DESCRIPTION
With this change only 0.25 times (instead of 1.0) of the view range is cached on the before and after of the window range. This reduces the amount of data to be fetched and managed down. This will improve the performance of the timeline-chart when, for example, zooming.

Horizontal panning inside the world range is still available due to the cached data.

Fixes #912

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>