### PR TITLE
tests: Re-enable previously skipped TooltipComponent unit tests

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -26,7 +26,7 @@
     "react-contexify": "^5.0.0",
     "react-grid-layout": "1.2.0",
     "react-modal": "^3.8.1",
-    "react-tooltip": "4.2.14",
+    "react-tooltip": "4.2.17",
     "react-virtualized": "^9.21.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.86.0",

--- a/packages/react-components/src/components/__tests__/tooltip-component.test.tsx
+++ b/packages/react-components/src/components/__tests__/tooltip-component.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { cleanup } from '@testing-library/react';
-import { mount } from 'enzyme';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { TooltipComponent } from '../tooltip-component';
 
 afterEach(cleanup);
@@ -14,11 +13,11 @@ const tooltip = new TooltipComponent(10);
 tooltip.setState = jest.fn();
 
 describe('Tooltip component', () => {
-  // Skip until a replacement for Enzyme that works with React 18 is found
-  it.skip('renders itself', () => {
-    const wrapper = mount(<TooltipComponent />);
-
-    expect(wrapper.contains(<TooltipComponent />)).toBe(true);
+  it('renders itself', () => {
+    let tooltipComponent: React.RefObject<TooltipComponent>;
+    tooltipComponent = React.createRef();
+    const { getByTestId } = render(<TooltipComponent ref={tooltipComponent} />);
+    expect(getByTestId('tooltip-component')).toBeDefined();
   });
 
   it('displays a tooltip for a time graph state component', () => {
@@ -56,16 +55,15 @@ describe('Tooltip component', () => {
   })
 
   // Skip until a replacement for Enzyme that works with React 18 is found
-  it.skip('resets timer on mouse enter', () => {
+  it('resets timer on mouse enter', () => {
     tooltip.state = {
       element: model,
       func: undefined,
       content: 'Test'
     }
-    const wrapper = mount(<TooltipComponent />);
-    wrapper.simulate('mouseenter');
-    wrapper.simulate('mouseleave');
-    
+    const { getByTestId } = render(<TooltipComponent />);
+    fireEvent.mouseEnter(getByTestId('tooltip-component'));
+    fireEvent.mouseLeave(getByTestId('tooltip-component'));
     expect(tooltip.setState).toBeCalledWith({ content: undefined });
   })
 })

--- a/packages/react-components/src/components/tooltip-component.tsx
+++ b/packages/react-components/src/components/tooltip-component.tsx
@@ -26,7 +26,7 @@ export class TooltipComponent extends React.Component<unknown, TooltipComponentS
     }
 
     render(): React.ReactNode {
-        return <div
+        return <div data-testid="tooltip-component"
             onMouseEnter={() => {
                 if (this.timerId) {
                     clearTimeout(this.timerId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12667,10 +12667,10 @@ react-test-renderer@^18.2.0:
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
 
-react-tooltip@4.2.14:
-  version "4.2.14"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.14.tgz#8e06b5926fdf6672e78d8ccadaa16bef40d131d7"
-  integrity sha512-hS2kAlpjyH5MXL9DaGKsdmEFCIEuMD2RZXkEJeNjmDe05dHpqj93o5JgpmczAgQFk099+JSsnHUDo7pIOuyMDQ==
+react-tooltip@4.2.17:
+  version "4.2.17"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.17.tgz#4884ce253ab298ee395950b24b752282efa8ac5d"
+  integrity sha512-LzwUbQYzeRyrjbuuCbYUB0dlJpFPGPwigWS052umr1QulcF5N4czabDiWJ+Y585Q7ijvMFuBbeOvnI/azoTusw==
   dependencies:
     prop-types "^15.7.2"
     uuid "^7.0.3"


### PR DESCRIPTION
Re-enable previously skipped TooltipComponent unit tests

**Problem with this update preventing merge:**
This requires a fix for [issue](https://github.com/ReactTooltip/react-tooltip/issues/681) which is available with react-tooltip version 4.2.17.. However, the behaviour of the tooltip changes when runnning in the theia-trace-extension (tooltip position follows mouse pointer) and it contains a problem, that the afterShow() method is not being called anymore after moving mouse quickly into tooltip window. I tried also upgrading the the latest 4.x version, but the issues are the same.

react-tooltip v4.x is not developed further and v5.x is available. However, v5.x changes the API and implementation heavily. A quick try to migrate was not successful due to the need data-tooltip-id (or anchors) in the element that the tooltip is for. I'm not sure if we can adapt it to make it work with our application.

We could also look into alternatives, e.g. other libraries or implementing the tooltip differently similar to the xy tooltip (tooltip-xy-component.tsx).

Both alternatives require a re-implementation of the tooltip and then we need to update the tooltip tests for that. 

**Note this PR is for documentation purposes**