### PR TITLE
Add docker to maintained CONTRIBUTING.md examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,7 @@ more may be necessary depending on the case. Here is an example used to uplift f
    * Some bumps may then be required also in the extension; consider applying them.
 1. Uplift the version of each `@theia/` dependency in these `package.json` files, from `1.34.1` to `1.34.2` (replacing the former with the latter):
    * `./examples/browser/package.json`
+   * `./examples/docker/example-package.json`
    * `./examples/electron/package.json`
    * `./package.json`
    * `./theia-extensions/viewer-prototype/package.json`


### PR DESCRIPTION
Add the `docker` example, recently added, to the list of maintained theia versions in `CONTRIBUTING.md`.

The related PR simply forgot to amend this specific part, that is also recent.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>