### PR TITLE
Added support for time range columns in datatree-output-component

### DIFF
--- a/examples/browser/webpack.config.js
+++ b/examples/browser/webpack.config.js
@@ -1,0 +1,25 @@
+/**
+ * This file can be edited to customize webpack configuration.
+ * To reset delete this file and rerun theia build again.
+ */
+// @ts-check
+const config = require('./gen-webpack.config.js');
+const webpack = require("webpack");
+
+
+/**
+ * Expose bundled modules on window.theia.moduleName namespace, e.g.
+ * window['theia']['@theia/core/lib/common/uri'].
+ * Such syntax can be used by external code, for instance, for testing.
+config.module.rules.push({
+    test: /\.js$/,
+    loader: require.resolve('@theia/application-manager/lib/expose-loader')
+}); */
+
+config[0].plugins.push(new webpack.DefinePlugin({
+  'process.env': {
+    NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
+  }
+}));
+
+module.exports = config;

--- a/examples/electron/webpack.config.js
+++ b/examples/electron/webpack.config.js
@@ -1,0 +1,24 @@
+/**
+ * This file can be edited to customize webpack configuration.
+ * To reset delete this file and rerun theia build again.
+ */
+// @ts-check
+const config = require('./gen-webpack.config.js');
+const webpack = require("webpack");
+
+/**
+ * Expose bundled modules on window.theia.moduleName namespace, e.g.
+ * window['theia']['@theia/core/lib/common/uri'].
+ * Such syntax can be used by external code, for instance, for testing.
+config.module.rules.push({
+    test: /\.js$/,
+    loader: require.resolve('@theia/application-manager/lib/expose-loader')
+}); */
+
+config[0].plugins.push(new webpack.DefinePlugin({
+    'process.env': {
+      NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
+    }
+  }));
+
+module.exports = config;

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -23,6 +23,7 @@
     "d3": "^7.1.1",
     "lodash": "^4.17.15",
     "react-chartjs-2": "^2.7.6",
