### PR TITLE
Add Prettier to script to help enforce code style

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,5 @@ jobs:
     - run: yarn --frozen-lockfile --ignore-scripts
 
     - run: yarn lint
+
+      - run: yarn format

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "endOfLine": "lf",
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/configs/base.eslintrc.json
+++ b/configs/base.eslintrc.json
@@ -9,8 +9,12 @@
   },
   "plugins": [
     "@typescript-eslint",
+    "prettier",
     "import",
     "no-null"
+  ],
+  "extends": [
+    "prettier"
   ],
   "env": {
     "browser": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "lerna run lint",
     "test": "lerna run test --",
     "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
-    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
+    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes",
+    "format": "prettier --write */**/*.{ts,tsx}"
   },
   "keywords": [
     "theia-extension",
@@ -48,6 +49,7 @@
     "@theia/cli": "1.34.2",
     "jsonc-parser": "^3.0.0",
     "lerna": "^4.0.0",
+    "prettier": "2.8.8",
     "typescript": "4.5.5"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11941,6 +11941,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 pretty-format@^27.0.2:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"


### PR DESCRIPTION
This commit adds Prettier to the trace extension. Prettier allows the extension to define rules for code style and formatting. This helps keep the format of the code consistent and allow quick formatting of new code.

Fix #861.