### PR TITLE
releng: Include date in version string for next versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "lerna run lint",
     "test": "lerna run test --",
     "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
-    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
+    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
   },
   "keywords": [
     "theia-extension",


### PR DESCRIPTION
This is to make sure -next versions sort properly so 'yarn upgrade' upgrades to valid newer versions.

fixes #842

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>