+    "react-contexify": "^5.0.0",
     "react-grid-layout": "1.2.0",
     "react-modal": "^3.8.1",
     "react-tooltip": "4.2.14",

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -132,6 +133,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -186,6 +188,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -260,6 +263,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -314,6 +318,7 @@ exports[`Entry with children All unchecked 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -426,6 +431,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -500,6 +506,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -554,6 +561,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -628,6 +636,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -682,6 +691,7 @@ exports[`Entry with children Check one grandchild 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -794,6 +804,7 @@ exports[`Entry with children Collapse one child 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -868,6 +879,7 @@ exports[`Entry with children Collapse one child 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -922,6 +934,7 @@ exports[`Entry with children Collapse one child 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -1074,6 +1087,7 @@ Array [
         <tr
           className=""
           onClick={[Function]}
+          onContextMenu={[Function]}
         >
           <td>
             <span>
@@ -1148,6 +1162,7 @@ Array [
         <tr
           className=""
           onClick={[Function]}
+          onContextMenu={[Function]}
         >
           <td>
             <span>
@@ -1202,6 +1217,7 @@ Array [
         <tr
           className=""
           onClick={[Function]}
+          onContextMenu={[Function]}
         >
           <td>
             <span>
@@ -1276,6 +1292,7 @@ Array [
         <tr
           className=""
           onClick={[Function]}
+          onContextMenu={[Function]}
         >
           <td>
             <span>
@@ -1330,6 +1347,7 @@ Array [
         <tr
           className=""
           onClick={[Function]}
+          onContextMenu={[Function]}
         >
           <td>
             <span>
@@ -1443,6 +1461,7 @@ exports[`one level of entries 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -1468,6 +1487,7 @@ exports[`one level of entries 1`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -1553,6 +1573,7 @@ exports[`one level of entries 2`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -1605,6 +1626,7 @@ exports[`one level of entries 2`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -1675,6 +1697,7 @@ exports[`one level of entries 3`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>
@@ -1727,6 +1750,7 @@ exports[`one level of entries 3`] = `
       <tr
         className=""
         onClick={[Function]}
+        onContextMenu={[Function]}
       >
         <td>
           <span>

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/table-row.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/table-row.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Checked status 1`] = `
 <tr
   className=""
   onClick={[Function]}
+  onContextMenu={[Function]}
 >
   <td>
     <span>
@@ -56,6 +57,7 @@ exports[`Checked status 2`] = `
 <tr
   className=""
   onClick={[Function]}
+  onContextMenu={[Function]}
 >
   <td>
     <span>
@@ -108,6 +110,7 @@ exports[`Checked status 3`] = `
 <tr
   className=""
   onClick={[Function]}
+  onContextMenu={[Function]}
 >
   <td>
     <span>
@@ -160,6 +163,7 @@ exports[`Levels 1`] = `
 <tr
   className=""
   onClick={[Function]}
+  onContextMenu={[Function]}
 >
   <td>
     <span>
@@ -212,6 +216,7 @@ exports[`Levels 2`] = `
 <tr
   className=""
   onClick={[Function]}
+  onContextMenu={[Function]}
 >
   <td>
     <span>
@@ -265,6 +270,7 @@ Array [
   <tr
     className=""
     onClick={[Function]}
+    onContextMenu={[Function]}
   >
     <td>
       <span>
@@ -339,6 +345,7 @@ Array [
   <tr
     className=""
     onClick={[Function]}
+    onContextMenu={[Function]}
   >
     <td>
       <span>
@@ -393,6 +400,7 @@ Array [
   <tr
     className=""
     onClick={[Function]}
+    onContextMenu={[Function]}
   >
     <td>
       <span>
@@ -451,6 +459,7 @@ exports[`Uncheckable 1`] = `
 <tr
   className=""
   onClick={[Function]}
+  onContextMenu={[Function]}
 >
   <td>
     <span>
@@ -477,6 +486,7 @@ Array [
   <tr
     className=""
     onClick={[Function]}
+    onContextMenu={[Function]}
   >
     <td>
       <span>
@@ -546,6 +556,7 @@ Array [
   <tr
     className=""
     onClick={[Function]}
+    onContextMenu={[Function]}
   >
     <td>
       <span>
@@ -595,6 +606,7 @@ Array [
   <tr
     className=""
     onClick={[Function]}
+    onContextMenu={[Function]}
   >
     <td>
       <span>
@@ -648,6 +660,7 @@ exports[`with children With children collapsed 1`] = `
 <tr
   className=""
   onClick={[Function]}
+  onContextMenu={[Function]}
 >
   <td>
     <span>

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/table-row.test.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/table-row.test.tsx
@@ -9,6 +9,7 @@ const mockOnChecked = jest.fn();
 const mockOnCollapse = jest.fn();
 const mockOnClose = jest.fn();
 const mockOnClick = jest.fn();
+const mockOnContext = jest.fn();
 
 const cell1Text = "cell1 - text";
 const testTreeNode = {
@@ -28,6 +29,7 @@ test('Checked status', () => {
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
         onRowClick={mockOnClick}
+        onContextMenu={mockOnContext}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(treeNodeUnchecked).toMatchSnapshot();
@@ -40,6 +42,7 @@ test('Checked status', () => {
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
         onRowClick={mockOnClick}
+        onContextMenu={mockOnContext}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(treeNodeChecked).toMatchSnapshot();
@@ -52,6 +55,7 @@ test('Checked status', () => {
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
         onRowClick={mockOnClick}
+        onContextMenu={mockOnContext}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(treeNodePartialCheck).toMatchSnapshot();
@@ -66,6 +70,7 @@ test('Uncheckable', () => {
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
         onRowClick={mockOnClick}
+        onContextMenu={mockOnContext}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(uncheckableTree).toMatchSnapshot();
@@ -80,6 +85,7 @@ test('Levels', () => {
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
         onRowClick={mockOnClick}
+        onContextMenu={mockOnContext}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(lessPadding).toMatchSnapshot();
@@ -92,6 +98,7 @@ test('Levels', () => {
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
         onRowClick={mockOnClick}
+        onContextMenu={mockOnContext}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
         .toJSON();
     expect(morePadding).toMatchSnapshot();
@@ -107,6 +114,7 @@ test('Toggle check', async () => {
         collapsedNodes={[]}
         onToggleCollapse={mockOnCollapse}
         onRowClick={mockOnClick}
+        onContextMenu={mockOnContext}
         onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
     const element = getByText(cell1Text);
     let {getByRole} = within(element);
@@ -155,6 +163,7 @@ describe('with children', () => {
             collapsedNodes={[]}
             onToggleCollapse={mockOnCollapse}
             onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
             .toJSON();
         expect(nodeWithChildren).toMatchSnapshot();
@@ -170,6 +179,7 @@ describe('with children', () => {
             collapsedNodes={[parentNode.id]}
             onToggleCollapse={mockOnCollapse}
             onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
             .toJSON();
         expect(nodeWithChildren).toMatchSnapshot();
@@ -186,6 +196,7 @@ describe('with children', () => {
             collapsedNodes={[]}
             onToggleCollapse={mockOnCollapse}
             onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
         const element = getByText(parentText);
         const collapsedEl = within(element).getAllByRole("img", {hidden: true})[0];
@@ -232,6 +243,7 @@ describe('Multiple labels', () => {
             collapsedNodes={[]}
             onToggleCollapse={mockOnCollapse}
             onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
             onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
             .toJSON();
         expect(nodeWithChildren).toMatchSnapshot();

--- a/packages/react-components/src/components/utils/filter-tree/column-header.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/column-header.tsx
@@ -1,6 +1,9 @@
+import { DataType } from 'tsp-typescript-client/lib/models/data-type';
+
 export default interface ColumnHeader {
     title: string,
     tooltip?: string,
     sortable?: boolean,
-    resizable?: boolean
+    resizable?: boolean,
+    dataType?: DataType
 }

--- a/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
@@ -15,6 +15,7 @@ interface EntryTreeProps {
     showFilter: boolean;
     onToggleCheck: (ids: number[]) => void;
     onRowClick: (id: number) => void;
+    onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
     onClose: (id: number) => void;
     onToggleCollapse: (id: number, nodes: TreeNode[]) => void;
     onOrderChange: (ids: number[]) => void;

--- a/packages/react-components/src/components/utils/filter-tree/table-body.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-body.tsx
@@ -13,6 +13,7 @@ interface TableBodyProps {
     onRowClick: (id: number) => void;
     onClose: (id: number) => void;
     onToggleCheck: (id: number) => void;
+    onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
 }
 
 export class TableBody extends React.Component<TableBodyProps> {

--- a/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
@@ -11,7 +11,6 @@ export class TableCell extends React.Component<TableCellProps> {
     constructor(props: TableCellProps) {
         super(props);
     }
-
     render(): React.ReactNode {
         const { node, index } = this.props;
         const content = node.labels[index];

--- a/packages/react-components/src/components/utils/filter-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-row.tsx
@@ -16,6 +16,7 @@ interface TableRowProps {
     onClose: (id: number) => void;
     onToggleCheck: (id: number) => void;
     onRowClick: (id: number) => void;
+    onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
 }
 
 export class TableRow extends React.Component<TableRowProps> {
@@ -61,7 +62,7 @@ export class TableRow extends React.Component<TableRowProps> {
             : undefined;
 
     renderRow = (): React.ReactNode => {
-        const { node } = this.props;
+        const { node} = this.props;
         const row = node.labels.map((_label: string, index) =>
             <TableCell
                 key={node.id + '-' + index}
@@ -98,6 +99,13 @@ export class TableRow extends React.Component<TableRowProps> {
         }
     };
 
+    onContextMenu = (event: React.MouseEvent<HTMLDivElement>): void => {
+        const { node, onContextMenu } = this.props;
+        if (onContextMenu) {
+            onContextMenu(event, node.id);
+        }
+    };
+
     render(): React.ReactNode | undefined {
         if (!this.props.node) { return undefined; }
         const children = this.renderChildren();
@@ -109,6 +117,7 @@ export class TableRow extends React.Component<TableRowProps> {
                 <tr
                     className={className}
                     onClick={this.onClick}
+                    onContextMenu={this.onContextMenu}
                 >{this.renderRow()}</tr>
                 {children}
             </React.Fragment>

--- a/packages/react-components/src/components/utils/filter-tree/table.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table.tsx
@@ -13,6 +13,7 @@ interface TableProps {
     isClosable: boolean;
     sortConfig: SortConfig[];
     onRowClick: (id: number) => void;
+    onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
     getCheckedStatus: (id: number) => number;
     onToggleCollapse: (id: number) => void;
     onToggleCheck: (id: number) => void;

--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -19,6 +19,7 @@ interface FilterTreeProps {
     onToggleCheck: (ids: number[]) => void;     // Optional
     onClose: (id: number) => void;
     onRowClick: (id: number) => void;
+    onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
     onToggleCollapse: (id: number, nodes: TreeNode[]) => void;
     onOrderChange: (ids: number[]) => void;
     showHeader: boolean;
@@ -264,6 +265,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             onToggleCollapse={this.handleCollapse}
             onToggleCheck={this.handleCheck}
             onRowClick={this.props.onRowClick}
+            onContextMenu={this.props.onContextMenu}
             onClose={this.handleClose}
             onSort={this.handleOrderChange}
             onSortConfigChange={this.handleSortConfigChange}

--- a/packages/react-components/style/react-contextify.css
+++ b/packages/react-components/style/react-contextify.css
@@ -1,0 +1,234 @@
+.react-contexify {
+    position: fixed;
+    opacity: 0;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    background-color: #ffffff;
+    box-sizing: border-box;
+    box-shadow: 0px 10px 30px -5px rgba(0, 0, 0, 0.3);
+    border-radius: 6px;
+    padding: 6px 0;
+    min-width: 200px;
+    z-index: 100;
+  }
+  .react-contexify__submenu--is-open, .react-contexify__submenu--is-open > .react-contexify__item__content {
+    color: var(--theia-menu-selectionForeground);
+    background-color: var(--theia-menu-selectionBackground);
+  }
+  .react-contexify__submenu--is-open > .react-contexify__submenu {
+    pointer-events: initial;
+    opacity: 1;
+  }
+  .react-contexify .react-contexify__submenu {
+    position: absolute;
+    /* negate padding */
+    top: -6px;
+    pointer-events: none;
+    transition: opacity 0.275s;
+  }
+  .react-contexify__submenu-arrow {
+    margin-left: auto;
+    font-size: 12px;
+  }
+  .react-contexify__separator {
+    width: 100%;
+    height: 1px;
+    cursor: default;
+    margin: 4px 0;
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+  .react-contexify__will-leave--disabled {
+    pointer-events: none;
+  }
+  .react-contexify__item {
+    cursor: pointer;
+    position: relative;
+  }
+  .react-contexify__item:focus {
+    outline: 0;
+  }
+  .react-contexify__item:not(.react-contexify__item--disabled):hover > .react-contexify__item__content, .react-contexify__item:not(.react-contexify__item--disabled):focus > .react-contexify__item__content {
+    color: var(--theia-menu-selectionForeground);
+    background-color: var(--theia-menu-selectionBackground);
+  }
+  .react-contexify__item:not(.react-contexify__item--disabled):hover > .react-contexify__submenu {
+    pointer-events: initial;
+    opacity: 1;
+  }
+  .react-contexify__item--disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+  .react-contexify__item__content {
+    padding: 6px 12px;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-align: center;
+        align-items: center;
+    white-space: nowrap;
+    color: var(--theia-menu-foreground);
+    position: relative;
+  }
+  
+  .react-contexify__theme--dark {
+    background-color: var(--theia-menu-background);
+  }
+  .react-contexify__theme--dark .react-contexify__submenu {
+    background-color: var(--theia-menu-background);
+  }
+  .react-contexify__theme--dark .react-contexify__separator {
+    background-color: var(--theia-menu-background);
+  }
+  .react-contexify__theme--dark .react-contexify__item__content {
+    color: var(--theia-menu-foreground);
+  }
+  
+  .react-contexify__theme--light {
+    background-color: var(--theia-menu-background);
+  }
+  .react-contexify__theme--light .react-contexify__separator {
+    background-color: var(--theia-menu-foreground);
+  }
+  .react-contexify__theme--light .react-contexify__submenu--is-open,
+  .react-contexify__theme--light .react-contexify__submenu--is-open > .react-contexify__item__content {
+    color: var(--theia-menu-foreground);
+    background-color: var(--theia-menu-background);;
+  }
+  .react-contexify__theme--light .react-contexify__item:not(.react-contexify__item--disabled):hover > .react-contexify__item__content, .react-contexify__theme--light .react-contexify__item:not(.react-contexify__item--disabled):focus > .react-contexify__item__content {
+    color: var(--theia-menu-selectionForeground);
+    background-color: var(--theia-menu-selectionBackground);
+  }
+  .react-contexify__theme--light .react-contexify__item__content {
+    color: var(--theia-menu-foreground);
+  }
+  
+  @keyframes react-contexify__scaleIn {
+    from {
+      opacity: 0;
+      transform: scale3d(0.3, 0.3, 0.3);
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes react-contexify__scaleOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+      transform: scale3d(0.3, 0.3, 0.3);
+    }
+  }
+  .react-contexify__will-enter--scale {
+    transform-origin: top left;
+    animation: react-contexify__scaleIn 0.3s;
+  }
+  
+  .react-contexify__will-leave--scale {
+    transform-origin: top left;
+    animation: react-contexify__scaleOut 0.3s;
+  }
+  
+  @keyframes react-contexify__fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @keyframes react-contexify__fadeOut {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+  }
+  .react-contexify__will-enter--fade {
+    animation: react-contexify__fadeIn 0.3s ease;
+  }
+  
+  .react-contexify__will-leave--fade {
+    animation: react-contexify__fadeOut 0.3s ease;
+  }
+  
+  @keyframes react-contexify__flipInX {
+    from {
+      transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
+    }
+    to {
+      transform: perspective(800px);
+    }
+  }
+  @keyframes react-contexify__flipOutX {
+    from {
+      transform: perspective(800px);
+    }
+    to {
+      transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
+      opacity: 0;
+    }
+  }
+  .react-contexify__will-enter--flip {
+    -webkit-backface-visibility: visible !important;
+            backface-visibility: visible !important;
+    transform-origin: top center;
+    animation: react-contexify__flipInX 0.3s;
+  }
+  
+  .react-contexify__will-leave--flip {
+    transform-origin: top center;
+    animation: react-contexify__flipOutX 0.3s;
+    -webkit-backface-visibility: visible !important;
+            backface-visibility: visible !important;
+  }
+  
+  @keyframes swing-in-top-fwd {
+    0% {
+      transform: rotateX(-100deg);
+      transform-origin: top;
+      opacity: 0;
+    }
+    100% {
+      transform: rotateX(0deg);
+      transform-origin: top;
+      opacity: 1;
+    }
+  }
+  @keyframes react-contexify__slideIn {
+    from {
+      opacity: 0;
+      transform: scale3d(1, 0.3, 1);
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes react-contexify__slideOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+      transform: scale3d(1, 0.3, 1);
+    }
+  }
+  .react-contexify__will-enter--slide {
+    transform-origin: top center;
+    animation: react-contexify__slideIn 0.3s;
+  }
+  
+  .react-contexify__will-leave--slide {
+    transform-origin: top center;
+    animation: react-contexify__slideOut 0.3s;
+  }
+  
+  /*# sourceMappingURL=ReactContexify.css.map */

--- a/yarn.lock
+++ b/yarn.lock
@@ -12560,6 +12560,13 @@ react-chartjs-2@^2.7.6:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
+react-contexify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-contexify/-/react-contexify-5.0.0.tgz#11b477550a0ee5a9a144399bc17c7c56bbc60057"
+  integrity sha512-2FIp7lxJ6dtfGr8EZ4uVV5p5TQjd0n2h/JU7PrejNIMiCeZWvSVPFh4lj1ZvjXosglBvP7q5JQQ8yUCdSaMSaw==
+  dependencies:
+    clsx "^1.1.1"
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -14343,9 +14350,9 @@ tslib@^2.2.0, tslib@^2.3.1:
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsp-typescript-client@next:
-  version "0.4.0-next.9b23dfe.0"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.9b23dfe.0.tgz#5ba0d1486daf12c4ffff0085e9f47cd37c2acbfa"
-  integrity sha512-hDEy7n/8sEyqPAAEajyIVek5FSmiMk/FoFceypVScSSi6cC2swf3SD83aM2FWp6zWK3DVpgK3XvzgrMAgNuD8A==
+  version "0.4.0-next.143a5ab.0"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.143a5ab.0.tgz#b7258f168cab720b3892dedc54a8794de3d6867f"
+  integrity sha512-vyJATe8mvY3mbBSCr9THPEh2+wTqbwb1MdAxJO6tanZagOt+zqMuNh+k9ZOKCyaWBqndkUOLX6W6hF8cbH5NaQ==
   dependencies:
     json-bigint sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473
     node-fetch "^2.5.0"


### PR DESCRIPTION
Columns of data type TIME_RANGE provide time ranges in the trace that can be selected and navigated to.

If data provider provides columns of TIME_RANGE then it creates a context-sensitive menu item to select that time range in the trace viewer.

Trace Compass patches to test:
- https://git.eclipse.org/r/c/tracecompass/org.eclipse.tracecompass/+/199993/3
- https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/199989/2

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>