### PR TITLE
Sync Trace-Extension for Markers-Navigation Update

### DIFF
--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -55,11 +55,11 @@ exports[`Entry with children All unchecked 1`] = `
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               onClick={[Function]}
@@ -120,10 +120,7 @@ exports[`Entry with children All unchecked 1`] = `
             parent
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             parent second column
           </span>
@@ -132,11 +129,11 @@ exports[`Entry with children All unchecked 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -177,10 +174,7 @@ exports[`Entry with children All unchecked 1`] = `
             child1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             child1 second column
           </span>
@@ -189,11 +183,11 @@ exports[`Entry with children All unchecked 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               onClick={[Function]}
@@ -254,10 +248,7 @@ exports[`Entry with children All unchecked 1`] = `
             child2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             child2 second column
           </span>
@@ -266,11 +257,11 @@ exports[`Entry with children All unchecked 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -311,10 +302,7 @@ exports[`Entry with children All unchecked 1`] = `
             grandchild1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             grandchild1 second column
           </span>
@@ -323,11 +311,11 @@ exports[`Entry with children All unchecked 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -368,10 +356,7 @@ exports[`Entry with children All unchecked 1`] = `
             grandchild2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             grandchild2 second column
           </span>
@@ -438,11 +423,11 @@ exports[`Entry with children Check one grandchild 1`] = `
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               onClick={[Function]}
@@ -503,10 +488,7 @@ exports[`Entry with children Check one grandchild 1`] = `
             parent
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             parent second column
           </span>
@@ -515,11 +497,11 @@ exports[`Entry with children Check one grandchild 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -560,10 +542,7 @@ exports[`Entry with children Check one grandchild 1`] = `
             child1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             child1 second column
           </span>
@@ -572,11 +551,11 @@ exports[`Entry with children Check one grandchild 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               onClick={[Function]}
@@ -637,10 +616,7 @@ exports[`Entry with children Check one grandchild 1`] = `
             child2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             child2 second column
           </span>
@@ -649,11 +625,11 @@ exports[`Entry with children Check one grandchild 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -694,10 +670,7 @@ exports[`Entry with children Check one grandchild 1`] = `
             grandchild1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             grandchild1 second column
           </span>
@@ -706,11 +679,11 @@ exports[`Entry with children Check one grandchild 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -751,10 +724,7 @@ exports[`Entry with children Check one grandchild 1`] = `
             grandchild2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             grandchild2 second column
           </span>
@@ -821,11 +791,11 @@ exports[`Entry with children Collapse one child 1`] = `
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               onClick={[Function]}
@@ -886,10 +856,7 @@ exports[`Entry with children Collapse one child 1`] = `
             parent
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             parent second column
           </span>
@@ -898,11 +865,11 @@ exports[`Entry with children Collapse one child 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -943,10 +910,7 @@ exports[`Entry with children Collapse one child 1`] = `
             child1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             child1 second column
           </span>
@@ -955,11 +919,11 @@ exports[`Entry with children Collapse one child 1`] = `
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               onClick={[Function]}
@@ -1020,10 +984,7 @@ exports[`Entry with children Collapse one child 1`] = `
             child2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             child2 second column
           </span>
@@ -1110,11 +1071,11 @@ Array [
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+        <tr
+          className=""
+          onClick={[Function]}
+        >
+          <td>
             <span>
               <div
                 onClick={[Function]}
@@ -1175,10 +1136,7 @@ Array [
               parent
             </span>
           </td>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+          <td>
             <span>
               parent second column
             </span>
@@ -1187,11 +1145,11 @@ Array [
             className="filler"
           />
         </tr>
-        <tr>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+        <tr
+          className=""
+          onClick={[Function]}
+        >
+          <td>
             <span>
               <div
                 style={
@@ -1232,10 +1190,7 @@ Array [
               child1
             </span>
           </td>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+          <td>
             <span>
               child1 second column
             </span>
@@ -1244,11 +1199,11 @@ Array [
             className="filler"
           />
         </tr>
-        <tr>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+        <tr
+          className=""
+          onClick={[Function]}
+        >
+          <td>
             <span>
               <div
                 onClick={[Function]}
@@ -1309,10 +1264,7 @@ Array [
               child2
             </span>
           </td>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+          <td>
             <span>
               child2 second column
             </span>
@@ -1321,11 +1273,11 @@ Array [
             className="filler"
           />
         </tr>
-        <tr>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+        <tr
+          className=""
+          onClick={[Function]}
+        >
+          <td>
             <span>
               <div
                 style={
@@ -1366,10 +1318,7 @@ Array [
               grandchild1
             </span>
           </td>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+          <td>
             <span>
               grandchild1 second column
             </span>
@@ -1378,11 +1327,11 @@ Array [
             className="filler"
           />
         </tr>
-        <tr>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+        <tr
+          className=""
+          onClick={[Function]}
+        >
+          <td>
             <span>
               <div
                 style={
@@ -1423,10 +1372,7 @@ Array [
               grandchild2
             </span>
           </td>
-          <td
-            className=""
-            onClick={[Function]}
-          >
+          <td>
             <span>
               grandchild2 second column
             </span>
@@ -1494,11 +1440,11 @@ exports[`one level of entries 1`] = `
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -1512,21 +1458,18 @@ exports[`one level of entries 1`] = `
             entry1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span />
         </td>
         <td
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -1540,10 +1483,7 @@ exports[`one level of entries 1`] = `
             entry2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             entry2 column2
           </span>
@@ -1610,11 +1550,11 @@ exports[`one level of entries 2`] = `
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -1655,21 +1595,18 @@ exports[`one level of entries 2`] = `
             entry1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span />
         </td>
         <td
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -1710,10 +1647,7 @@ exports[`one level of entries 2`] = `
             entry2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             entry2 column2
           </span>
@@ -1738,11 +1672,11 @@ exports[`one level of entries 3`] = `
     }
   >
     <tbody>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -1783,21 +1717,18 @@ exports[`one level of entries 3`] = `
             entry1
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span />
         </td>
         <td
           className="filler"
         />
       </tr>
-      <tr>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+      <tr
+        className=""
+        onClick={[Function]}
+      >
+        <td>
           <span>
             <div
               style={
@@ -1838,10 +1769,7 @@ exports[`one level of entries 3`] = `
             entry2
           </span>
         </td>
-        <td
-          className=""
-          onClick={[Function]}
-        >
+        <td>
           <span>
             entry2 column2
           </span>

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/table-row.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/table-row.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checked status 1`] = `
-<tr>
-  <td
-    className=""
-    onClick={[Function]}
-  >
+<tr
+  className=""
+  onClick={[Function]}
+>
+  <td>
     <span>
       <div
         style={
@@ -53,11 +53,11 @@ exports[`Checked status 1`] = `
 `;
 
 exports[`Checked status 2`] = `
-<tr>
-  <td
-    className=""
-    onClick={[Function]}
-  >
+<tr
+  className=""
+  onClick={[Function]}
+>
+  <td>
     <span>
       <div
         style={
@@ -105,11 +105,11 @@ exports[`Checked status 2`] = `
 `;
 
 exports[`Checked status 3`] = `
-<tr>
-  <td
-    className=""
-    onClick={[Function]}
-  >
+<tr
+  className=""
+  onClick={[Function]}
+>
+  <td>
     <span>
       <div
         style={
@@ -157,11 +157,11 @@ exports[`Checked status 3`] = `
 `;
 
 exports[`Levels 1`] = `
-<tr>
-  <td
-    className=""
-    onClick={[Function]}
-  >
+<tr
+  className=""
+  onClick={[Function]}
+>
+  <td>
     <span>
       <div
         style={
@@ -209,11 +209,11 @@ exports[`Levels 1`] = `
 `;
 
 exports[`Levels 2`] = `
-<tr>
-  <td
-    className=""
-    onClick={[Function]}
-  >
+<tr
+  className=""
+  onClick={[Function]}
+>
+  <td>
     <span>
       <div
         style={
@@ -262,11 +262,11 @@ exports[`Levels 2`] = `
 
 exports[`Multiple labels With children and labels 1`] = `
 Array [
-  <tr>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+  <tr
+    className=""
+    onClick={[Function]}
+  >
+    <td>
       <span>
         <div
           onClick={[Function]}
@@ -327,10 +327,7 @@ Array [
         parent 1 text
       </span>
     </td>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+    <td>
       <span>
         parent 2 text
       </span>
@@ -339,11 +336,11 @@ Array [
       className="filler"
     />
   </tr>,
-  <tr>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+  <tr
+    className=""
+    onClick={[Function]}
+  >
+    <td>
       <span>
         <div
           style={
@@ -384,10 +381,7 @@ Array [
         child1
       </span>
     </td>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+    <td>
       <span>
         child 1 text
       </span>
@@ -396,11 +390,11 @@ Array [
       className="filler"
     />
   </tr>,
-  <tr>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+  <tr
+    className=""
+    onClick={[Function]}
+  >
+    <td>
       <span>
         <div
           style={
@@ -441,10 +435,7 @@ Array [
         child2
       </span>
     </td>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+    <td>
       <span>
         child 2 text
       </span>
@@ -457,11 +448,11 @@ Array [
 `;
 
 exports[`Uncheckable 1`] = `
-<tr>
-  <td
-    className=""
-    onClick={[Function]}
-  >
+<tr
+  className=""
+  onClick={[Function]}
+>
+  <td>
     <span>
       <div
         style={
@@ -483,11 +474,11 @@ exports[`Uncheckable 1`] = `
 
 exports[`with children With children 1`] = `
 Array [
-  <tr>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+  <tr
+    className=""
+    onClick={[Function]}
+  >
+    <td>
       <span>
         <div
           onClick={[Function]}
@@ -552,11 +543,11 @@ Array [
       className="filler"
     />
   </tr>,
-  <tr>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+  <tr
+    className=""
+    onClick={[Function]}
+  >
+    <td>
       <span>
         <div
           style={
@@ -601,11 +592,11 @@ Array [
       className="filler"
     />
   </tr>,
-  <tr>
-    <td
-      className=""
-      onClick={[Function]}
-    >
+  <tr
+    className=""
+    onClick={[Function]}
+  >
+    <td>
       <span>
         <div
           style={
@@ -654,11 +645,11 @@ Array [
 `;
 
 exports[`with children With children collapsed 1`] = `
-<tr>
-  <td
-    className=""
-    onClick={[Function]}
-  >
+<tr
+  className=""
+  onClick={[Function]}
+>
+  <td>
     <span>
       <div
         onClick={[Function]}

--- a/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
@@ -5,8 +5,6 @@ interface TableCellProps {
     node: TreeNode;
     index: number;
     children?: React.ReactNode | React.ReactNode[];
-    onRowClick: (id: number) => void;
-    selectedRow?: number;
 }
 
 export class TableCell extends React.Component<TableCellProps> {
@@ -14,20 +12,12 @@ export class TableCell extends React.Component<TableCellProps> {
         super(props);
     }
 
-    private onClick = () => {
-        const { node, onRowClick } = this.props;
-        if (onRowClick) {
-            onRowClick(node.id);
-        }
-    };
-
     render(): React.ReactNode {
-        const { node, selectedRow, index } = this.props;
+        const { node, index } = this.props;
         const content = node.labels[index];
-        const className = (selectedRow === node.id) ? 'selected' : '';
 
         return (
-            <td key={this.props.index+'-td-'+this.props.node.id} onClick={this.onClick} className={className}>
+            <td key={this.props.index+'-td-'+this.props.node.id}>
                 <span>
                     {this.props.children}
                     {content}

--- a/packages/react-components/src/components/utils/filter-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-row.tsx
@@ -61,14 +61,12 @@ export class TableRow extends React.Component<TableRowProps> {
             : undefined;
 
     renderRow = (): React.ReactNode => {
-        const { node, onRowClick, selectedRow } = this.props;
+        const { node } = this.props;
         const row = node.labels.map((_label: string, index) =>
             <TableCell
                 key={node.id + '-' + index}
                 index={index}
                 node={node}
-                onRowClick={onRowClick}
-                selectedRow={selectedRow}
             >
                 { (index === 0) ? this.renderToggleCollapse() : undefined }
                 { (index === 0) ? this.renderCheckbox() : undefined }
@@ -93,13 +91,25 @@ export class TableRow extends React.Component<TableRowProps> {
         return undefined;
     };
 
+    onClick = (): void => {
+        const { node, onRowClick } = this.props;
+        if (onRowClick) {
+            onRowClick(node.id);
+        }
+    };
+
     render(): React.ReactNode | undefined {
         if (!this.props.node) { return undefined; }
         const children = this.renderChildren();
+        const { node, selectedRow } = this.props;
+        const className = selectedRow === node.id ? 'selected' : '';
 
         return (
             <React.Fragment>
-                <tr>{this.renderRow()}</tr>
+                <tr
+                    className={className}
+                    onClick={this.onClick}
+                >{this.renderRow()}</tr>
                 {children}
             </React.Fragment>
         );

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -235,7 +235,7 @@ canvas {
     display: block;
 }
 
-.table-tree td.selected {
+.table-tree tr.selected td {
     background-color: var(--theia-selection-background) !important;
 }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
@@ -22,9 +22,15 @@ export class TimeGraphShortcutsTable extends React.Component {
                                 </td>
                             </tr>
                             <tr>
-                                <td>Zoom to state&apos;s range</td>
+                                <td>Next Marker</td>
                                 <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span>Double-click state</span>
+                                    <span className='monaco-keybinding-key'>.</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Previous Marker</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>,</span>
                                 </td>
                             </tr>
                         </tbody>
@@ -49,6 +55,12 @@ export class TimeGraphShortcutsTable extends React.Component {
                                 <td>Zoom to selected</td>
                                 <td className='monaco-keybinding shortcuts-table-keybinding'>
                                     <span className='monaco-keybinding-key'>Z</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Zoom to state&apos;s range</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span>Double-click state</span>
                                 </td>
                             </tr>
                         </tbody>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14231,9 +14231,9 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8,
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timeline-chart@next:
-  version "0.3.0-next.f029da1.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.f029da1.0.tgz#4978b695dbf0e02f3a3df0170ef641c0a6a63de4"
-  integrity sha512-E/cA7HSC8kbcdo5SuNY6hjmV8xQM89Rhq/SzQOr0Niw+4tYf69On/i7dAK+rRYrcDg3UNJCTQ2E7jS+ycMjR9Q==
+  version "0.3.0-next.82a0ac9.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.82a0ac9.0.tgz#4fd27cd71d0ee2aebced20ea3bc5b3e95247fbcb"
+  integrity sha512-YGHlz7wT904qqhGSYO+iX37YYVXZmHh931loKHBYEYEzkCAhZ2rkcR34ELj5y6U8Pxb1M7GDQZdWicKOxTSbGA==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"


### PR DESCRIPTION
Navigation of markers using new cursor class 

Implements functionality to navigate through markers using "," & ".".
Includes new "TimeGraphMarkersChartCursors" layer and uses it with the
chart layer in the Markers Container.

Depends on: eclipse-cdt-cloud/timeline-chart#239

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
Signed-Off-By: Will Yang <william.yang@ericsson.com>