### PR TITLE
Upgrade to timeline-chart 0.3.0-next.20230419183309.9e0527f.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13810,9 +13810,9 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8,
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timeline-chart@next:
-  version "0.3.0-next.82a0ac9.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.82a0ac9.0.tgz#4fd27cd71d0ee2aebced20ea3bc5b3e95247fbcb"
-  integrity sha512-YGHlz7wT904qqhGSYO+iX37YYVXZmHh931loKHBYEYEzkCAhZ2rkcR34ELj5y6U8Pxb1M7GDQZdWicKOxTSbGA==
+  version "0.3.0-next.20230419183309.9e0527f.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.20230419183309.9e0527f.0.tgz#fcd6fe2b75d62c13a6f3d90c16ce250659e05383"
+  integrity sha512-vAjzxcubaLYeN3TXl9MQH3SYdFj2qedVPcOK/nnUE5iqE7oe8T9fcu3fSbV0E3g9hTh/VNo1gGk0KmKbMVMPFQ==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"


### PR DESCRIPTION
This includes performance improvement for state labels: https://github.com/eclipse-cdt-cloud/timeline-chart/pull/242

Bernd Hufmann <bernd.hufmann@ericsson.com>