### PR TITLE
Update parameter for onViewRangeChanged handler

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -208,8 +208,8 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         this.unitController.onSelectionRangeChange(range => {
             this.handleTimeSelectionChange(range);
         });
-        this.unitController.onViewRangeChanged(viewRangeParam => {
-            this.handleViewRangeChange(viewRangeParam);
+        this.unitController.onViewRangeChanged((oldRange, newRange) => {
+            this.handleViewRangeChange(oldRange, newRange);
         });
         this.tooltipComponent = React.createRef();
         this.tooltipXYComponent = React.createRef();
@@ -442,8 +442,8 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         }
     }
 
-    private handleViewRangeChange(viewRange: TimelineChart.TimeGraphRange) {
-        const { start, end } = viewRange;
+    private handleViewRangeChange(oldRange: TimelineChart.TimeGraphRange, newRange: TimelineChart.TimeGraphRange) {
+        const { start, end } = newRange;
         const payload = {
             experimentUUID: this.props.experiment.UUID,
             timeRange: new TimeRange(start, end)
@@ -452,7 +452,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
 
         this.setState(
             prevState => ({
-                currentViewRange: new TimeRange(viewRange.start, viewRange.end, prevState.timeOffset)
+                currentViewRange: new TimeRange(newRange.start, newRange.end, prevState.timeOffset)
             }),
             () => this.updateHistory()
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13815,9 +13815,9 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8,
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timeline-chart@next:
-  version "0.3.0-next.20230419183309.9e0527f.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.20230419183309.9e0527f.0.tgz#fcd6fe2b75d62c13a6f3d90c16ce250659e05383"
-  integrity sha512-vAjzxcubaLYeN3TXl9MQH3SYdFj2qedVPcOK/nnUE5iqE7oe8T9fcu3fSbV0E3g9hTh/VNo1gGk0KmKbMVMPFQ==
+  version "0.3.0-next.20230524200734.08fb2e6.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.20230524200734.08fb2e6.0.tgz#ecb27b8f3f4a1cf3a07bcbc15456fc3ce7f311f1"
+  integrity sha512-uHfr0Z+K34gzXov0N8POhKY5ujftTY1yQDvlLb5QPkG4aJgKb/Vz9ql9CGO9EkjSoGt1mB8dwA3Y3gQxZTqS1w==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"


### PR DESCRIPTION
The [performance improvement patch for the timeline chart](https://github.com/eclipse-cdt-cloud/timeline-chart/pull/246) changes the parameters provided to handlers of the onViewRangeChanged event on the unit controller. This commit updates the Theia Trace Extension to ensure that it works with the performance improvement patch.

This PR is to be merged after the performance improvement patch.
