### PR TITLE
Add Prettier to script to help enforce code style

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build-and-test:
     runs-on: ${{ matrix.os }}
 
@@ -17,49 +16,51 @@ jobs:
         node-version: [16.x]
 
     steps:
-    - name: install dependencies on ubuntu
-      if: startsWith(matrix.os,'ubuntu')
-      run: |
-        sudo apt install -y make gcc pkg-config build-essential libx11-dev libxkbfile-dev
+      - name: install dependencies on ubuntu
+        if: startsWith(matrix.os,'ubuntu')
+        run: |
+          sudo apt install -y make gcc pkg-config build-essential libx11-dev libxkbfile-dev
 
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - name: Cache node_modules with yarn
-      uses: actions/cache@v2
-      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+      - name: Cache node_modules with yarn
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-    - run: yarn --frozen-lockfile
+      - run: yarn --frozen-lockfile
 
-    - run: yarn test
-      env:
-        CI: true
+      - run: yarn test
+        env:
+          CI: true
 
   code-lint:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check out Git repository
-      uses: actions/checkout@v2
+      - name: Check out Git repository
+        uses: actions/checkout@v2
 
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '16'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
 
-    # ESLint and Prettier must be in `package.json`
-    - run: yarn --frozen-lockfile --ignore-scripts
+      # ESLint and Prettier must be in `package.json`
+      - run: yarn --frozen-lockfile --ignore-scripts
 
-    - run: yarn lint
+      - run: yarn lint
+
+      - run: yarn format

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "endOfLine": "lf",
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "es5"
+  }

--- a/configs/base.eslintrc.json
+++ b/configs/base.eslintrc.json
@@ -7,19 +7,13 @@
       "jsx": true
     }
   },
-  "plugins": [
-    "@typescript-eslint",
-    "import",
-    "no-null"
-  ],
+  "plugins": ["@typescript-eslint", "prettier", "import", "no-null"],
+  "extends": ["prettier"],
   "env": {
     "browser": true,
     "node": true
   },
-  "ignorePatterns": [
-    "node_modules",
-    "*.d.ts"
-  ],
+  "ignorePatterns": ["node_modules", "*.d.ts"],
   "rules": {
     "@typescript-eslint/no-namespace": "off"
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "@theia/cli": "1.34.2",
     "jsonc-parser": "^3.0.0",
     "lerna": "^4.0.0",
-    "typescript": "4.5.5"
+    "typescript": "4.5.5",
+    "prettier": "^2.1.5"
   },
   "workspaces": [
     "examples/*",


### PR DESCRIPTION
Fix the issue https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/861 regarding code style by applying the below changes:

[1] A .prettierrc file was added with the rules for Prettier
[2] Package.json and base.eslintrc.json were revised to include Prettier
[3] In build.yml file, an instruction to run Prettier was incorporated to the build workflow

Signed-off-by: Estelle Foisy [estelle.foisy@ericsson.com](mailto:estelle.foisy@ericsson.com)