### PR TITLE
Add Prettier to script to help enforce code style

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,5 @@ jobs:
     - run: yarn --frozen-lockfile --ignore-scripts
 
     - run: yarn lint
+
+      - run: yarn format

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "endOfLine": "lf",
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/configs/base.eslintrc.json
+++ b/configs/base.eslintrc.json
@@ -9,8 +9,12 @@
   },
   "plugins": [
     "@typescript-eslint",
+    "prettier",
     "import",
     "no-null"
+  ],
+  "extends": [
+    "prettier"
   ],
   "env": {
     "browser": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "lerna run lint",
     "test": "lerna run test --",
     "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
-    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
+    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes",
+    "format": "prettier --write */**/*.{ts,tsx}"
   },
   "keywords": [
     "theia-extension",


### PR DESCRIPTION
Fix the issue #861 regarding code style by applying the below changes: 

[1] A .prettierrc file was added with the rules for Prettier
[2] Package.json and base.eslintrc.json were revised to include Prettier
[3] In build.yml file, an instruction to run Prettier was incorporated to the build workflow

Signed-off-by: Estelle Foisy [estelle.foisy@ericsson.com](mailto:estelle.foisy@ericsson.com)
