### PR TITLE
Fix selecting of timegraph row when tree row is selected

### DIFF
--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -121,6 +122,7 @@ exports[`Entry with children All unchecked 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             parent second column
@@ -133,6 +135,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -176,6 +179,7 @@ exports[`Entry with children All unchecked 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             child1 second column
@@ -188,6 +192,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -251,6 +256,7 @@ exports[`Entry with children All unchecked 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             child2 second column
@@ -263,6 +269,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -306,6 +313,7 @@ exports[`Entry with children All unchecked 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             grandchild1 second column
@@ -318,6 +326,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -361,6 +370,7 @@ exports[`Entry with children All unchecked 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             grandchild2 second column
@@ -431,6 +441,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -494,6 +505,7 @@ exports[`Entry with children Check one grandchild 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             parent second column
@@ -506,6 +518,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -549,6 +562,7 @@ exports[`Entry with children Check one grandchild 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             child1 second column
@@ -561,6 +575,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -624,6 +639,7 @@ exports[`Entry with children Check one grandchild 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             child2 second column
@@ -636,6 +652,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -679,6 +696,7 @@ exports[`Entry with children Check one grandchild 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             grandchild1 second column
@@ -691,6 +709,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -734,6 +753,7 @@ exports[`Entry with children Check one grandchild 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             grandchild2 second column
@@ -804,6 +824,7 @@ exports[`Entry with children Collapse one child 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -867,6 +888,7 @@ exports[`Entry with children Collapse one child 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             parent second column
@@ -879,6 +901,7 @@ exports[`Entry with children Collapse one child 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -922,6 +945,7 @@ exports[`Entry with children Collapse one child 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             child1 second column
@@ -934,6 +958,7 @@ exports[`Entry with children Collapse one child 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -997,6 +1022,7 @@ exports[`Entry with children Collapse one child 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             child2 second column
@@ -1087,6 +1113,7 @@ Array [
         <tr>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               <div
@@ -1150,6 +1177,7 @@ Array [
           </td>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               parent second column
@@ -1162,6 +1190,7 @@ Array [
         <tr>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               <div
@@ -1205,6 +1234,7 @@ Array [
           </td>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               child1 second column
@@ -1217,6 +1247,7 @@ Array [
         <tr>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               <div
@@ -1280,6 +1311,7 @@ Array [
           </td>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               child2 second column
@@ -1292,6 +1324,7 @@ Array [
         <tr>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               <div
@@ -1335,6 +1368,7 @@ Array [
           </td>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               grandchild1 second column
@@ -1347,6 +1381,7 @@ Array [
         <tr>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               <div
@@ -1390,6 +1425,7 @@ Array [
           </td>
           <td
             className=""
+            onClick={[Function]}
           >
             <span>
               grandchild2 second column
@@ -1461,6 +1497,7 @@ exports[`one level of entries 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -1477,6 +1514,7 @@ exports[`one level of entries 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span />
         </td>
@@ -1487,6 +1525,7 @@ exports[`one level of entries 1`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -1503,6 +1542,7 @@ exports[`one level of entries 1`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             entry2 column2
@@ -1573,6 +1613,7 @@ exports[`one level of entries 2`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -1616,6 +1657,7 @@ exports[`one level of entries 2`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span />
         </td>
@@ -1626,6 +1668,7 @@ exports[`one level of entries 2`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -1669,6 +1712,7 @@ exports[`one level of entries 2`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             entry2 column2
@@ -1697,6 +1741,7 @@ exports[`one level of entries 3`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -1740,6 +1785,7 @@ exports[`one level of entries 3`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span />
         </td>
@@ -1750,6 +1796,7 @@ exports[`one level of entries 3`] = `
       <tr>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             <div
@@ -1793,6 +1840,7 @@ exports[`one level of entries 3`] = `
         </td>
         <td
           className=""
+          onClick={[Function]}
         >
           <span>
             entry2 column2

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/table-row.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/table-row.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Checked status 1`] = `
 <tr>
   <td
     className=""
+    onClick={[Function]}
   >
     <span>
       <div
@@ -55,6 +56,7 @@ exports[`Checked status 2`] = `
 <tr>
   <td
     className=""
+    onClick={[Function]}
   >
     <span>
       <div
@@ -106,6 +108,7 @@ exports[`Checked status 3`] = `
 <tr>
   <td
     className=""
+    onClick={[Function]}
   >
     <span>
       <div
@@ -157,6 +160,7 @@ exports[`Levels 1`] = `
 <tr>
   <td
     className=""
+    onClick={[Function]}
   >
     <span>
       <div
@@ -208,6 +212,7 @@ exports[`Levels 2`] = `
 <tr>
   <td
     className=""
+    onClick={[Function]}
   >
     <span>
       <div
@@ -260,6 +265,7 @@ Array [
   <tr>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         <div
@@ -323,6 +329,7 @@ Array [
     </td>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         parent 2 text
@@ -335,6 +342,7 @@ Array [
   <tr>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         <div
@@ -378,6 +386,7 @@ Array [
     </td>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         child 1 text
@@ -390,6 +399,7 @@ Array [
   <tr>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         <div
@@ -433,6 +443,7 @@ Array [
     </td>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         child 2 text
@@ -449,6 +460,7 @@ exports[`Uncheckable 1`] = `
 <tr>
   <td
     className=""
+    onClick={[Function]}
   >
     <span>
       <div
@@ -474,6 +486,7 @@ Array [
   <tr>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         <div
@@ -542,6 +555,7 @@ Array [
   <tr>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         <div
@@ -590,6 +604,7 @@ Array [
   <tr>
     <td
       className=""
+      onClick={[Function]}
     >
       <span>
         <div
@@ -642,6 +657,7 @@ exports[`with children With children collapsed 1`] = `
 <tr>
   <td
     className=""
+    onClick={[Function]}
   >
     <span>
       <div

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/table-row.test.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/table-row.test.tsx
@@ -8,6 +8,7 @@ import { within } from "@testing-library/dom";
 const mockOnChecked = jest.fn();
 const mockOnCollapse = jest.fn();
 const mockOnClose = jest.fn();
+const mockOnClick = jest.fn();
 
 const cell1Text = "cell1 - text";
 const testTreeNode = {
@@ -26,6 +27,7 @@ test('Checked status', () => {
         isCheckable={true}
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
+        onRowClick={mockOnClick}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(treeNodeUnchecked).toMatchSnapshot();
@@ -37,6 +39,7 @@ test('Checked status', () => {
         isCheckable={true}
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
+        onRowClick={mockOnClick}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(treeNodeChecked).toMatchSnapshot();
@@ -48,6 +51,7 @@ test('Checked status', () => {
         isCheckable={true}
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
+        onRowClick={mockOnClick}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(treeNodePartialCheck).toMatchSnapshot();
@@ -61,6 +65,7 @@ test('Uncheckable', () => {
         getCheckedStatus={id => 0}
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
+        onRowClick={mockOnClick}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(uncheckableTree).toMatchSnapshot();
@@ -74,6 +79,7 @@ test('Levels', () => {
         isCheckable={true}
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
+        onRowClick={mockOnClick}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(lessPadding).toMatchSnapshot();
@@ -85,6 +91,7 @@ test('Levels', () => {
         isCheckable={true}
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
+        onRowClick={mockOnClick}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(morePadding).toMatchSnapshot();
@@ -99,6 +106,7 @@ test('Toggle check', async () => {
         isCheckable={true}
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
+        onRowClick={mockOnClick}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
     const element = getByText(cell1Text);
     let {getByRole} = within(element);
@@ -146,6 +154,7 @@ describe('with children', () => {
             isCheckable={true}
             collapsedNodes={[]}
             onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
             .toJSON();
         expect(nodeWithChildren).toMatchSnapshot();
@@ -160,6 +169,7 @@ describe('with children', () => {
             isCheckable={true}
             collapsedNodes={[parentNode.id]}
             onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
             .toJSON();
         expect(nodeWithChildren).toMatchSnapshot();
@@ -175,6 +185,7 @@ describe('with children', () => {
             isCheckable={true}
             collapsedNodes={[]}
             onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
         const element = getByText(parentText);
         const collapsedEl = within(element).getAllByRole("img", {hidden: true})[0];
@@ -220,6 +231,7 @@ describe('Multiple labels', () => {
             isCheckable={true}
             collapsedNodes={[]}
             onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
             .toJSON();
         expect(nodeWithChildren).toMatchSnapshot();

--- a/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
@@ -4,8 +4,9 @@ import { TreeNode } from './tree-node';
 interface TableCellProps {
     node: TreeNode;
     index: number;
-    selectedRow?: number;
     children?: React.ReactNode | React.ReactNode[];
+    onRowClick: (id: number) => void;
+    selectedRow?: number;
 }
 
 export class TableCell extends React.Component<TableCellProps> {
@@ -13,13 +14,20 @@ export class TableCell extends React.Component<TableCellProps> {
         super(props);
     }
 
+    private onClick = () => {
+        const { node, onRowClick } = this.props;
+        if (onRowClick) {
+            onRowClick(node.id);
+        }
+    };
+
     render(): React.ReactNode {
         const { node, selectedRow, index } = this.props;
         const content = node.labels[index];
         const className = (selectedRow === node.id) ? 'selected' : '';
 
         return (
-            <td key={this.props.index+'-td-'+this.props.node.id} className={className}>
+            <td key={this.props.index+'-td-'+this.props.node.id} onClick={this.onClick} className={className}>
                 <span>
                     {this.props.children}
                     {content}

--- a/packages/react-components/src/components/utils/filter-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-row.tsx
@@ -15,6 +15,7 @@ interface TableRowProps {
     onToggleCollapse: (id: number) => void;
     onClose: (id: number) => void;
     onToggleCheck: (id: number) => void;
+    onRowClick: (id: number) => void;
 }
 
 export class TableRow extends React.Component<TableRowProps> {
@@ -60,12 +61,13 @@ export class TableRow extends React.Component<TableRowProps> {
             : undefined;
 
     renderRow = (): React.ReactNode => {
-        const { node, selectedRow } = this.props;
+        const { node, onRowClick, selectedRow } = this.props;
         const row = node.labels.map((_label: string, index) =>
             <TableCell
                 key={node.id + '-' + index}
                 index={index}
                 node={node}
+                onRowClick={onRowClick}
                 selectedRow={selectedRow}
             >
                 { (index === 0) ? this.renderToggleCollapse() : undefined }


### PR DESCRIPTION
There was a regression introduced by commits 05086c9 and 5396d83.

Fixes #774

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>