### PR TITLE
Set up Prettier to enforce code style

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Run code through Prettier
+f194f10b3b3ed4b0cdd2bf28786a9c6f28248c94

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,4 @@ jobs:
     - run: yarn --frozen-lockfile --ignore-scripts
 
     - run: yarn lint
+    - run: yarn format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Ignore artifacts:
+build
+coverage

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+    "tabWidth": 4,
+    "arrowParens": "avoid",
+    "singleQuote": true,
+    "trailingComma": "none",
+    "printWidth": 120
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,16 @@ more may be necessary depending on the case. Here is an example used to uplift f
 1. Align `node-version` in `.github/workflows` yaml files with Theia's.
    * Referring also to Theia's `"node"` and `@types/node` versions in its root `package.json` file.
 
+## Formatting code with Prettier
+
+If a commit fails to pass CI checks because of its format, contributors can use Prettier, which is already conveniently set up in the project,
+to quickly format their commit.
+
+* To format a single file, simply run `yarn prettier --write <path-to-file>`.
+* To run Prettier on all source code files, run `yarn format:write`. Prettier will only format files that are not formatted correctly.
+* To check if new changes comply with Prettier rules, run `yarn prettier --check <path-to-file>` or `yarn format:check` to perform the check on a single file
+  or all source code file, respectively.
+
 ## Ignoring linting/formatting commits
 
 Should one be needing to use `git blame` to view the changes that were made recently to a file, it might be necessary to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,15 @@ more may be necessary depending on the case. Here is an example used to uplift f
 1. Align `node-version` in `.github/workflows` yaml files with Theia's.
    * Referring also to Theia's `"node"` and `@types/node` versions in its root `package.json` file.
 
+## Ignoring linting/formatting commits
+
+Should one be needing to use `git blame` to view the changes that were made recently to a file, it might be necessary to
+ignore the changes that were made in linting/formatting commits. In the root of the repo, there is a `.git-blame-ignore-revs`
+file. Adding the SHA-1 of a commit to this file will make `git-blame` ignore that commit. To use this file:
+
+* For GitHub, this file is automatically detected and will ignore all the commits that are included in the file.
+* With Git CLI, run `git blame --ignore-revs-file=.git-blame-ignore-revs <pathToSomeFile>` to ignore the commits.
+
 ## Contact
 
 For issues related to the Trace Viewer, please open a GitHub tracker for the [Theia Trace Extension][trace-viewer].

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "lint": "lerna run lint",
     "test": "lerna run test --",
     "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
-    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
+    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes",
+    "format:write": "lerna run format:write",
+    "format:check": "lerna run format:check"
   },
   "keywords": [
     "theia-extension",
@@ -48,6 +50,7 @@
     "@theia/cli": "1.34.2",
     "jsonc-parser": "^3.0.0",
     "lerna": "^4.0.0",
+    "prettier": "2.8.8",
     "typescript": "4.5.5"
   },
   "workspaces": [

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -33,7 +33,9 @@
     "clean": "rimraf lib *.tsbuildinfo",
     "lint": "eslint .",
     "test": "echo 'test'",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "format:write": "prettier --write ./src",
+    "format:check": "prettier --check ./src"
   },
   "gitHead": "4f93878b0ef9d58254a1f41daf99d03b4608df13"
 }

--- a/packages/base/src/experiment-manager.ts
+++ b/packages/base/src/experiment-manager.ts
@@ -8,18 +8,16 @@ import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client
 import { signalManager, Signals } from './signals/signal-manager';
 
 export class ExperimentManager {
-
     private fOpenExperiments: Map<string, Experiment> = new Map();
     private fTspClient: TspClient;
     private fTraceManager: TraceManager;
 
-    constructor(
-        tspClient: TspClient,
-        traceManager: TraceManager
-    ) {
+    constructor(tspClient: TspClient, traceManager: TraceManager) {
         this.fTspClient = tspClient;
         this.fTraceManager = traceManager;
-        signalManager().on(Signals.EXPERIMENT_DELETED, (experiment: Experiment) => this.onExperimentDeleted(experiment));
+        signalManager().on(Signals.EXPERIMENT_DELETED, (experiment: Experiment) =>
+            this.onExperimentDeleted(experiment)
+        );
     }
 
     /**
@@ -82,10 +80,12 @@ export class ExperimentManager {
         }
 
         const tryCreate = async function (tspClient: TspClient, retry: number): Promise<TspClientResponse<Experiment>> {
-            return tspClient.createExperiment(new Query({
-                'name': retry === 0 ? name : name + '(' + retry + ')',
-                'traces': traceURIs
-            }));
+            return tspClient.createExperiment(
+                new Query({
+                    name: retry === 0 ? name : name + '(' + retry + ')',
+                    traces: traceURIs
+                })
+            );
         };
         let tryNb = 0;
         let experimentResponse: TspClientResponse<Experiment> | undefined;

--- a/packages/base/src/lazy-tsp-client.ts
+++ b/packages/base/src/lazy-tsp-client.ts
@@ -8,9 +8,9 @@ import { TspClient } from 'tsp-typescript-client';
  * Only keep methods, discard properties.
  */
 export type LazyTspClient = {
-    [K in keyof TspClient]: TspClient[K] extends (...args: infer A) => (infer R | Promise<infer R>)
+    [K in keyof TspClient]: TspClient[K] extends (...args: infer A) => infer R | Promise<infer R>
         ? (...args: A) => Promise<R>
-        : never // Discard property.
+        : never; // Discard property.
 };
 
 export type LazyTspClientFactory = typeof LazyTspClientFactory;
@@ -25,7 +25,7 @@ export function LazyTspClientFactory(url: Promise<string>): TspClient {
             let method = target[property];
             if (!method) {
                 target[property] = method = async (...args: any[]) => {
-                    const tspClient = await tspClientPromise as any;
+                    const tspClient = (await tspClientPromise) as any;
                     return tspClient[property](...args);
                 };
             }

--- a/packages/base/src/message-manager.ts
+++ b/packages/base/src/message-manager.ts
@@ -1,7 +1,7 @@
 export enum MessageCategory {
     TRACE_CONTEXT,
     SERVER_MESSAGE,
-    SERVER_STATUS,
+    SERVER_STATUS
 }
 
 export enum MessageSeverity {
@@ -18,22 +18,19 @@ export interface StatusMessage {
 }
 
 export declare interface MessageManager {
-
     addStatusMessage(messageKey: string, message: StatusMessage): void;
     removeStatusMessage(messageKey: string): void;
-
 }
 
 export class MessageManager implements MessageManager {
-
-    addStatusMessage(messageKey: string, {text,
-        category = MessageCategory.SERVER_MESSAGE,
-        severity = MessageSeverity.INFO }: StatusMessage): void {
+    addStatusMessage(
+        messageKey: string,
+        { text, category = MessageCategory.SERVER_MESSAGE, severity = MessageSeverity.INFO }: StatusMessage
+    ): void {
         console.log('New status message', messageKey, text, category, severity);
     }
 
     removeStatusMessage(messageKey: string): void {
         console.log('Removing status message status message', messageKey);
     }
-
 }

--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -26,7 +26,7 @@ export declare interface SignalManager {
     fireResetZoomSignal(): void;
     fireMarkerCategoriesFetchedSignal(): void;
     fireMarkerSetsFetchedSignal(): void;
-    fireMarkerCategoryClosedSignal(payload: { traceViewerId: string, markerCategory: string }): void;
+    fireMarkerCategoryClosedSignal(payload: { traceViewerId: string; markerCategory: string }): void;
     fireTraceServerStartedSignal(): void;
     fireUndoSignal(): void;
     fireRedoSignal(): void;
@@ -35,8 +35,8 @@ export declare interface SignalManager {
     firePinView(output: OutputDescriptor, payload?: any): void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fireUnPinView(output: OutputDescriptor, payload?: any): void;
-    fireOverviewOutputSelectedSignal(payload: { traceId: string, outputDescriptor: OutputDescriptor}): void;
-    fireSaveAsCsv(payload: {traceId: string, data: string}): void;
+    fireOverviewOutputSelectedSignal(payload: { traceId: string; outputDescriptor: OutputDescriptor }): void;
+    fireSaveAsCsv(payload: { traceId: string; data: string }): void;
     fireSelectionRangeUpdated(payload: TimeRangeUpdatePayload): void;
     fireViewRangeUpdated(payload: TimeRangeUpdatePayload): void;
     fireRequestSelectionRangeChange(payload: TimeRangeUpdatePayload): void;
@@ -73,7 +73,7 @@ export const Signals = {
     SAVE_AS_CSV: 'save as csv',
     VIEW_RANGE_UPDATED: 'view range updated',
     SELECTION_RANGE_UPDATED: 'selection range updated',
-    REQUEST_SELECTION_RANGE_CHANGE: 'change selection range',
+    REQUEST_SELECTION_RANGE_CHANGE: 'change selection range'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -104,13 +104,13 @@ export class SignalManager extends EventEmitter implements SignalManager {
     fireOutputAddedSignal(payload: OutputAddedSignalPayload): void {
         this.emit(Signals.OUTPUT_ADDED, payload);
     }
-    fireItemPropertiesSignalUpdated(properties?: { [key: string]: string; }): void {
+    fireItemPropertiesSignalUpdated(properties?: { [key: string]: string }): void {
         this.emit(Signals.ITEM_PROPERTIES_UPDATED, properties);
     }
     fireThemeChangedSignal(theme: string): void {
         this.emit(Signals.THEME_CHANGED, theme);
     }
-    fireSelectionChangedSignal(payload: { [key: string]: string; }): void {
+    fireSelectionChangedSignal(payload: { [key: string]: string }): void {
         this.emit(Signals.SELECTION_CHANGED, payload);
     }
     fireCloseTraceViewerTabSignal(traceUUID: string): void {
@@ -131,7 +131,7 @@ export class SignalManager extends EventEmitter implements SignalManager {
     fireMarkerSetsFetchedSignal(): void {
         this.emit(Signals.MARKERSETS_FETCHED);
     }
-    fireMarkerCategoryClosedSignal(payload: { traceViewerId: string, markerCategory: string }): void {
+    fireMarkerCategoryClosedSignal(payload: { traceViewerId: string; markerCategory: string }): void {
         this.emit(Signals.MARKER_CATEGORY_CLOSED, payload);
     }
     fireTraceServerStartedSignal(): void {
@@ -154,10 +154,10 @@ export class SignalManager extends EventEmitter implements SignalManager {
     fireOpenOverviewOutputSignal(traceId: string): void {
         this.emit(Signals.OPEN_OVERVIEW_OUTPUT, traceId);
     }
-    fireOverviewOutputSelectedSignal(payload: { traceId: string, outputDescriptor: OutputDescriptor}): void {
+    fireOverviewOutputSelectedSignal(payload: { traceId: string; outputDescriptor: OutputDescriptor }): void {
         this.emit(Signals.OVERVIEW_OUTPUT_SELECTED, payload);
     }
-    fireSaveAsCsv(payload: {traceId: string, data: string}): void {
+    fireSaveAsCsv(payload: { traceId: string; data: string }): void {
         this.emit(Signals.SAVE_AS_CSV, payload);
     }
     fireViewRangeUpdated(payload: TimeRangeUpdatePayload): void {
@@ -169,7 +169,6 @@ export class SignalManager extends EventEmitter implements SignalManager {
     fireRequestSelectionRangeChange(payload: TimeRangeUpdatePayload): void {
         this.emit(Signals.REQUEST_SELECTION_RANGE_CHANGE, payload);
     }
-
 }
 
 let instance: SignalManager = new SignalManager();

--- a/packages/base/src/signals/time-range-data-signal-payloads.tsx
+++ b/packages/base/src/signals/time-range-data-signal-payloads.tsx
@@ -1,6 +1,6 @@
 import { TimeRange } from '../utils/time-range';
 
 export interface TimeRangeUpdatePayload {
-    experimentUUID: string,
-    timeRange?: TimeRange,
+    experimentUUID: string;
+    timeRange?: TimeRange;
 }

--- a/packages/base/src/trace-manager.ts
+++ b/packages/base/src/trace-manager.ts
@@ -1,19 +1,15 @@
-
 import { Trace } from 'tsp-typescript-client/lib/models/trace';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { Query } from 'tsp-typescript-client/lib/models/query/query';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
-import { signalManager} from './signals/signal-manager';
+import { signalManager } from './signals/signal-manager';
 
 export class TraceManager {
-
     private fOpenTraces: Map<string, Trace> = new Map();
     private fTspClient: TspClient;
 
-    constructor(
-        tspClient: TspClient
-    ) {
+    constructor(tspClient: TspClient) {
         this.fTspClient = tspClient;
     }
 
@@ -74,10 +70,12 @@ export class TraceManager {
         const name = traceName ? traceName : traceURI.replace(/\/$/, '').replace(/(.*\/)?/, '');
 
         const tryOpen = async function (tspClient: TspClient, retry: number): Promise<TspClientResponse<Trace>> {
-            return tspClient.openTrace(new Query({
-                'name': retry === 0 ? name : name + '(' + retry + ')',
-                'uri': traceURI
-            }));
+            return tspClient.openTrace(
+                new Query({
+                    name: retry === 0 ? name : name + '(' + retry + ')',
+                    uri: traceURI
+                })
+            );
         };
         let tryNb = 0;
         let traceResponse: TspClientResponse<Trace> | undefined;

--- a/packages/base/src/utils/convert-color-string-to-hex.ts
+++ b/packages/base/src/utils/convert-color-string-to-hex.ts
@@ -12,10 +12,14 @@ export function convertColorStringToHexNumber(rgb: string): number {
         // Working with RGB String
         const match = rgb.match(/\d+/g);
         if (match) {
-            string = '0x' + match.map(x => {
-                    x = parseInt(x).toString(16);
-                    return (x.length === 1) ? '0' + x : x;
-                }).join('');
+            string =
+                '0x' +
+                match
+                    .map(x => {
+                        x = parseInt(x).toString(16);
+                        return x.length === 1 ? '0' + x : x;
+                    })
+                    .join('');
             string = string.slice(0, 8);
         }
     }

--- a/packages/base/src/utils/value-hash.ts
+++ b/packages/base/src/utils/value-hash.ts
@@ -14,7 +14,7 @@ const hash = (str: string): number => {
     let hashCode = 0;
     for (let i = 0; i < str.length; i++) {
         const chr = str.charCodeAt(i);
-        hashCode = ((hashCode << 5) - hashCode) + chr;
+        hashCode = (hashCode << 5) - hashCode + chr;
         hashCode |= 0; // Convert to 32bit integer
     }
     return hashCode;

--- a/packages/react-components/.eslintrc.js
+++ b/packages/react-components/.eslintrc.js
@@ -37,5 +37,22 @@ module.exports = {
         projectFolderIgnoreList: [
             '/lib/'
         ]
-    }
+    },
+    overrides: [
+        {
+            // Apply rule override only to files with the following extensions
+            files: ['*.tsx', '*.jsx'],
+            rules: {
+                '@typescript-eslint/ban-types': [
+                    'error',
+                    {
+                        extendDefaults: true,
+                        types: {
+                            '{}': false,
+                        },
+                    },
+                ],
+            },
+        },
+    ]
 };

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -63,6 +63,8 @@
     "clean": "rimraf lib *.tsbuildinfo",
     "lint": "eslint .",
     "test": "jest  --config jest.config.json",
-    "watch": "tsc -b -w"
+    "watch": "tsc -b -w",
+    "format:write": "prettier --write ./src",
+    "format:check": "prettier --check ./src"
   }
 }

--- a/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
+++ b/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
@@ -10,7 +10,6 @@ import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { ColDef, Column, ColumnApi, GridApi, IRowModel, RowNode } from 'ag-grid-community';
 
 describe('<TableOutputComponent />', () => {
-
     let tableComponent: any;
     const ref = (el: TableOutputComponent | undefined | null): void => {
         tableComponent = el;
@@ -50,7 +49,7 @@ describe('<TableOutputComponent />', () => {
                 start: BigInt(0),
                 end: BigInt(0),
                 final: true,
-                compatibleProviders: []            
+                compatibleProviders: []
             },
             markerCategories: undefined,
             markerSetId: '0',
@@ -59,7 +58,7 @@ describe('<TableOutputComponent />', () => {
             viewRange: new TimeRange(BigInt(0), BigInt(0)),
             selectionRange: undefined,
             onOutputRemove: () => 0,
-            unitController: new TimeGraphUnitController(BigInt(0), { start: BigInt(0), end: BigInt(0)}),
+            unitController: new TimeGraphUnitController(BigInt(0), { start: BigInt(0), end: BigInt(0) }),
             backgroundTheme: 'light',
             tooltipXYComponent: null,
             outputWidth: 0
@@ -67,19 +66,19 @@ describe('<TableOutputComponent />', () => {
 
         const tableOutputComponentState = [
             {
-                "headerName":"Trace",
-                "field":"0",
-                "width":0,
-                "resizable":true,
-                "cellRenderer":"cellRenderer",
-                "cellRendererParams":{"filterModel":{},"searchResultsColor":"#cccc00"},
-                "suppressMenu":true,
-                "filter":"agTextColumnFilter",
-                "floatingFilter":true,
-                "floatingFilterComponent":"searchFilterRenderer",
-                "floatingFilterComponentParams":{"suppressFilterButton":true,"colName":"0"},
-                "icons":{"filter":""},
-                "tooltipField":"0"
+                headerName: 'Trace',
+                field: '0',
+                width: 0,
+                resizable: true,
+                cellRenderer: 'cellRenderer',
+                cellRendererParams: { filterModel: {}, searchResultsColor: '#cccc00' },
+                suppressMenu: true,
+                filter: 'agTextColumnFilter',
+                floatingFilter: true,
+                floatingFilterComponent: 'searchFilterRenderer',
+                floatingFilterComponentParams: { suppressFilterButton: true, colName: '0' },
+                icons: { filter: '' },
+                tooltipField: '0'
             }
         ];
 
@@ -89,10 +88,8 @@ describe('<TableOutputComponent />', () => {
         const table: TableOutputComponent = tableComponent;
         act(() => {
             // fire events that update state
-            table.setState(
-                {tableColumns: tableOutputComponentState}
-            );
-          });
+            table.setState({ tableColumns: tableOutputComponentState });
+        });
 
         // Renders with provided props
         expect(table.state.tableColumns).toEqual(tableOutputComponentState);
@@ -124,14 +121,14 @@ describe('<TableOutputComponent />', () => {
     const mockShowParentFilter = jest.fn();
 
     test('Empty search filter renderer', () => {
-        const searchFilter = create(<SearchFilterRenderer 
-            colName={'jest Test'}
-            onFilterChange={mockOnFilterChange}
-            onclickNext={mockOnClickNext}
-            onclickPrevious={mockOnClickPrevious} 
-            column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)} 
-            filterParams={
-                {
+        const searchFilter = create(
+            <SearchFilterRenderer
+                colName={'jest Test'}
+                onFilterChange={mockOnFilterChange}
+                onclickNext={mockOnClickNext}
+                onclickPrevious={mockOnClickPrevious}
+                column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)}
+                filterParams={{
                     api: new GridApi(),
                     column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
                     colDef: {} as ColDef,
@@ -141,30 +138,30 @@ describe('<TableOutputComponent />', () => {
                     filterModifiedCallback: mockFilterModifiedCallback,
                     valueGetter: mockValueGetter,
                     doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
-                    context: '',
-                }
-            } 
-            currentParentModel={mockCurrentParentModel} 
-            parentFilterInstance={mockParentilterInstance} 
-            suppressFilterButton={false} 
-            api={new GridApi()} 
-            columnApi={new ColumnApi()}
-            showParentFilter={mockShowParentFilter}
-            context={''}
-            filterModel= {new Map<string,string>()}
-        />).toJSON();
+                    context: ''
+                }}
+                currentParentModel={mockCurrentParentModel}
+                parentFilterInstance={mockParentilterInstance}
+                suppressFilterButton={false}
+                api={new GridApi()}
+                columnApi={new ColumnApi()}
+                showParentFilter={mockShowParentFilter}
+                context={''}
+                filterModel={new Map<string, string>()}
+            />
+        ).toJSON();
         expect(searchFilter).toMatchSnapshot();
     });
 
     test('Search filter renderer key interactions', () => {
-        render(<SearchFilterRenderer 
-            colName={'jest Test'}
-            onFilterChange={mockOnFilterChange}
-            onclickNext={mockOnClickNext}
-            onclickPrevious={mockOnClickPrevious} 
-            column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)} 
-            filterParams={
-                {
+        render(
+            <SearchFilterRenderer
+                colName={'jest Test'}
+                onFilterChange={mockOnFilterChange}
+                onclickNext={mockOnClickNext}
+                onclickPrevious={mockOnClickPrevious}
+                column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)}
+                filterParams={{
                     api: new GridApi(),
                     column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
                     colDef: {} as ColDef,
@@ -174,25 +171,25 @@ describe('<TableOutputComponent />', () => {
                     filterModifiedCallback: mockFilterModifiedCallback,
                     valueGetter: mockValueGetter,
                     doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
-                    context: '',
-                }
-            } 
-            currentParentModel={mockCurrentParentModel} 
-            parentFilterInstance={mockParentilterInstance} 
-            suppressFilterButton={false} 
-            api={new GridApi()}
-            columnApi={new ColumnApi()}
-            showParentFilter={mockShowParentFilter}
-            context={''}
-            filterModel={new Map<string,string>()}
-        />);
+                    context: ''
+                }}
+                currentParentModel={mockCurrentParentModel}
+                parentFilterInstance={mockParentilterInstance}
+                suppressFilterButton={false}
+                api={new GridApi()}
+                columnApi={new ColumnApi()}
+                showParentFilter={mockShowParentFilter}
+                context={''}
+                filterModel={new Map<string, string>()}
+            />
+        );
 
         const parentDiv = screen.getByTestId('search-filter-element-parent');
         fireEvent.click(parentDiv);
         const input = screen.getByTestId('search-filter-element-input');
-        fireEvent.keyDown(input, {key: 'Enter', code: 'Enter', charCode: 13});
+        fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 });
         expect(mockOnClickNext).toHaveBeenCalledTimes(1);
-        fireEvent.keyDown(input, {key: 'Escape', code: 'Escape', charCode: 27});
+        fireEvent.keyDown(input, { key: 'Escape', code: 'Escape', charCode: 27 });
         expect(mockOnFilterChange).toHaveBeenCalledTimes(1);
     });
 
@@ -224,20 +221,20 @@ describe('<TableOutputComponent />', () => {
             throw new Error('Function not implemented.');
         },
         searchResultsColor: '#FFFF00',
-        filterModel: new Map<string,string>()
-    }
+        filterModel: new Map<string, string>()
+    };
 
     test('Cell renderer', () => {
-        const cellRenderer = create(<CellRenderer {...cellRendererProps}/>).toJSON();
+        const cellRenderer = create(<CellRenderer {...cellRendererProps} />).toJSON();
         expect(cellRenderer).toMatchSnapshot();
     });
 
     test('Cell renderer with search selection', () => {
         cellRendererProps.colDef.field = 'testField';
         cellRendererProps.filterModel.set('testField', 'test');
-        cellRendererProps.data = {'isMatched' : true};
+        cellRendererProps.data = { isMatched: true };
 
-        const cellRenderer = create(<CellRenderer {...cellRendererProps}/>).toJSON();
+        const cellRenderer = create(<CellRenderer {...cellRendererProps} />).toJSON();
         expect(cellRenderer).toMatchSnapshot();
     });
 
@@ -245,15 +242,14 @@ describe('<TableOutputComponent />', () => {
         delete cellRendererProps.filterModel;
         delete cellRendererProps.searchResultsColor;
 
-        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps}/>).toJSON();
+        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps} />).toJSON();
         expect(loadingRenderer).toMatchSnapshot();
     });
 
     test('Loading renderer in loading', () => {
         cellRendererProps.value = undefined;
 
-        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps}/>).toJSON();
+        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps} />).toJSON();
         expect(loadingRenderer).toMatchSnapshot();
     });
-
-})
+});

--- a/packages/react-components/src/components/__tests__/tooltip-component.test.tsx
+++ b/packages/react-components/src/components/__tests__/tooltip-component.test.tsx
@@ -3,89 +3,88 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { TooltipComponent } from '../tooltip-component';
 
 const model = {
-  id: '123',
-  range: { start: 1, end: 10 },
-  label: 'model'
-}
+    id: '123',
+    range: { start: 1, end: 10 },
+    label: 'model'
+};
 const tooltip = new TooltipComponent(10);
 tooltip.setState = jest.fn();
 
 describe('Tooltip component', () => {
+    let axisComponent: any;
+    const ref = (el: TooltipComponent | undefined | null): void => {
+        axisComponent = el;
+    };
 
-  let axisComponent: any;
-  const ref = (el: TooltipComponent | undefined | null): void => {
-    axisComponent = el;
-  };
+    beforeEach(() => {
+        axisComponent = null;
+    });
 
-  beforeEach(() => {
-    axisComponent = null;
-  });
+    afterEach(() => {
+        cleanup();
+        jest.clearAllMocks();
+    });
 
-  afterEach(() => {
-    cleanup();
-    jest.clearAllMocks();
-  });
+    /*
+     * Skip due to issues with TooltipComponent:
+     *
+     * react-tooltip v4.2.14 works in the application but causes an exception
+     * in tests (https://github.com/ReactTooltip/react-tooltip/issues/681),
+     * which is fixed in v4.2.17. However, version v4.2.17 breaks the tooltip
+     * when running in the application.
+     */
+    it.skip('renders itself', () => {
+        render(<TooltipComponent />);
+        expect(axisComponent).toBeTruthy();
+        expect(axisComponent instanceof TooltipComponent).toBe(true);
+    });
 
-  /*
-   * Skip due to issues with TooltipComponent:
-   *
-   * react-tooltip v4.2.14 works in the application but causes an exception
-   * in tests (https://github.com/ReactTooltip/react-tooltip/issues/681),
-   * which is fixed in v4.2.17. However, version v4.2.17 breaks the tooltip
-   * when running in the application.
-   */
-  it.skip('renders itself', () => {
-    render(<TooltipComponent />);
-    expect(axisComponent).toBeTruthy();
-    expect(axisComponent instanceof TooltipComponent).toBe(true);
-  });
+    // Skip due to issues with TooltipComponent (see above for details)
+    it.skip('resets timer on mouse enter', () => {
+        tooltip.state = {
+            element: model,
+            func: undefined,
+            content: 'Test'
+        };
+        render(<TooltipComponent />);
+        const component = screen.getByRole('tooltip-component-role');
+        fireEvent.mouseEnter(component);
+        fireEvent.mouseLeave(component);
 
-  // Skip due to issues with TooltipComponent (see above for details)
-  it.skip('resets timer on mouse enter', () => {
-      tooltip.state = {
-        element: model,
-        func: undefined,
-        content: 'Test'
-      }
-      render(<TooltipComponent />);
-      const component = screen.getByRole('tooltip-component-role');
-      fireEvent.mouseEnter(component);
-      fireEvent.mouseLeave(component);
+        expect(tooltip.setState).toBeCalledWith({ content: undefined });
+    });
 
-      expect(tooltip.setState).toBeCalledWith({ content: undefined });
-  })
+    it('displays a tooltip for a time graph state component', () => {
+        tooltip.state = {
+            element: undefined,
+            func: undefined,
+            content: undefined
+        };
+        tooltip.setElement(model);
 
-  it('displays a tooltip for a time graph state component', () => {
-    tooltip.state = {
-      element: undefined,
-      func: undefined,
-      content: undefined
-    }
-    tooltip.setElement(model);
-    
-    expect(tooltip.setState).toBeCalledWith({ element: model, func: undefined });
-  });
+        expect(tooltip.setState).toBeCalledWith({ element: model, func: undefined });
+    });
 
-  it('hides tooltip if mouse is not hovering over element', async () => {
-    tooltip.state = {
-      element: model,
-      func: undefined,
-      content: 'Test'
-    }
-    tooltip.setElement(undefined);
-    await new Promise((r) => setTimeout(r, 500));
-    
-    expect(tooltip.setState).toBeCalledWith({ content: undefined });
-  })
+    it('hides tooltip if mouse is not hovering over element', async () => {
+        tooltip.state = {
+            element: model,
+            func: undefined,
+            content: 'Test'
+        };
+        tooltip.setElement(undefined);
+        await new Promise(r => setTimeout(r, 500));
 
-  it('hide tooltip because there is no content', () => {
-    tooltip.state = {
-      element: model,
-      func: undefined,
-      content: undefined
-    }
-    tooltip.setElement(undefined);
-    
-    expect(tooltip.setState).toBeCalledWith({ content: undefined });
-  })
-})
+        expect(tooltip.setState).toBeCalledWith({ content: undefined });
+    });
+
+    it('hide tooltip because there is no content', () => {
+        tooltip.state = {
+            element: model,
+            func: undefined,
+            content: undefined
+        };
+        tooltip.setElement(undefined);
+
+        expect(tooltip.setState).toBeCalledWith({ content: undefined });
+    });
+});

--- a/packages/react-components/src/components/abstract-dialog-component.tsx
+++ b/packages/react-components/src/components/abstract-dialog-component.tsx
@@ -4,9 +4,9 @@ import '../../style/dialog-component-style.css';
 import '../../style/output-components-style.css';
 
 export interface DialogComponentProps {
-    title: string,
-    onCloseDialog: () => void,
-    isOpen: boolean
+    title: string;
+    onCloseDialog: () => void;
+    isOpen: boolean;
 }
 
 export abstract class AbstractDialogComponent<P extends DialogComponentProps, S> extends React.Component<P, S> {
@@ -15,21 +15,29 @@ export abstract class AbstractDialogComponent<P extends DialogComponentProps, S>
     }
 
     render(): React.ReactNode {
-        return <ReactModal isOpen={this.props.isOpen}
-        overlayClassName="dialog-overlay"
-        className="dialog"
-        ariaHideApp={false}
-        onRequestClose={this.props.onCloseDialog}
-        shouldFocusAfterRender={false}>
-            <div onClick={e => {e.preventDefault();}}>
-                <div className='dialog-header'>
-                    <div>{this.props.title}</div>
-                    <i className='dialog-header-close codicon codicon-close' onClick={this.props.onCloseDialog}></i>
+        return (
+            <ReactModal
+                isOpen={this.props.isOpen}
+                overlayClassName="dialog-overlay"
+                className="dialog"
+                ariaHideApp={false}
+                onRequestClose={this.props.onCloseDialog}
+                shouldFocusAfterRender={false}
+            >
+                <div
+                    onClick={e => {
+                        e.preventDefault();
+                    }}
+                >
+                    <div className="dialog-header">
+                        <div>{this.props.title}</div>
+                        <i className="dialog-header-close codicon codicon-close" onClick={this.props.onCloseDialog}></i>
+                    </div>
+                    <div className="dialog-body">{this.renderDialogBody()}</div>
+                    <div className="dialog-footer">{this.renderFooter()}</div>
                 </div>
-                <div className='dialog-body'>{this.renderDialogBody()}</div>
-                <div className='dialog-footer'>{this.renderFooter()}</div>
-            </div>
-        </ReactModal>;
+            </ReactModal>
+        );
     }
 
     protected abstract renderDialogBody(): React.ReactElement;

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -41,7 +41,7 @@ export interface AbstractOutputProps {
     onTouchStart?: VoidFunction;
     onTouchEnd?: VoidFunction;
     setChartOffset?: (chartOffset: number) => void;
-    pinned?: boolean
+    pinned?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     persistChartState?: any;
     children?: string;
@@ -53,8 +53,10 @@ export interface AbstractOutputState {
     dropDownOpen?: boolean;
 }
 
-export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends React.Component<P, S> {
-
+export abstract class AbstractOutputComponent<
+    P extends AbstractOutputProps,
+    S extends AbstractOutputState
+> extends React.Component<P, S> {
     private readonly DEFAULT_HANDLE_WIDTH = 30;
 
     protected mainOutputContainer: React.RefObject<HTMLDivElement>;
@@ -85,29 +87,36 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     }
 
     render(): JSX.Element {
-        return <div style={{ ...this.props.style, width: this.props.outputWidth }}
-            id={this.getOutputComponentDomId()}
-            tabIndex={-1}
-            className={'output-container ' + this.props.className}
-            onMouseUp={this.props.onMouseUp}
-            onMouseDown={this.props.onMouseDown}
-            onTouchStart={this.props.onTouchStart}
-            onTouchEnd={this.props.onTouchEnd}
-            data-tip=''
-            data-for='tooltip-component'>
+        return (
             <div
-                id={this.getOutputComponentDomId() + 'handle'}
-                className={this.showViewOptionsCondition() ?
-                    'widget-handle-with-options' : 'widget-handle'} style={{ width: this.getHandleWidth(), height: this.props.style.height }}
+                style={{ ...this.props.style, width: this.props.outputWidth }}
+                id={this.getOutputComponentDomId()}
+                tabIndex={-1}
+                className={'output-container ' + this.props.className}
+                onMouseUp={this.props.onMouseUp}
+                onMouseDown={this.props.onMouseDown}
+                onTouchStart={this.props.onTouchStart}
+                onTouchEnd={this.props.onTouchEnd}
+                data-tip=""
+                data-for="tooltip-component"
             >
-                {this.renderTitleBar()}
+                <div
+                    id={this.getOutputComponentDomId() + 'handle'}
+                    className={this.showViewOptionsCondition() ? 'widget-handle-with-options' : 'widget-handle'}
+                    style={{ width: this.getHandleWidth(), height: this.props.style.height }}
+                >
+                    {this.renderTitleBar()}
+                </div>
+                <div
+                    className="main-output-container"
+                    ref={this.mainOutputContainer}
+                    style={{ width: this.props.outputWidth - this.getHandleWidth(), height: this.props.style.height }}
+                >
+                    {this.renderMainOutputContainer()}
+                </div>
+                {this.props.children}
             </div>
-            <div className='main-output-container' ref={this.mainOutputContainer}
-                style={{ width: this.props.outputWidth - this.getHandleWidth(), height: this.props.style.height }}>
-                {this.renderMainOutputContainer()}
-            </div>
-            {this.props.children}
-        </div>;
+        );
     }
 
     private renderTitleBar(): React.ReactNode {
@@ -124,39 +133,50 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         };
         const titleOverflown = this.titleRef.current && isOverflown() ? 'custom-ellipsis' : 'hidden-ellipsis';
 
-        return <React.Fragment>
-            <button className='remove-component-button' onClick={this.closeComponent}>
-                <FontAwesomeIcon icon={faTimes} />
-            </button>
-            {this.showViewOptionsCondition() &&
-                <div className='options-menu-container'>
-                    <button
-                        title='Show View Options'
-                        className='options-menu-button'
-                        onClick={this.toggleDropDown}
-                    >
-                        <FontAwesomeIcon icon={faBars} />
-                    </button>
-                    <DropDownComponent dropDownOpen={this.state.dropDownOpen ?? false} dropDownOptions={this.dropDownOptions}
-                        ref={this.dropDownMenuRef} {...this.props}></DropDownComponent>
+        return (
+            <React.Fragment>
+                <button className="remove-component-button" onClick={this.closeComponent}>
+                    <FontAwesomeIcon icon={faTimes} />
+                </button>
+                {this.showViewOptionsCondition() && (
+                    <div className="options-menu-container">
+                        <button title="Show View Options" className="options-menu-button" onClick={this.toggleDropDown}>
+                            <FontAwesomeIcon icon={faBars} />
+                        </button>
+                        <DropDownComponent
+                            dropDownOpen={this.state.dropDownOpen ?? false}
+                            dropDownOptions={this.dropDownOptions}
+                            ref={this.dropDownMenuRef}
+                            {...this.props}
+                        ></DropDownComponent>
+                    </div>
+                )}
+                <div
+                    ref={this.titleBarLabelRef}
+                    className="title-bar-label"
+                    title={outputTooltip}
+                    onClick={() => this.setFocus()}
+                >
+                    <span ref={this.titleRef}>{outputName}</span>
+                    <span className={titleOverflown}>...</span>
+                    <FontAwesomeIcon
+                        id={this.getOutputComponentDomId() + 'handleSpinner'}
+                        icon={faSpinner}
+                        spin
+                        style={{ marginTop: '5px', visibility: 'hidden' }}
+                    />
+                    {this.props.pinned === true && (
+                        <FontAwesomeIcon icon={faThumbtack} title="Pinned View" className="pin-view-icon" />
+                    )}
                 </div>
-            }
-            <div ref={this.titleBarLabelRef} className='title-bar-label' title={outputTooltip} onClick={() => this.setFocus()}>
-                <span ref={this.titleRef}>{outputName}</span>
-                <span className={titleOverflown}>...</span>
-                <FontAwesomeIcon
-                    id={this.getOutputComponentDomId() + 'handleSpinner'}
-                    icon={faSpinner}
-                    spin
-                    style={{ marginTop: '5px', visibility: 'hidden'}}
-                />
-                {this.props.pinned === true && <FontAwesomeIcon icon={faThumbtack} title='Pinned View' className='pin-view-icon'/>}
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 
     private showViewOptionsCondition(): boolean {
-        const nonPinViewOptionExists = this.dropDownOptions.some(option => option.label !== this.PIN_VIEW_LABEL && option.label !== this.UNPIN_VIEW_LABEL);
+        const nonPinViewOptionExists = this.dropDownOptions.some(
+            option => option.label !== this.PIN_VIEW_LABEL && option.label !== this.UNPIN_VIEW_LABEL
+        );
         return nonPinViewOptionExists || this.props.pinned !== false;
     }
 
@@ -237,7 +257,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             label: label,
             onClick: onClick,
             arg: arg,
-            condition: condition,
+            condition: condition
         } as OptionState;
         if (this.dropDownOptions.includes(newOption)) {
             return;
@@ -260,21 +280,23 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     }
 
     protected renderAnalysisFailed(): React.ReactElement {
-        return <>
-            <div className='message-main-area'>
-                Trace analysis failed.
-            </div>
-        </>;
+        return (
+            <>
+                <div className="message-main-area">Trace analysis failed.</div>
+            </>
+        );
     }
 
     protected renderEmptyResults(): React.ReactElement {
-        return <>
-                <div className='message-main-area'>
+        return (
+            <>
+                <div className="message-main-area">
                     Trace analysis complete.
                     <br />
                     No results: Trace missing required events.
                 </div>
-        </>;
+            </>
+        );
     }
 
     protected getOutputComponentDomId(): string {

--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -3,11 +3,13 @@ import * as React from 'react';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 
 export type AbstractTreeOutputState = AbstractOutputState & {
-    showTree: boolean
+    showTree: boolean;
 };
 
-export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractTreeOutputState> extends AbstractOutputComponent<P, S> {
-
+export abstract class AbstractTreeOutputComponent<
+    P extends AbstractOutputProps,
+    S extends AbstractTreeOutputState
+> extends AbstractOutputComponent<P, S> {
     private readonly DEFAULT_Y_AXIS_WIDTH = 40;
     private readonly DEFAULT_SASH_WIDTH = 4;
 
@@ -22,28 +24,46 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
     }
 
     renderMainArea(): React.ReactNode {
-        return <React.Fragment>
-            {this.state.showTree && <div ref={this.treeRef} className='output-component-tree disable-select'
-                style={{ width: this.getTreeWidth(), height: this.props.style.height }}
-            >
-                {this.renderTree()}
-            </div>}
-            <div className='output-component-y-axis' style={{
-                height: this.props.style.height,
-                backgroundColor: '#' + this.props.style.chartBackgroundColor.toString(16)
-            }}>
-                {this.renderYAxis()}
-            </div>
-            <div className='output-component-sash' onMouseDown={event => this.onSashDown(event)} style={{
-                width: this.getSashWidth(), height: this.props.style.height
-            }}/>
-            <div className='output-component-chart' style={{
-                width: this.getChartWidth(), height: this.props.style.height,
-                backgroundColor: '#' + this.props.style.chartBackgroundColor.toString(16)
-            }}>
-                {this.renderChart()}
-            </div>
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                {this.state.showTree && (
+                    <div
+                        ref={this.treeRef}
+                        className="output-component-tree disable-select"
+                        style={{ width: this.getTreeWidth(), height: this.props.style.height }}
+                    >
+                        {this.renderTree()}
+                    </div>
+                )}
+                <div
+                    className="output-component-y-axis"
+                    style={{
+                        height: this.props.style.height,
+                        backgroundColor: '#' + this.props.style.chartBackgroundColor.toString(16)
+                    }}
+                >
+                    {this.renderYAxis()}
+                </div>
+                <div
+                    className="output-component-sash"
+                    onMouseDown={event => this.onSashDown(event)}
+                    style={{
+                        width: this.getSashWidth(),
+                        height: this.props.style.height
+                    }}
+                />
+                <div
+                    className="output-component-chart"
+                    style={{
+                        width: this.getChartWidth(),
+                        height: this.props.style.height,
+                        backgroundColor: '#' + this.props.style.chartBackgroundColor.toString(16)
+                    }}
+                >
+                    {this.renderChart()}
+                </div>
+            </React.Fragment>
+        );
     }
 
     private onSashDown(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void {
@@ -55,8 +75,10 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
 
     private onSashMove(ev: MouseEvent): void {
         if (this.sashDownX !== -1 && this.props?.setChartOffset) {
-            const chartOffset = Math.max(this.sashDownOffset + (ev.clientX - this.sashDownX),
-                this.getHandleWidth() + this.getYAxisWidth() + this.getSashWidth());
+            const chartOffset = Math.max(
+                this.sashDownOffset + (ev.clientX - this.sashDownX),
+                this.getHandleWidth() + this.getYAxisWidth() + this.getSashWidth()
+            );
             this.props.setChartOffset(chartOffset);
             ev.preventDefault();
         }
@@ -89,14 +111,13 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
             outputStatus = await this.fetchTree();
             const timeout = 500 * factor;
             await new Promise(resolve => setTimeout(resolve, timeout));
-            factor = factor > maxFactor ? factor: factor + 1;
+            factor = factor > maxFactor ? factor : factor + 1;
         }
     }
 
     componentWillUnmount(): void {
         // fix Warning: Can't perform a React state update on an unmounted component
         this.setState = (_state, _callback) => undefined;
-
     }
 
     protected getYAxisWidth(): number {
@@ -109,7 +130,7 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
 
     public getTreeWidth(): number {
         // Make tree thinner when chart has a y-axis
-        const yAxisWidth = this.props.outputDescriptor.type === 'TREE_TIME_XY' ? this.getYAxisWidth(): 0;
+        const yAxisWidth = this.props.outputDescriptor.type === 'TREE_TIME_XY' ? this.getYAxisWidth() : 0;
         return Math.max(0, this.props.style.chartOffset - this.getHandleWidth() - yAxisWidth - this.getSashWidth());
     }
 

--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -15,7 +15,12 @@ import * as React from 'react';
 import { flushSync } from 'react-dom';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
 import { BIMath } from 'timeline-chart/lib/bigint-utils';
-import { XYChartFactoryParams, xyChartFactory, GetClosestPointParam, getClosestPointForScatterPlot } from './utils/xy-output-component-utils';
+import {
+    XYChartFactoryParams,
+    xyChartFactory,
+    GetClosestPointParam,
+    getClosestPointForScatterPlot
+} from './utils/xy-output-component-utils';
 import { ChartOptions } from 'chart.js';
 import { Line, Scatter } from 'react-chartjs-2';
 import { getAllExpandedNodeIds } from './utils/filter-tree/utils';
@@ -67,8 +72,10 @@ class xyPair {
     }
 }
 
-export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S extends AbstractXYOutputState> extends AbstractTreeOutputComponent<P, S> {
-
+export abstract class AbstractXYOutputComponent<
+    P extends AbstractOutputProps,
+    S extends AbstractXYOutputState
+> extends AbstractTreeOutputComponent<P, S> {
     // References
     private yAxisRef: any;
     protected divRef: any;
@@ -100,7 +107,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
 
     protected endSelection = (event: MouseEvent): void => {
         if (this.clickedMouseButton === MouseButton.RIGHT) {
-           this.applySelectionZoom();
+            this.applySelectionZoom();
         }
 
         this.mouseIsDown = false;
@@ -122,7 +129,9 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
     };
 
     private plugin = {
-        afterDraw: (chartInstance: Chart, _easing: Chart.Easing, _options?: any) => { this.afterChartDraw(chartInstance.ctx, chartInstance.chartArea); }
+        afterDraw: (chartInstance: Chart, _easing: Chart.Easing, _options?: any) => {
+            this.afterChartDraw(chartInstance.ctx, chartInstance.chartArea);
+        }
     };
 
     private _debouncedUpdateXY = debounce(() => this.updateXY(), 500);
@@ -162,11 +171,11 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
             newList = newList.concat(id);
         }
         const orderedIds = getAllExpandedNodeIds(nodes, newList);
-        this.setState({collapsedNodes: newList, orderedNodes: orderedIds});
+        this.setState({ collapsedNodes: newList, orderedNodes: orderedIds });
     }
 
     protected onOrderChange(ids: number[]): void {
-        this.setState({orderedNodes: ids});
+        this.setState({ orderedNodes: ids });
     }
 
     protected onToggleCheck(ids: number[]): void {
@@ -195,14 +204,14 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         };
     }
 
-    private applySelectionZoom(): void{
+    private applySelectionZoom(): void {
         const newStartRange = this.startPositionMouseRightClick;
         const newEndRange = this.getTimeForX(this.positionXMove);
         this.updateRange(newStartRange, newEndRange);
     }
 
     protected updateSelection(): void {
-        if (this.props.unitController.selectionRange){
+        if (this.props.unitController.selectionRange) {
             const xStartPos = this.props.unitController.selectionRange.start;
             this.props.unitController.selectionRange = {
                 start: xStartPos,
@@ -219,10 +228,17 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         const viewRangeChanged = this.props.viewRange !== prevProps.viewRange;
         const checkedSeriesChanged = this.state.checkedSeries !== prevState.checkedSeries;
         const collapsedNodesChanged = this.state.collapsedNodes !== prevState.collapsedNodes;
-        const chartWidthChanged = this.props.style.width !== prevProps.style.width || this.props.style.chartOffset !== prevProps.style.chartOffset
-                                || this.props.style.componentLeft !== prevProps.style.componentLeft;
+        const chartWidthChanged =
+            this.props.style.width !== prevProps.style.width ||
+            this.props.style.chartOffset !== prevProps.style.chartOffset ||
+            this.props.style.componentLeft !== prevProps.style.componentLeft;
         const outputStatusChanged = this.state.outputStatus !== prevState.outputStatus;
-        const needToUpdate = viewRangeChanged || checkedSeriesChanged || collapsedNodesChanged || chartWidthChanged || outputStatusChanged;
+        const needToUpdate =
+            viewRangeChanged ||
+            checkedSeriesChanged ||
+            collapsedNodesChanged ||
+            chartWidthChanged ||
+            outputStatusChanged;
 
         if (needToUpdate) {
             this._debouncedUpdateXY();
@@ -253,7 +269,11 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
     async fetchTree(): Promise<ResponseStatus> {
         this.viewSpinner(true);
         const parameters = QueryHelper.timeRangeQuery(this.props.range.getStart(), this.props.range.getEnd());
-        const tspClientResponse = await this.props.tspClient.fetchXYTree(this.props.traceId, this.props.outputDescriptor.id, parameters);
+        const tspClientResponse = await this.props.tspClient.fetchXYTree(
+            this.props.traceId,
+            this.props.outputDescriptor.id,
+            parameters
+        );
         const treeResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && treeResponse) {
             if (treeResponse.model) {
@@ -261,20 +281,23 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
                 const columns = [];
                 if (headers && headers.length > 0) {
                     headers.forEach(header => {
-                        columns.push({title: header.name, sortable: true, resizable: true, tooltip: header.tooltip});
+                        columns.push({ title: header.name, sortable: true, resizable: true, tooltip: header.tooltip });
                     });
                 } else {
-                    columns.push({title: 'Name', sortable: true});
+                    columns.push({ title: 'Name', sortable: true });
                 }
                 const checkedSeries = this.getAllCheckedIds(treeResponse.model.entries);
-                this.setState({
-                    outputStatus: treeResponse.status,
-                    xyTree: treeResponse.model.entries,
-                    checkedSeries,
-                    columns
-                }, () => {
-                    this.updateXY();
-                });
+                this.setState(
+                    {
+                        outputStatus: treeResponse.status,
+                        xyTree: treeResponse.model.entries,
+                        checkedSeries,
+                        columns
+                    },
+                    () => {
+                        this.updateXY();
+                    }
+                );
             } else {
                 this.setState({
                     outputStatus: treeResponse.status
@@ -304,8 +327,8 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         this.onToggleCheck = this.onToggleCheck.bind(this);
         this.onToggleCollapse = this.onToggleCollapse.bind(this);
         this.onOrderChange = this.onOrderChange.bind(this);
-        return this.state.xyTree.length ?
-            <div className='scrollable' style={{ height: this.props.style.height }}>
+        return this.state.xyTree.length ? (
+            <div className="scrollable" style={{ height: this.props.style.height }}>
                 <EntryTree
                     entries={this.state.xyTree}
                     showCheckboxes={true}
@@ -317,8 +340,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
                     headers={this.state.columns}
                 />
             </div>
-        : undefined
-        ;
+        ) : undefined;
     }
 
     renderYAxis(): React.ReactNode {
@@ -332,24 +354,34 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         const yTransform = `translate(${this.margin.left}, 0)`;
 
         // Abbreviate large numbers
-        const scaleYLabel = (d: number) => (
-            d >= 1000000000000 ? Math.round(d / 100000000000) / 10 + 'G' :
-            d >= 1000000000 ? Math.round(d / 100000000) / 10 + 'B':
-            d >= 1000000 ? Math.round(d / 100000) / 10 + 'M' :
-            d >= 1000 ? Math.round(d / 100) / 10 + 'K':
-            Math.round(d * 10) / 10
-        );
+        const scaleYLabel = (d: number) =>
+            d >= 1000000000000
+                ? Math.round(d / 100000000000) / 10 + 'G'
+                : d >= 1000000000
+                ? Math.round(d / 100000000) / 10 + 'B'
+                : d >= 1000000
+                ? Math.round(d / 100000) / 10 + 'M'
+                : d >= 1000
+                ? Math.round(d / 100) / 10 + 'K'
+                : Math.round(d * 10) / 10;
 
         if (this.state.allMax > 0) {
-            select(this.yAxisRef.current).call(axisLeft(yScale).tickSizeOuter(0).ticks(4)).call(g => g.select('.domain').remove());
-            select(this.yAxisRef.current).selectAll('.tick text').style('font-size', '11px').text((d: any) => scaleYLabel(d));
+            select(this.yAxisRef.current)
+                .call(axisLeft(yScale).tickSizeOuter(0).ticks(4))
+                .call(g => g.select('.domain').remove());
+            select(this.yAxisRef.current)
+                .selectAll('.tick text')
+                .style('font-size', '11px')
+                .text((d: any) => scaleYLabel(d));
         }
 
-        return <React.Fragment>
-            <svg height={chartHeight} width={this.margin.left}>
-                <g className='y-axis' ref={this.yAxisRef} transform={yTransform} />
-            </svg>
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                <svg height={chartHeight} width={this.margin.left}>
+                    <g className="y-axis" ref={this.yAxisRef} transform={yTransform} />
+                </svg>
+            </React.Fragment>
+        );
     }
 
     resultsAreEmpty(): boolean {
@@ -406,9 +438,18 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
             end = viewRange.getEnd();
         }
 
-        const xyDataParameters = QueryHelper.selectionTimeRangeQuery(start, end, this.getChartWidth(), this.state.checkedSeries);
+        const xyDataParameters = QueryHelper.selectionTimeRangeQuery(
+            start,
+            end,
+            this.getChartWidth(),
+            this.state.checkedSeries
+        );
 
-        const tspClientResponse = await this.props.tspClient.fetchXY(this.props.traceId, this.props.outputDescriptor.id, xyDataParameters);
+        const tspClientResponse = await this.props.tspClient.fetchXY(
+            this.props.traceId,
+            this.props.outputDescriptor.id,
+            xyDataParameters
+        );
         const xyDataResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && xyDataResponse?.model?.series) {
             const series = xyDataResponse.model.series;
@@ -428,7 +469,9 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
     private viewSpinner(status: boolean): void {
         if (document.getElementById(this.getOutputComponentDomId() + 'handleSpinner')) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            document.getElementById(this.getOutputComponentDomId() + 'handleSpinner')!.style.visibility = status ? 'visible' : 'hidden';
+            document.getElementById(this.getOutputComponentDomId() + 'handleSpinner')!.style.visibility = status
+                ? 'visible'
+                : 'hidden';
         }
     }
 
@@ -467,7 +510,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
 
         // flushSync: force immediate state update instead of waiting for React 18's automatic batching
         flushSync(() => {
-            this.setState({ xyData: scatterData});
+            this.setState({ xyData: scatterData });
         });
 
         this.calculateYRange();
@@ -502,8 +545,18 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
     }
 
     private getSeriesColor(key: string): string {
-        const colors = ['rgba(191, 33, 30, 1)', 'rgba(30, 56, 136, 1)', 'rgba(71, 168, 189, 1)', 'rgba(245, 230, 99, 1)', 'rgba(255, 173, 105, 1)',
-            'rgba(216, 219, 226, 1)', 'rgba(212, 81, 19, 1)', 'rgba(187, 155, 176  , 1)', 'rgba(6, 214, 160, 1)', 'rgba(239, 71, 111, 1)'];
+        const colors = [
+            'rgba(191, 33, 30, 1)',
+            'rgba(30, 56, 136, 1)',
+            'rgba(71, 168, 189, 1)',
+            'rgba(245, 230, 99, 1)',
+            'rgba(255, 173, 105, 1)',
+            'rgba(216, 219, 226, 1)',
+            'rgba(212, 81, 19, 1)',
+            'rgba(187, 155, 176  , 1)',
+            'rgba(6, 214, 160, 1)',
+            'rgba(239, 71, 111, 1)'
+        ];
         let colorIndex = this.colorMap.get(key);
         if (colorIndex === undefined) {
             colorIndex = this.currentColorIndex % colors.length;
@@ -544,8 +597,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         const offset = range.getOffset() ?? BigInt(0);
         const duration = range.getDuration();
         const chartWidth = this.getChartWidth() === 0 ? 1 : this.getChartWidth();
-        const time = range.getStart() - offset +
-            BIMath.round(x / chartWidth * Number(duration));
+        const time = range.getStart() - offset + BIMath.round((x / chartWidth) * Number(duration));
         return time;
     }
 
@@ -554,7 +606,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         const start = range.getStart();
         const duration = range.getDuration();
         const chartWidth = this.getChartWidth() === 0 ? 1 : this.getChartWidth();
-        const x = Number(time - start) / Number(duration) * chartWidth;
+        const x = (Number(time - start) / Number(duration)) * chartWidth;
         return x;
     }
 
@@ -563,8 +615,11 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
             const zoomCenterTime = this.getZoomTime();
             const startDistance = zoomCenterTime - this.props.unitController.viewRange.start;
             const zoomFactor = isZoomIn ? ZOOM_IN_RATE : ZOOM_OUT_RATE;
-            const newDuration = BIMath.clamp(Number(this.props.unitController.viewRangeLength) * zoomFactor,
-                BigInt(2), this.props.unitController.absoluteRange);
+            const newDuration = BIMath.clamp(
+                Number(this.props.unitController.viewRangeLength) * zoomFactor,
+                BigInt(2),
+                this.props.unitController.absoluteRange
+            );
             const newStartRange = BIMath.max(0, zoomCenterTime - BIMath.round(Number(startDistance) * zoomFactor));
             const newEndRange = newStartRange + newDuration;
             this.updateRange(newStartRange, newEndRange);
@@ -575,8 +630,8 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
         const panFactor = 0.1;
         const percentRange = BIMath.round(Number(this.props.unitController.viewRangeLength) * panFactor);
         const panNumber = panLeft ? BigInt(-1) : BigInt(1);
-        const startRange = this.props.unitController.viewRange.start + (panNumber * percentRange);
-        const endRange = this.props.unitController.viewRange.end + (panNumber * percentRange);
+        const startRange = this.props.unitController.viewRange.start + panNumber * percentRange;
+        const endRange = this.props.unitController.viewRange.end + panNumber * percentRange;
         if (startRange < 0) {
             this.props.unitController.viewRange = {
                 start: BigInt(0),
@@ -603,7 +658,9 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
             timeLabel = this.props.unitController.numberTranslator(timeForX);
         }
         const chartWidth = this.isBarPlot ? this.getChartWidth() : this.chartRef.current.chartInstance.width;
-        const chartHeight = this.isBarPlot ? parseInt(this.props.style.height.toString()) : this.chartRef.current.chartInstance.height;
+        const chartHeight = this.isBarPlot
+            ? parseInt(this.props.style.height.toString())
+            : this.chartRef.current.chartInstance.height;
         const arraySize = this.state.xyData.labels.length;
         const index = Math.max(Math.round((xPos / chartWidth) * (arraySize - 1)), 0);
         const points: any = [];
@@ -626,7 +683,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
                         range: this.getDisplayedRange(),
                         margin: this.margin,
                         allMax: this.state.allMax,
-                        allMin: this.state.allMin,
+                        allMin: this.state.allMin
                     };
 
                     // Find the data point that is the closest to the mouse position
@@ -646,7 +703,7 @@ export abstract class AbstractXYOutputComponent<P extends AbstractOutputProps, S
                 // calculate nearest value.
                 yValue = d.data[index];
             }
-            const rounded: number = isNaN(yValue) ? 0 : (Math.round(Number(yValue) * 100) / 100);
+            const rounded: number = isNaN(yValue) ? 0 : Math.round(Number(yValue) * 100) / 100;
             let formatted: string = new Intl.NumberFormat().format(rounded);
 
             if (this.isScatterPlot && this.props.unitController.numberTranslator) {

--- a/packages/react-components/src/components/data-providers/style-provider.ts
+++ b/packages/react-components/src/components/data-providers/style-provider.ts
@@ -75,8 +75,10 @@ export class StyleProvider {
             }
         };
         this.tmpStyleObject = {
-            'org.eclipse.tracecompass.internal.analysis.os.linux.core.threadstatus.ThreadStatusDataProvider': threadStyleObject,
-            'org.eclipse.tracecompass.internal.analysis.os.linux.core.threadstatus.ResourcesStatusDataProvider': resourceStyleObject
+            'org.eclipse.tracecompass.internal.analysis.os.linux.core.threadstatus.ThreadStatusDataProvider':
+                threadStyleObject,
+            'org.eclipse.tracecompass.internal.analysis.os.linux.core.threadstatus.ResourcesStatusDataProvider':
+                resourceStyleObject
         };
     }
 
@@ -86,7 +88,11 @@ export class StyleProvider {
      */
     public async getStyleModel(forceUpdate?: boolean): Promise<OutputStyleModel | undefined> {
         if (!this.styleModel || forceUpdate) {
-            const tspClientResponse = await this.tspClient.fetchStyles(this.traceId, this.outputId, QueryHelper.query());
+            const tspClientResponse = await this.tspClient.fetchStyles(
+                this.traceId,
+                this.outputId,
+                QueryHelper.query()
+            );
             const styleResponse = tspClientResponse.getModel();
             if (tspClientResponse.isOk() && styleResponse) {
                 this.styleModel = styleResponse.model;
@@ -154,7 +160,7 @@ export class StyleProvider {
             const value = styleValues[property];
             if (typeof value === 'number') {
                 const numberValue = value as number;
-                return (factor === undefined) ? numberValue : factor * numberValue;
+                return factor === undefined ? numberValue : factor * numberValue;
             }
 
             // Get the next style
@@ -176,7 +182,10 @@ export class StyleProvider {
      *            the style property
      * @return the style property color value, or undefined
      */
-    public getColorStyle(elementStyle: OutputElementStyle, property: string): { color: number, alpha: number } | undefined {
+    public getColorStyle(
+        elementStyle: OutputElementStyle,
+        property: string
+    ): { color: number; alpha: number } | undefined {
         let color: string | undefined = undefined;
         let opacity: number | undefined = undefined;
         let blend = undefined;
@@ -212,9 +221,14 @@ export class StyleProvider {
             // Get the next style
             style = this.popNextStyle(style, styleQueue);
         }
-        const alpha = (opacity === undefined) ? 1.0 : opacity;
-        const rgba = (color === undefined) ? (opacity === undefined ? undefined : this.rgbaToColor(0, 0, 0, alpha)) : this.rgbStringToColor(color, alpha);
-        return (rgba === undefined) ? undefined : (blend === undefined) ? rgba : this.blend(rgba, blend);
+        const alpha = opacity === undefined ? 1.0 : opacity;
+        const rgba =
+            color === undefined
+                ? opacity === undefined
+                    ? undefined
+                    : this.rgbaToColor(0, 0, 0, alpha)
+                : this.rgbStringToColor(color, alpha);
+        return rgba === undefined ? undefined : blend === undefined ? rgba : this.blend(rgba, blend);
     }
 
     private popNextStyle(style: OutputElementStyle, styleQueue: string[]): OutputElementStyle | undefined {
@@ -235,7 +249,10 @@ export class StyleProvider {
         return nextStyle;
     }
 
-    private blend(color1: { color: number, alpha: number }, color2: { color: number, alpha: number }): { color: number, alpha: number } {
+    private blend(
+        color1: { color: number; alpha: number },
+        color2: { color: number; alpha: number }
+    ): { color: number; alpha: number } {
         /**
          * If a color component 'c' with alpha 'a' is blended with color
          * component 'd' with alpha 'b', the blended color and alpha are:
@@ -246,9 +263,21 @@ export class StyleProvider {
          * </pre>
          */
         const alpha = color1.alpha + color2.alpha - color1.alpha * color2.alpha;
-        const r = this.blendComponent(color1.alpha, (color1.color >> 16) & 0xff, color2.alpha, (color2.color >> 16) & 0xff, alpha);
-        const g = this.blendComponent(color1.alpha, (color1.color >> 8) & 0xff, color2.alpha, (color2.color >> 8) & 0xff, alpha);
-        const b = this.blendComponent(color1.alpha, (color1.color) & 0xff, color2.alpha, (color2.color) & 0xff, alpha);
+        const r = this.blendComponent(
+            color1.alpha,
+            (color1.color >> 16) & 0xff,
+            color2.alpha,
+            (color2.color >> 16) & 0xff,
+            alpha
+        );
+        const g = this.blendComponent(
+            color1.alpha,
+            (color1.color >> 8) & 0xff,
+            color2.alpha,
+            (color2.color >> 8) & 0xff,
+            alpha
+        );
+        const b = this.blendComponent(color1.alpha, color1.color & 0xff, color2.alpha, color2.color & 0xff, alpha);
         return this.rgbaToColor(r, g, b, alpha);
     }
 
@@ -256,19 +285,19 @@ export class StyleProvider {
         return Math.floor((alpha1 * (1.0 - alpha2) * color1 + alpha2 * color2) / alpha);
     }
 
-    private rgbStringToColor(rgbString: string, alpha: number): { color: number, alpha: number } {
+    private rgbStringToColor(rgbString: string, alpha: number): { color: number; alpha: number } {
         const color = parseInt(rgbString.replace(/^#/, ''), 16);
         return { color, alpha };
     }
 
-    private rgbaStringToColor(rgbaString: string): { color: number, alpha: number } {
+    private rgbaStringToColor(rgbaString: string): { color: number; alpha: number } {
         const int = parseInt(rgbaString.replace(/^#/, ''), 16);
         const color = (int >> 8) & 0xffffff;
         const alpha = (int & 0xff) / 255;
         return { color, alpha };
     }
 
-    private rgbaToColor(r: number, g: number, b: number, alpha: number): { color: number, alpha: number } {
+    private rgbaToColor(r: number, g: number, b: number, alpha: number): { color: number; alpha: number } {
         const color = (r << 16) + (g << 8) + b;
         return { color, alpha };
     }

--- a/packages/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/packages/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
-import { TimeGraphArrow, TimeGraphEntry, TimeGraphRow, TimeGraphState } from 'tsp-typescript-client/lib/models/timegraph';
+import {
+    TimeGraphArrow,
+    TimeGraphEntry,
+    TimeGraphRow,
+    TimeGraphState
+} from 'tsp-typescript-client/lib/models/timegraph';
 import { TimeGraphStateComponent } from 'timeline-chart/lib/components/time-graph-state';
 import { TimeGraphAnnotationComponent } from 'timeline-chart/lib/components/time-graph-annotation';
 import { TimelineChart } from 'timeline-chart/lib/time-graph-model';
@@ -42,8 +47,15 @@ export class TspDataProvider {
      * @param annotationMarkers requested annotation categories
      * @returns time graph model
      */
-    async getData(ids: number[], entries: TimeGraphEntry[], totalTimeRange: TimeRange, worldRange?: TimelineChart.TimeGraphRange,
-        nbTimes?: number, annotationMarkers?: string[], markerSetId?: string): Promise<TimelineChart.TimeGraphModel> {
+    async getData(
+        ids: number[],
+        entries: TimeGraphEntry[],
+        totalTimeRange: TimeRange,
+        worldRange?: TimelineChart.TimeGraphRange,
+        nbTimes?: number,
+        annotationMarkers?: string[],
+        markerSetId?: string
+    ): Promise<TimelineChart.TimeGraphModel> {
         this.timeGraphEntries = [...entries];
         if (!this.timeGraphEntries.length || !worldRange || !nbTimes) {
             return {
@@ -80,7 +92,11 @@ export class TspDataProvider {
         const arrowsPromise = this.client.fetchTimeGraphArrows(this.traceUUID, this.outputId, fetchParameters);
 
         // Wait for responses
-        const [tspClientAnnotationsResponse, tspClientStatesResponse, tspClientArrowsResponse] = await Promise.all([annotationsPromise, statesPromise, arrowsPromise]);
+        const [tspClientAnnotationsResponse, tspClientStatesResponse, tspClientArrowsResponse] = await Promise.all([
+            annotationsPromise,
+            statesPromise,
+            arrowsPromise
+        ]);
 
         // the start time which is normalized to logical 0 in timeline chart.
         const chartStart = totalTimeRange.getStart();
@@ -145,9 +161,11 @@ export class TspDataProvider {
         };
     }
 
-    private getArrows(tspClientArrowsResponse: TspClientResponse<GenericResponse<TimeGraphArrow[]>>,
-        viewRange?: TimelineChart.TimeGraphRange, nbTimes?: number): TimelineChart.TimeGraphArrow[] {
-
+    private getArrows(
+        tspClientArrowsResponse: TspClientResponse<GenericResponse<TimeGraphArrow[]>>,
+        viewRange?: TimelineChart.TimeGraphRange,
+        nbTimes?: number
+    ): TimelineChart.TimeGraphArrow[] {
         let timeGraphArrows: TimeGraphArrow[] = [];
         if (viewRange && nbTimes) {
             const stateResponseArrows = tspClientArrowsResponse.getModel();
@@ -156,15 +174,17 @@ export class TspDataProvider {
             }
         }
         const offset = this.timeGraphEntries[0].start;
-        const arrows = timeGraphArrows.map(arrow => ({
-                sourceId: arrow.sourceId,
-                destinationId: arrow.targetId,
-                range: {
-                    start: arrow.start - offset,
-                    end: arrow.end - offset
-                } as TimelineChart.TimeGraphRange
-            } as TimelineChart.TimeGraphArrow
-        ));
+        const arrows = timeGraphArrows.map(
+            arrow =>
+                ({
+                    sourceId: arrow.sourceId,
+                    destinationId: arrow.targetId,
+                    range: {
+                        start: arrow.start - offset,
+                        end: arrow.end - offset
+                    } as TimelineChart.TimeGraphRange
+                } as TimelineChart.TimeGraphArrow)
+        );
         return arrows;
     }
 
@@ -175,7 +195,10 @@ export class TspDataProvider {
             if (timeGraphRow) {
                 newTimeGraphRows.push(timeGraphRow);
             } else {
-                const emptyRow: TimeGraphRow = { states: [{ start: BigInt(0), end: BigInt(0), label: '', tags: 0 }], entryId: id };
+                const emptyRow: TimeGraphRow = {
+                    states: [{ start: BigInt(0), end: BigInt(0), label: '', tags: 0 }],
+                    entryId: id
+                };
                 newTimeGraphRows.push(emptyRow);
             }
         });
@@ -256,7 +279,10 @@ export class TspDataProvider {
         };
     }
 
-    async fetchStateTooltip(element: TimeGraphStateComponent, viewRange: TimeRange): Promise<{ [key: string]: string } | undefined> {
+    async fetchStateTooltip(
+        element: TimeGraphStateComponent,
+        viewRange: TimeRange
+    ): Promise<{ [key: string]: string } | undefined> {
         const offset = viewRange.getOffset() ? viewRange.getOffset() : BigInt(0);
         // use start of state for fetching tooltip since hover time is not available
         const time = element.model.range.start + (offset ? offset : BigInt(0));
@@ -266,12 +292,17 @@ export class TspDataProvider {
             duration: element.model.range.end - element.model.range.start
         };
         const entryId = [element.row.model.id];
-        const parameters = QueryHelper.selectionTimeQuery([time], entryId, { [QueryHelper.REQUESTED_ELEMENT_KEY]: requestedElement });
+        const parameters = QueryHelper.selectionTimeQuery([time], entryId, {
+            [QueryHelper.REQUESTED_ELEMENT_KEY]: requestedElement
+        });
         const tooltipResponse = await this.client.fetchTimeGraphTooltip(this.traceUUID, this.outputId, parameters);
         return tooltipResponse.getModel()?.model;
     }
 
-    async fetchAnnotationTooltip(element: TimeGraphAnnotationComponent, viewRange: TimeRange): Promise<{ [key: string]: string } | undefined> {
+    async fetchAnnotationTooltip(
+        element: TimeGraphAnnotationComponent,
+        viewRange: TimeRange
+    ): Promise<{ [key: string]: string } | undefined> {
         const elementRange = element.model.range;
         const offset = viewRange.getOffset() ? viewRange.getOffset() : BigInt(0);
         const time = elementRange.start + (offset ? offset : BigInt(0));
@@ -282,7 +313,9 @@ export class TspDataProvider {
             entryId: element.row.model.id
         };
         const entryId = [element.row.model.id];
-        const parameters = QueryHelper.selectionTimeQuery([time], entryId, { [QueryHelper.REQUESTED_ELEMENT_KEY]: requestedElement });
+        const parameters = QueryHelper.selectionTimeQuery([time], entryId, {
+            [QueryHelper.REQUESTED_ELEMENT_KEY]: requestedElement
+        });
         const tooltipResponse = await this.client.fetchTimeGraphTooltip(this.traceUUID, this.outputId, parameters);
         return tooltipResponse.getModel()?.model;
     }

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -16,8 +16,7 @@ import '../../style/react-contextify.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
-type DataTreeOutputProps = AbstractOutputProps & {
-};
+type DataTreeOutputProps = AbstractOutputProps & {};
 
 type DataTreeOuputState = AbstractOutputState & {
     selectedSeriesId: number[];
@@ -42,7 +41,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
             xyTree: [],
             collapsedNodes: [],
             orderedNodes: [],
-            columns: [{title: 'Name', sortable: true}],
+            columns: [{ title: 'Name', sortable: true }]
         };
         this.addPinViewOptions();
         this.addOptions('Export to CSV...', () => this.exportOutput());
@@ -63,7 +62,13 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
                 const columns = [];
                 if (headers && headers.length > 0) {
                     headers.forEach(header => {
-                        columns.push({ title: header.name, sortable: true, resizable: true, tooltip: header.tooltip, dataType: header.dataType });
+                        columns.push({
+                            title: header.name,
+                            sortable: true,
+                            resizable: true,
+                            tooltip: header.tooltip,
+                            dataType: header.dataType
+                        });
                     });
                 } else {
                     columns.push({ title: 'Name', sortable: true });
@@ -93,11 +98,12 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
     renderTree(): React.ReactNode | undefined {
         this.onToggleCollapse = this.onToggleCollapse.bind(this);
         this.onOrderChange = this.onOrderChange.bind(this);
-        return this.state.xyTree.length
-            ? <div
+        return this.state.xyTree.length ? (
+            <div
                 tabIndex={0}
                 id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
-                className='scrollable' style={{ height: this.props.style.height }}
+                className="scrollable"
+                style={{ height: this.props.style.height }}
             >
                 <EntryTree
                     entries={this.state.xyTree}
@@ -109,32 +115,38 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
                     headers={this.state.columns}
                 />
             </div>
-            : undefined
-            ;
+        ) : undefined;
     }
 
     renderMainArea(): React.ReactNode {
-        return <React.Fragment>
-            {this.state.outputStatus === ResponseStatus.COMPLETED ?
-                <div>
-                    {this.renderContextMenu()}
-                    <div ref={this.treeRef} className='output-component-tree disable-select'
-                        style={{ height: this.props.style.height, width: this.props.outputWidth - this.getHandleWidth() }}
-                    >
-                        {this.renderTree()}
+        return (
+            <React.Fragment>
+                {this.state.outputStatus === ResponseStatus.COMPLETED ? (
+                    <div>
+                        {this.renderContextMenu()}
+                        <div
+                            ref={this.treeRef}
+                            className="output-component-tree disable-select"
+                            style={{
+                                height: this.props.style.height,
+                                width: this.props.outputWidth - this.getHandleWidth()
+                            }}
+                        >
+                            {this.renderTree()}
+                        </div>
                     </div>
-                </div>
-                :
-                <div tabIndex={0} id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'} className='analysis-running-main-area'>
-                    <FontAwesomeIcon
-                        icon={faSpinner}
-                        spin
-                        style={{ marginRight: '5px' }}
-                    />
-                    <span>Analysis running</span>
-                </div>
-            }
-        </React.Fragment>;
+                ) : (
+                    <div
+                        tabIndex={0}
+                        id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
+                        className="analysis-running-main-area"
+                    >
+                        <FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />
+                        <span>Analysis running</span>
+                    </div>
+                )}
+            </React.Fragment>
+        );
     }
 
     renderContextMenu(): React.ReactNode {
@@ -145,16 +157,28 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
                 timeRanges.push(col.title);
             }
         });
-        return <React.Fragment> {
-            <Menu id={MENU_ID + this.props.outputDescriptor.id} theme={this.props.backgroundTheme} animation={'fade'} >
-                {(timeRanges && timeRanges.length > 0) ?
-                       timeRanges.map(key => <Item key={key} id={key} onClick={this.handleItemClick}>Select {key}</Item>)
-                    :
-                    <></>
+        return (
+            <React.Fragment>
+                {' '}
+                {
+                    <Menu
+                        id={MENU_ID + this.props.outputDescriptor.id}
+                        theme={this.props.backgroundTheme}
+                        animation={'fade'}
+                    >
+                        {timeRanges && timeRanges.length > 0 ? (
+                            timeRanges.map(key => (
+                                <Item key={key} id={key} onClick={this.handleItemClick}>
+                                    Select {key}
+                                </Item>
+                            ))
+                        ) : (
+                            <></>
+                        )}
+                    </Menu>
                 }
-            </Menu>
-        }
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 
     protected handleItemClick = (args: ItemParams): void => {
@@ -211,25 +235,25 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
 
             if (Object.keys(timeProperties).length > 0) {
                 const { show } = useContextMenu({
-                    id: MENU_ID + this.props.outputDescriptor.id,
+                    id: MENU_ID + this.props.outputDescriptor.id
                 });
 
                 show(event, {
                     props: {
-                        data: timeProperties,
+                        data: timeProperties
                     },
                     position: this.getMenuPosition(event)
                 });
             }
         }
     }
-    getMenuPosition(event: React.MouseEvent<HTMLDivElement>): { x: number, y: number } {
+    getMenuPosition(event: React.MouseEvent<HTMLDivElement>): { x: number; y: number } {
         const refNode = this.treeRef.current;
         if (refNode) {
             return {
                 // Compute position relative to treeRef
-                x: (event.clientX - refNode.getBoundingClientRect().left),
-                y: (event.clientY - refNode.getBoundingClientRect().top)
+                x: event.clientX - refNode.getBoundingClientRect().left,
+                y: event.clientY - refNode.getBoundingClientRect().top
             };
         }
         return {
@@ -274,9 +298,15 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
         if (this.props.selectionRange) {
             let payload: any;
             if (this.props.selectionRange.getStart() < this.props.selectionRange.getEnd()) {
-                payload = QueryHelper.timeRangeQuery(this.props.selectionRange.getStart(), this.props.selectionRange.getEnd());
+                payload = QueryHelper.timeRangeQuery(
+                    this.props.selectionRange.getStart(),
+                    this.props.selectionRange.getEnd()
+                );
             } else {
-                payload = QueryHelper.timeRangeQuery(this.props.selectionRange.getEnd(), this.props.selectionRange.getStart());
+                payload = QueryHelper.timeRangeQuery(
+                    this.props.selectionRange.getEnd(),
+                    this.props.selectionRange.getStart()
+                );
             }
 
             payload.parameters.isFiltered = true;
@@ -288,7 +318,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
                 if (treeResponse.model) {
                     this.setState({
                         outputStatus: treeResponse.status,
-                        xyTree: treeResponse.model.entries,
+                        xyTree: treeResponse.model.entries
                     });
                 }
             }
@@ -302,7 +332,9 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
     }
 
     private async exportOutput(): Promise<void> {
-        const focusContainer = document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'focusContainer');
+        const focusContainer = document.getElementById(
+            this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'
+        );
         if (focusContainer) {
             const table = focusContainer.querySelector('div:nth-child(2) > table');
             if (table) {
@@ -334,10 +366,18 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
     }
 
     private async tryFetchDataTree(payload: any) {
-        let tspClientResponse = await this.props.tspClient.fetchDataTree(this.props.traceId, this.props.outputDescriptor.id, payload);
+        let tspClientResponse = await this.props.tspClient.fetchDataTree(
+            this.props.traceId,
+            this.props.outputDescriptor.id,
+            payload
+        );
         if (!tspClientResponse.isOk()) {
             // Older trace servers might not support fetchDatatTree endpoint. Fall-back to fetchXYTree
-            tspClientResponse = await this.props.tspClient.fetchXYTree(this.props.traceId, this.props.outputDescriptor.id, payload);
+            tspClientResponse = await this.props.tspClient.fetchXYTree(
+                this.props.traceId,
+                this.props.outputDescriptor.id,
+                payload
+            );
         }
         return tspClientResponse;
     }

--- a/packages/react-components/src/components/drop-down-component.tsx
+++ b/packages/react-components/src/components/drop-down-component.tsx
@@ -23,21 +23,18 @@ export class DropDownOption extends React.Component<OptionProps, OptionState> {
             label: props.label,
             onClick: props.onClick ?? undefined,
             arg: props.arg ?? undefined,
-            condition: props.condition ?? (() => true),
+            condition: props.condition ?? (() => true)
         };
     }
 
     render(): JSX.Element {
         return (
             <React.Fragment>
-                {this.state.condition?.() &&
-                    <li
-                        className="drop-down-list-item"
-                        onClick={() => this.state.onClick?.(this.state.arg?.())}
-                    >
+                {this.state.condition?.() && (
+                    <li className="drop-down-list-item" onClick={() => this.state.onClick?.(this.state.arg?.())}>
                         <div className="drop-down-list-item-text">{this.state.label}</div>
                     </li>
-                }
+                )}
             </React.Fragment>
         );
     }
@@ -45,7 +42,7 @@ export class DropDownOption extends React.Component<OptionProps, OptionState> {
 
 type DropDownProps = AbstractOutputProps & {
     dropDownOptions: OptionState[];
-    dropDownOpen: boolean
+    dropDownOpen: boolean;
 };
 
 export class DropDownComponent extends React.Component<DropDownProps> {
@@ -57,20 +54,18 @@ export class DropDownComponent extends React.Component<DropDownProps> {
     }
 
     render(): JSX.Element {
-        return <React.Fragment>
-            {this.props.dropDownOpen && (
-                <div className='options-menu-drop-down' ref={this.optionsMenuRef}>
-                    <ul>
-                        {this.props.dropDownOptions?.map((option, index) => (
-                            <DropDownOption
-                                {...this.props}
-                                key={index}
-                                {...option}
-                            />
-                        ))}
-                    </ul>
-                </div>
-            )}
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                {this.props.dropDownOpen && (
+                    <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
+                        <ul>
+                            {this.props.dropDownOptions?.map((option, index) => (
+                                <DropDownOption {...this.props} key={index} {...option} />
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </React.Fragment>
+        );
     }
 }

--- a/packages/react-components/src/components/null-output-component.tsx
+++ b/packages/react-components/src/components/null-output-component.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import { ResponseStatus } from 'tsp-typescript-client';
 import { AbstractOutputComponent, AbstractOutputProps, AbstractOutputState } from './abstract-output-component';
 
-type NullOutputState = AbstractOutputState & {
-};
+type NullOutputState = AbstractOutputState & {};
 
-type NullOutputProps = AbstractOutputProps & {
-};
+type NullOutputProps = AbstractOutputProps & {};
 
 export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps, NullOutputState> {
     constructor(props: NullOutputProps) {
@@ -17,12 +15,14 @@ export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps
     }
 
     renderMainArea(): React.ReactNode {
-        return <React.Fragment>
-            <div className='message-main-area'>
-                Not implemented yet!
-                <br />
-            </div>
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                <div className="message-main-area">
+                    Not implemented yet!
+                    <br />
+                </div>
+            </React.Fragment>
+        );
     }
 
     resultsAreEmpty(): boolean {
@@ -32,4 +32,4 @@ export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps
     setFocus(): void {
         return;
     }
-  }
+}

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -3,7 +3,16 @@ import { AbstractOutputComponent, AbstractOutputProps, AbstractOutputState } fro
 import * as React from 'react';
 import { flushSync } from 'react-dom';
 import { AgGridReact } from 'ag-grid-react';
-import { ColDef, IDatasource, GridReadyEvent, CellClickedEvent, GridApi, ColumnApi, Column, RowNode } from 'ag-grid-community';
+import {
+    ColDef,
+    IDatasource,
+    GridReadyEvent,
+    CellClickedEvent,
+    GridApi,
+    ColumnApi,
+    Column,
+    RowNode
+} from 'ag-grid-community';
 import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper';
 import { cloneDeep } from 'lodash';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
@@ -77,7 +86,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         this.state = {
             outputStatus: ResponseStatus.RUNNING,
             tableColumns: [],
-            showToggleColumns: false,
+            showToggleColumns: false
         };
 
         this.frameworkComponents = {
@@ -113,44 +122,47 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     }
 
     renderMainArea(): React.ReactNode {
-        return <div id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
-            tabIndex={-1}
-            onFocus={event => this.checkFocus(event)}
-            className={this.props.backgroundTheme === 'light' ? 'ag-theme-balham' : 'ag-theme-balham-dark'}
-            style={{
-                height: this.props.style.height,
-                width: this.props.outputWidth,
-                display: 'flex',
-                flexDirection: 'column'
-            }}>
-            <AgGridReact
-                columnDefs={this.columnArray}
-                rowModelType='infinite'
-                cacheBlockSize={this.props.cacheBlockSize}
-                maxBlocksInCache={this.props.maxBlocksInCache}
-                blockLoadDebounceMillis={this.props.blockLoadDebounce}
-                pagination={true}
-                paginationPageSize={this.paginationPageSize}
-                suppressPaginationPanel={true}
-                debug={this.debugMode}
-                onGridReady={this.onGridReady}
-                onCellClicked={this.onEventClick}
-                rowSelection='multiple'
-                onModelUpdated={this.onModelUpdated}
-                onCellKeyDown={this.onKeyDown}
-                components={this.frameworkComponents}
-                enableBrowserTooltips={true}
+        return (
+            <div
+                id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
+                tabIndex={-1}
+                onFocus={event => this.checkFocus(event)}
+                className={this.props.backgroundTheme === 'light' ? 'ag-theme-balham' : 'ag-theme-balham-dark'}
+                style={{
+                    height: this.props.style.height,
+                    width: this.props.outputWidth,
+                    display: 'flex',
+                    flexDirection: 'column'
+                }}
             >
-            </AgGridReact>
-            {this.pagination &&
-                <PaginationBarComponent
+                <AgGridReact
+                    columnDefs={this.columnArray}
+                    rowModelType="infinite"
+                    cacheBlockSize={this.props.cacheBlockSize}
+                    maxBlocksInCache={this.props.maxBlocksInCache}
+                    blockLoadDebounceMillis={this.props.blockLoadDebounce}
+                    pagination={true}
                     paginationPageSize={this.paginationPageSize}
-                    paginationTotalPages={this.paginationTotalPages}
-                    nbEvents={this.props.nbEvents}
-                    gridApi={this?.gridApi}
-                />
-            }
-        </div>;
+                    suppressPaginationPanel={true}
+                    debug={this.debugMode}
+                    onGridReady={this.onGridReady}
+                    onCellClicked={this.onEventClick}
+                    rowSelection="multiple"
+                    onModelUpdated={this.onModelUpdated}
+                    onCellKeyDown={this.onKeyDown}
+                    components={this.frameworkComponents}
+                    enableBrowserTooltips={true}
+                ></AgGridReact>
+                {this.pagination && (
+                    <PaginationBarComponent
+                        paginationPageSize={this.paginationPageSize}
+                        paginationTotalPages={this.paginationTotalPages}
+                        nbEvents={this.props.nbEvents}
+                        gridApi={this?.gridApi}
+                    />
+                )}
+            </div>
+        );
     }
 
     resultsAreEmpty(): boolean {
@@ -158,7 +170,9 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     }
 
     componentDidMount(): void {
-        this.props.unitController.onSelectionRangeChange(range => { this.handleTimeSelectionChange(range); });
+        this.props.unitController.onSelectionRangeChange(range => {
+            this.handleTimeSelectionChange(range);
+        });
     }
 
     private checkFocus(event: React.FocusEvent<HTMLDivElement, Element>): void {
@@ -202,7 +216,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         const rowIndex = event.rowIndex ?? 0;
         const itemPropsObj: { [key: string]: string } | undefined = this.fetchItemProperties(columns, data);
 
-        const currTimestamp = (this.timestampCol && data) ? data[this.timestampCol] : undefined;
+        const currTimestamp = this.timestampCol && data ? data[this.timestampCol] : undefined;
         this.enableIndexSelection = true;
         if (mouseEvent.shiftKey) {
             if (this.selectStartIndex === -1) {
@@ -252,7 +266,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         const keyEvent = event.event as KeyboardEvent;
         const rowIndex = event.rowIndex ?? 0;
         this.enableIndexSelection = true;
-        const currTimestamp = (this.timestampCol && event.data) ? event.data[this.timestampCol] : undefined;
+        const currTimestamp = this.timestampCol && event.data ? event.data[this.timestampCol] : undefined;
 
         if (gridApi) {
             let nextRow;
@@ -275,7 +289,11 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                             this.selectStartIndex = this.selectEndIndex = nextRow.rowIndex;
                         }
                     } else {
-                        if (this.selectStartIndex && this.selectEndIndex && this.selectEndIndex < this.selectStartIndex) {
+                        if (
+                            this.selectStartIndex &&
+                            this.selectEndIndex &&
+                            this.selectEndIndex < this.selectStartIndex
+                        ) {
                             if (currentRow && currentRow.id) {
                                 currentRow.setSelected(false);
                             }
@@ -318,7 +336,6 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                             this.endTimestamp = BigInt(nextRow.data[this.timestampCol]);
                         }
                     }
-
                 } else if (keyEvent.code === 'Space') {
                     this.selectEndIndex = rowIndex;
                     if (currTimestamp) {
@@ -477,7 +494,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         }
     }
 
-    private handleSelectionRangeUpdate(payload: { [key: string]: string; }) {
+    private handleSelectionRangeUpdate(payload: { [key: string]: string }) {
         const offset = this.props.viewRange.getOffset() || BigInt(0);
         const startTimestamp = payload['startTimestamp'];
         const endTimestamp = payload['endTimestamp'];
@@ -512,11 +529,14 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                 this.selectStartIndex = this.selectEndIndex = -1;
                 this.gridApi.deselectAll();
 
-                const index = await this.fetchTableIndex(this.startTimestamp > this.endTimestamp ? this.startTimestamp + BigInt(1) : this.startTimestamp);
+                const index = await this.fetchTableIndex(
+                    this.startTimestamp > this.endTimestamp ? this.startTimestamp + BigInt(1) : this.startTimestamp
+                );
                 if (index) {
                     const startIndex = this.startTimestamp > this.endTimestamp ? index - 1 : index;
                     this.selectStartIndex = this.selectStartIndex === -1 ? startIndex : this.selectStartIndex;
-                    this.selectEndIndex = (this.enableIndexSelection && this.selectEndIndex === -1) ? startIndex : this.selectEndIndex;
+                    this.selectEndIndex =
+                        this.enableIndexSelection && this.selectEndIndex === -1 ? startIndex : this.selectEndIndex;
                     this.updatePageIndex(index);
                     this.selectRows();
                 }
@@ -530,8 +550,11 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         const traceUUID = this.props.traceId;
         const tspClient = this.props.tspClient;
         const outputId = this.props.outputDescriptor.id;
-        const tspClientResponse = await tspClient.fetchTableLines(traceUUID, outputId,
-            QueryHelper.timeQuery([timestamp], { [QueryHelper.REQUESTED_TABLE_COUNT_KEY]: 1 }));
+        const tspClientResponse = await tspClient.fetchTableLines(
+            traceUUID,
+            outputId,
+            QueryHelper.timeQuery([timestamp], { [QueryHelper.REQUESTED_TABLE_COUNT_KEY]: 1 })
+        );
         const lineResponse = tspClientResponse.getModel();
         if (!tspClientResponse.isOk() || !lineResponse) {
             return undefined;
@@ -544,7 +567,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         return lines[0].index;
     }
 
-    private fetchAdditionalParams(direction?: Direction): ({ [key: string]: any }) {
+    private fetchAdditionalParams(direction?: Direction): { [key: string]: any } {
         let additionalParams: { [key: string]: any } = {};
         const filterObj: { [key: number]: string } = {};
         if (this.filterModel) {
@@ -553,7 +576,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                 filterObj[k] = value;
             });
             additionalParams = {
-                ['table_search_expressions']: filterObj,
+                ['table_search_expressions']: filterObj
             };
             if (direction !== undefined) {
                 additionalParams['table_search_direction'] = Direction[direction];
@@ -568,7 +591,11 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         const outputId = this.props.outputDescriptor.id;
 
         const additionalParams = this.fetchAdditionalParams();
-        const tspClientResponse = await tspClient.fetchTableLines(traceUUID, outputId, QueryHelper.tableQuery(this.columnIds, fetchIndex, linesToFetch, additionalParams));
+        const tspClientResponse = await tspClient.fetchTableLines(
+            traceUUID,
+            outputId,
+            QueryHelper.tableQuery(this.columnIds, fetchIndex, linesToFetch, additionalParams)
+        );
         const lineResponse = tspClientResponse.getModel();
         if (!tspClientResponse.isOk() || !lineResponse) {
             return new Array<any>();
@@ -594,7 +621,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                 obj[id] = cell.content;
             });
 
-            obj['isMatched'] = (line.tags !== undefined && line.tags > 0);
+            obj['isMatched'] = line.tags !== undefined && line.tags > 0;
             linesArray.push(obj);
         });
         return linesArray;
@@ -629,7 +656,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                 }
                 let isMatched = true;
                 this.filterModel.forEach((value, key) => {
-                    if ((rowNode.data[key].search(new RegExp(value)) === -1)) {
+                    if (rowNode.data[key].search(new RegExp(value)) === -1) {
                         isMatched = false;
                     }
                 });
@@ -646,7 +673,11 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         const tspClient = this.props.tspClient;
         const outputId = this.props.outputDescriptor.id;
         const additionalParams = this.fetchAdditionalParams(direction);
-        const tspClientResponse = await tspClient.fetchTableLines(traceUUID, outputId, QueryHelper.tableQuery(this.columnIds, currRowIndex, 1, additionalParams));
+        const tspClientResponse = await tspClient.fetchTableLines(
+            traceUUID,
+            outputId,
+            QueryHelper.tableQuery(this.columnIds, currRowIndex, 1, additionalParams)
+        );
         const lineResponse = tspClientResponse.getModel();
         if (!tspClientResponse.isOk() || !lineResponse) {
             return undefined;
@@ -730,7 +761,13 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                     currRowIndexFound = false;
                 }
                 // only checking 'rowNode.rowIndex' below makes its '=== 0' case false:
-                if (currRowIndexFound && !isFound && (rowNode.rowIndex || rowNode.rowIndex === 0) && rowNode.data && rowNode.data['isMatched']) {
+                if (
+                    currRowIndexFound &&
+                    !isFound &&
+                    (rowNode.rowIndex || rowNode.rowIndex === 0) &&
+                    rowNode.data &&
+                    rowNode.data['isMatched']
+                ) {
                     this.gridApi?.ensureIndexVisible(rowNode.rowIndex);
                     this.updatePageIndex(rowNode.rowIndex);
 
@@ -788,11 +825,20 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     }
 
     private isValidRowSelection(rowNode: RowNode): boolean {
-        if ((this.enableIndexSelection && this.selectStartIndex !== -1 && this.selectEndIndex !== -1
-            && rowNode.rowIndex && rowNode.rowIndex >= Math.min(this.selectStartIndex, this.selectEndIndex)
-            && rowNode.rowIndex <= Math.max(this.selectStartIndex, this.selectEndIndex)) || (!this.enableIndexSelection
-                && this.timestampCol && BigInt(rowNode.data[this.timestampCol]) >= (this.startTimestamp <= this.endTimestamp ? this.startTimestamp : this.endTimestamp)
-                && BigInt(rowNode.data[this.timestampCol]) <= (this.startTimestamp <= this.endTimestamp ? this.endTimestamp : this.startTimestamp))) {
+        if (
+            (this.enableIndexSelection &&
+                this.selectStartIndex !== -1 &&
+                this.selectEndIndex !== -1 &&
+                rowNode.rowIndex &&
+                rowNode.rowIndex >= Math.min(this.selectStartIndex, this.selectEndIndex) &&
+                rowNode.rowIndex <= Math.max(this.selectStartIndex, this.selectEndIndex)) ||
+            (!this.enableIndexSelection &&
+                this.timestampCol &&
+                BigInt(rowNode.data[this.timestampCol]) >=
+                    (this.startTimestamp <= this.endTimestamp ? this.startTimestamp : this.endTimestamp) &&
+                BigInt(rowNode.data[this.timestampCol]) <=
+                    (this.startTimestamp <= this.endTimestamp ? this.endTimestamp : this.startTimestamp))
+        ) {
             return true;
         }
         return false;
@@ -834,24 +880,28 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         }
         const columns = this.columnApi.getAllGridColumns();
 
-        return <React.Fragment>
-            <table style={{ width: '100%' }}>
-                <tbody>
-                    {columns.map((column, key) =>
-                        <tr key={key}>
-                            <td>
-                                <input
-                                    type='checkbox'
-                                    checked={this.columnApi!.getColumn(column)?.isVisible()}
-                                    onChange={() => this.toggleColumnVisibility(this.columnApi!, column.getColDef())}
-                                />
-                            </td>
-                            <td>{column.getColDef().headerName}</td>
-                        </tr>
-                    )}
-                </tbody>
-            </table>
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                <table style={{ width: '100%' }}>
+                    <tbody>
+                        {columns.map((column, key) => (
+                            <tr key={key}>
+                                <td>
+                                    <input
+                                        type="checkbox"
+                                        checked={this.columnApi!.getColumn(column)?.isVisible()}
+                                        onChange={() =>
+                                            this.toggleColumnVisibility(this.columnApi!, column.getColDef())
+                                        }
+                                    />
+                                </td>
+                                <td>{column.getColDef().headerName}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </React.Fragment>
+        );
     }
 
     protected closeOptionsDropDown(): void {
@@ -861,16 +911,23 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     }
 
     protected showAdditionalOptions(): React.ReactNode {
-        return <React.Fragment>
-            <ul>
-                <li className='drop-down-list-item' onClick={() => {
-                    this.setState({showToggleColumns: !this.state.showToggleColumns});
-                }}>
-                    <div className='drop-down-list-item-text'>Toggle Columns</div>
-                </li>
-            </ul>
-            {this.state.showToggleColumns && <div className='toggle-columns-table'>{this.renderToggleColumnsTable()}</div>}
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                <ul>
+                    <li
+                        className="drop-down-list-item"
+                        onClick={() => {
+                            this.setState({ showToggleColumns: !this.state.showToggleColumns });
+                        }}
+                    >
+                        <div className="drop-down-list-item-text">Toggle Columns</div>
+                    </li>
+                </ul>
+                {this.state.showToggleColumns && (
+                    <div className="toggle-columns-table">{this.renderToggleColumnsTable()}</div>
+                )}
+            </React.Fragment>
+        );
     }
 
     private updatePageIndex(rowIndex: number): void {

--- a/packages/react-components/src/components/table-renderer-components.tsx
+++ b/packages/react-components/src/components/table-renderer-components.tsx
@@ -24,16 +24,22 @@ interface SearchFilterRendererState {
 
 export class LoadingRenderer extends React.Component<ICellRendererParams> {
     render(): JSX.Element {
-        return <React.Fragment>
-            {this.props.value ? this.props.value : <FontAwesomeIcon icon={faSpinner} />}
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                {this.props.value ? this.props.value : <FontAwesomeIcon icon={faSpinner} />}
+            </React.Fragment>
+        );
     }
 }
 
 export class CellRenderer extends React.Component<CellRendererProps> {
     render(): JSX.Element {
         if (this.props.value === undefined) {
-            return <React.Fragment><FontAwesomeIcon icon={faSpinner} /></React.Fragment>;
+            return (
+                <React.Fragment>
+                    <FontAwesomeIcon icon={faSpinner} />
+                </React.Fragment>
+            );
         }
         const currField = this.props.colDef?.field;
         const currFieldVal = this.props.value || '';
@@ -42,38 +48,38 @@ export class CellRenderer extends React.Component<CellRendererProps> {
         const searchTerm = (currField && this.props.filterModel.get(currField)) || '';
         if (this.props.filterModel.size > 0) {
             if (isMatched) {
-                cellElement = <>
-                    {currFieldVal.split(new RegExp(searchTerm)).map((tag: string, index: number, array: string[]) =>
-                        <span key={index.toString()}>
-                            <>
-                                {tag}
-                            </>
-                            <>
-                                {
-                                    index < array.length - 1 ?
-                                        <span style={{ backgroundColor: this.props.searchResultsColor }}>{currFieldVal.match(new RegExp(searchTerm))[0]}</span>
-                                        : <></>
-                                }
-                            </>
-                        </span>
-                    )}
-                </>;
-            }
-            else {
+                cellElement = (
+                    <>
+                        {currFieldVal
+                            .split(new RegExp(searchTerm))
+                            .map((tag: string, index: number, array: string[]) => (
+                                <span key={index.toString()}>
+                                    <>{tag}</>
+                                    <>
+                                        {index < array.length - 1 ? (
+                                            <span style={{ backgroundColor: this.props.searchResultsColor }}>
+                                                {currFieldVal.match(new RegExp(searchTerm))[0]}
+                                            </span>
+                                        ) : (
+                                            <></>
+                                        )}
+                                    </>
+                                </span>
+                            ))}
+                    </>
+                );
+            } else {
                 cellElement = <span style={{ color: '#808080' }}> {currFieldVal} </span>;
             }
         } else {
             cellElement = <>{currFieldVal || ''}</>;
         }
 
-        return <React.Fragment>
-            {cellElement}
-        </React.Fragment>;
+        return <React.Fragment>{cellElement}</React.Fragment>;
     }
 }
 
 export class SearchFilterRenderer extends React.Component<SearchFilterRendererProps, SearchFilterRendererState> {
-
     private debouncedChangeHandler: (colName: string, inputVal: string) => void;
 
     constructor(props: SearchFilterRendererProps) {
@@ -95,20 +101,36 @@ export class SearchFilterRenderer extends React.Component<SearchFilterRendererPr
         this.onUpClickHandler = this.onUpClickHandler.bind(this);
         this.onCloseClickHandler = this.onCloseClickHandler.bind(this);
         this.onKeyDownEvent = this.onKeyDownEvent.bind(this);
-
     }
 
     render(): JSX.Element {
         return (
-            <div data-testid="search-filter-element-parent" onMouseEnter={this.onMouseEnterHandler} onMouseLeave={this.onMouseLeaveHandler} onClick={this.onClickHandler}>
-                {!this.state.hasClicked && !this.state.hasHovered &&
-                    <FontAwesomeIcon style={{ marginLeft: '10px' }} icon={faSearch} />}
-                {!this.state.hasClicked && this.state.hasHovered &&
+            <div
+                data-testid="search-filter-element-parent"
+                onMouseEnter={this.onMouseEnterHandler}
+                onMouseLeave={this.onMouseLeaveHandler}
+                onClick={this.onClickHandler}
+            >
+                {!this.state.hasClicked && !this.state.hasHovered && (
+                    <FontAwesomeIcon style={{ marginLeft: '10px' }} icon={faSearch} />
+                )}
+                {!this.state.hasClicked && this.state.hasHovered && (
                     <div style={{ cursor: 'pointer' }}>
                         <FontAwesomeIcon style={{ marginLeft: '10px' }} icon={faSearch} />
-                        <span style={{ marginLeft: '10px', fontSize: '13px', width: '50px', overflow: 'hidden', textOverflow: 'ellipsis' }}>Search</span>
-                    </div>}
-                {this.state.hasClicked &&
+                        <span
+                            style={{
+                                marginLeft: '10px',
+                                fontSize: '13px',
+                                width: '50px',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis'
+                            }}
+                        >
+                            Search
+                        </span>
+                    </div>
+                )}
+                {this.state.hasClicked && (
                     <div>
                         <input
                             data-testid="search-filter-element-input"
@@ -119,10 +141,26 @@ export class SearchFilterRenderer extends React.Component<SearchFilterRendererPr
                             style={{ width: '50%', margin: '10px' }}
                             defaultValue={this.props.filterModel.get(this.props.colName) ?? ''}
                         />
-                        <FontAwesomeIcon className='hoverClass' icon={faTimes} style={{ marginTop: '20px' }} onClick={this.onCloseClickHandler} />
-                        <FontAwesomeIcon className='hoverClass' icon={faAngleDown} style={{ marginLeft: '10px', marginTop: '20px' }} onClick={this.onDownClickHandler} />
-                        <FontAwesomeIcon className='hoverClass' icon={faAngleUp} style={{ marginLeft: '10px', marginTop: '20px' }} onClick={this.onUpClickHandler} />
-                    </div>}
+                        <FontAwesomeIcon
+                            className="hoverClass"
+                            icon={faTimes}
+                            style={{ marginTop: '20px' }}
+                            onClick={this.onCloseClickHandler}
+                        />
+                        <FontAwesomeIcon
+                            className="hoverClass"
+                            icon={faAngleDown}
+                            style={{ marginLeft: '10px', marginTop: '20px' }}
+                            onClick={this.onDownClickHandler}
+                        />
+                        <FontAwesomeIcon
+                            className="hoverClass"
+                            icon={faAngleUp}
+                            style={{ marginLeft: '10px', marginTop: '20px' }}
+                            onClick={this.onUpClickHandler}
+                        />
+                    </div>
+                )}
             </div>
         );
     }

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -41,7 +41,9 @@ type TimegraphOutputProps = AbstractOutputProps & {
 type TimegraphOutputState = AbstractTreeOutputState & {
     timegraphTree: TimeGraphEntry[];
     markerCategoryEntries: Entry[];
-    markerLayerData: { rows: TimelineChart.TimeGraphRowModel[], range: TimelineChart.TimeGraphRange, resolution: number } | undefined;
+    markerLayerData:
+        | { rows: TimelineChart.TimeGraphRowModel[]; range: TimelineChart.TimeGraphRange; resolution: number }
+        | undefined;
     selectedRow?: number;
     selectedMarkerRow?: number;
     collapsedNodes: number[];
@@ -74,7 +76,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
 
     private selectedElement: TimeGraphStateComponent | undefined;
     private selectedMarkerCategories: string[] | undefined = undefined;
-    private onSelectionChanged = (payload: { [key: string]: string; }) => this.doHandleSelectionChangedSignal(payload);
+    private onSelectionChanged = (payload: { [key: string]: string }) => this.doHandleSelectionChangedSignal(payload);
     private pendingSelection: TimeGraphEntry | undefined;
 
     constructor(props: TimegraphOutputProps) {
@@ -84,11 +86,15 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             timegraphTree: [],
             markerCategoryEntries: [],
             markerLayerData: undefined,
-            collapsedNodes: validateNumArray(this.props.persistChartState?.collapsedNodes) ? this.props.persistChartState.collapsedNodes as number[] : [],
+            collapsedNodes: validateNumArray(this.props.persistChartState?.collapsedNodes)
+                ? (this.props.persistChartState.collapsedNodes as number[])
+                : [],
             selectedRow: undefined,
             selectedMarkerRow: undefined,
             columns: [],
-            collapsedMarkerNodes: validateNumArray(this.props.persistChartState?.collapsedMarkerNodes) ? this.props.persistChartState.collapsedMarkerNodes as number[] : [],
+            collapsedMarkerNodes: validateNumArray(this.props.persistChartState?.collapsedMarkerNodes)
+                ? (this.props.persistChartState.collapsedMarkerNodes as number[])
+                : [],
             dataRows: [],
             showTree: true
         };
@@ -96,8 +102,16 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         this.onToggleCollapse = this.onToggleCollapse.bind(this);
         this.onMarkerCategoryRowClose = this.onMarkerCategoryRowClose.bind(this);
         this.onToggleAnnotationCollapse = this.onToggleAnnotationCollapse.bind(this);
-        this.tspDataProvider = new TspDataProvider(this.props.tspClient, this.props.traceId, this.props.outputDescriptor.id);
-        this.styleProvider = new StyleProvider(this.props.outputDescriptor.id, this.props.traceId, this.props.tspClient);
+        this.tspDataProvider = new TspDataProvider(
+            this.props.tspClient,
+            this.props.traceId,
+            this.props.outputDescriptor.id
+        );
+        this.styleProvider = new StyleProvider(
+            this.props.outputDescriptor.id,
+            this.props.traceId,
+            this.props.tspClient
+        );
         this.rowController = new TimeGraphRowController(this.props.style.rowHeight, this.totalHeight);
         this.markerRowController = new TimeGraphRowController(this.props.style.rowHeight, this.totalHeight);
         this.horizontalContainer = React.createRef();
@@ -110,15 +124,18 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
              * @param resolution requested time interval between samples
              * @returns row models with the actual range and resolution
              */
-            dataProvider: async (range: TimelineChart.TimeGraphRange, resolution: number, rowIds?: number[]) => this.fetchTimegraphData(range, resolution, rowIds),
+            dataProvider: async (range: TimelineChart.TimeGraphRange, resolution: number, rowIds?: number[]) =>
+                this.fetchTimegraphData(range, resolution, rowIds),
             stateStyleProvider: (state: TimelineChart.TimeGraphState) => this.getStateStyle(state),
-            rowAnnotationStyleProvider: (annotation: TimelineChart.TimeGraphAnnotation) => this.getAnnotationStyle(annotation),
+            rowAnnotationStyleProvider: (annotation: TimelineChart.TimeGraphAnnotation) =>
+                this.getAnnotationStyle(annotation),
             rowStyleProvider: (row?: TimelineChart.TimeGraphRowModel) => this.getRowStyle(row)
         };
 
         const markersProvider: TimeGraphChartProviders = {
             rowProvider: () => this.getMarkersRowIds(),
-            dataProvider: async (range: TimelineChart.TimeGraphRange, resolution: number) => this.fetchMarkersData(range, resolution),
+            dataProvider: async (range: TimelineChart.TimeGraphRange, resolution: number) =>
+                this.fetchMarkersData(range, resolution),
             stateStyleProvider: (state: TimelineChart.TimeGraphState) => this.getMarkerStateStyle(state),
             rowStyleProvider: (row?: TimelineChart.TimeGraphRowModel) => this.getRowStyle(row)
         };
@@ -127,7 +144,9 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         this.chartLayer = new TimeGraphChart('timeGraphChart', providers, this.rowController, COARSE_RESOLUTION_FACTOR);
         this.arrowLayer = new TimeGraphChartArrows('timeGraphChartArrows', this.rowController);
         this.vscrollLayer = new TimeGraphVerticalScrollbar('timeGraphVerticalScrollbar', this.rowController);
-        this.chartCursors = new TimeGraphChartCursors('chart-cursors', this.chartLayer, this.rowController, { color: this.props.style.cursorColor });
+        this.chartCursors = new TimeGraphChartCursors('chart-cursors', this.chartLayer, this.rowController, {
+            color: this.props.style.cursorColor
+        });
         this.rowController.onSelectedRowChangedHandler(this.onSelectionChange);
         this.markerRowController.onSelectedRowChangedHandler(this.onMarkerSelectionChange);
         this.rowController.onVerticalOffsetChangedHandler(() => {
@@ -137,7 +156,12 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         });
 
         this.markersChartLayer = new TimeGraphChart('timeGraphChart', markersProvider, this.markerRowController);
-        this.markerChartCursors = new TimeGraphMarkersChartCursors('chart-cursors-new', this.markersChartLayer, this.markerRowController, { color: this.props.style.cursorColor });
+        this.markerChartCursors = new TimeGraphMarkersChartCursors(
+            'chart-cursors-new',
+            this.markersChartLayer,
+            this.markerRowController,
+            { color: this.props.style.cursorColor }
+        );
         this.chartLayer.onSelectedStateChanged(model => {
             this.pendingSelection = undefined;
             if (model) {
@@ -181,7 +205,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         });
         this.addPinViewOptions(() => ({
             collapsedNodes: this.state.collapsedNodes,
-            collapsedMarkerNodes: this.state.collapsedMarkerNodes,
+            collapsedMarkerNodes: this.state.collapsedMarkerNodes
         }));
     }
 
@@ -216,7 +240,11 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
 
     async fetchTree(): Promise<ResponseStatus> {
         const parameters = QueryHelper.timeRangeQuery(this.props.range.getStart(), this.props.range.getEnd());
-        const tspClientResponse = await this.props.tspClient.fetchTimeGraphTree(this.props.traceId, this.props.outputDescriptor.id, parameters);
+        const tspClientResponse = await this.props.tspClient.fetchTimeGraphTree(
+            this.props.traceId,
+            this.props.outputDescriptor.id,
+            parameters
+        );
         const treeResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && treeResponse) {
             if (treeResponse.model) {
@@ -229,11 +257,14 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 } else {
                     columns.push({ title: 'Name', sortable: true });
                 }
-                this.setState({
-                    outputStatus: treeResponse.status,
-                    timegraphTree: treeResponse.model.entries,
-                    columns
-                }, this.updateTotalHeight);
+                this.setState(
+                    {
+                        outputStatus: treeResponse.status,
+                        timegraphTree: treeResponse.model.entries,
+                        columns
+                    },
+                    this.updateTotalHeight
+                );
             } else {
                 this.setState({
                     outputStatus: treeResponse.status
@@ -248,19 +279,23 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     async componentDidUpdate(prevProps: TimegraphOutputProps, prevState: TimegraphOutputState): Promise<void> {
-        if (prevState.outputStatus === ResponseStatus.RUNNING ||
+        if (
+            prevState.outputStatus === ResponseStatus.RUNNING ||
             !isEqual(this.state.collapsedNodes, prevState.collapsedNodes) ||
             !isEqual(prevProps.markerCategories, this.props.markerCategories) ||
-            prevProps.markerSetId !== this.props.markerSetId) {
+            prevProps.markerSetId !== this.props.markerSetId
+        ) {
             this.selectedMarkerCategories = this.props.markerCategories;
             this.chartLayer.updateChart();
             this.markersChartLayer.updateChart();
             this.arrowLayer.update();
             this.rangeEventsLayer.update();
         }
-        if (!isEqual(this.state.markerCategoryEntries, prevState.markerCategoryEntries) ||
+        if (
+            !isEqual(this.state.markerCategoryEntries, prevState.markerCategoryEntries) ||
             !isEqual(this.state.collapsedMarkerNodes, prevState.collapsedMarkerNodes) ||
-            !isEqual(this.state.markerLayerData, prevState.markerLayerData)) {
+            !isEqual(this.state.markerLayerData, prevState.markerLayerData)
+        ) {
             this.markersChartLayer.updateChart();
         }
     }
@@ -300,7 +335,10 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     markerLayerData
                 });
             }
-            signalManager().fireMarkerCategoryClosedSignal({ traceViewerId: this.props.traceId, markerCategory: annotationLabel });
+            signalManager().fireMarkerCategoryClosedSignal({
+                traceViewerId: this.props.traceId,
+                markerCategory: annotationLabel
+            });
         }
     }
 
@@ -351,7 +389,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
      * @return
      *      Correspondent TimeGraphEntry from this.state.timegraphTree
      */
-    private findElement(payload: { [key: string]: string | { [key: string]: string }}): TimeGraphEntry | undefined {
+    private findElement(payload: { [key: string]: string | { [key: string]: string } }): TimeGraphEntry | undefined {
         let element: TimeGraphEntry | undefined = undefined;
         let max = 0;
         if (payload && payload.load) {
@@ -359,12 +397,14 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 if (el.metadata) {
                     let cnt = 0;
                     Object.entries(el.metadata).forEach(([key, values]) => {
-                        if (typeof (payload.load) !== 'string') {
+                        if (typeof payload.load !== 'string') {
                             const val = payload.load[key];
                             if (val !== undefined) {
                                 const num = Number(val);
                                 // at least one value in array needs to match
-                                const result = values.find((value: string | number) => (num !== undefined && num === value) || (val === value));
+                                const result = values.find(
+                                    (value: string | number) => (num !== undefined && num === value) || val === value
+                                );
                                 if (result !== undefined) {
                                     cnt++;
                                 }
@@ -377,7 +417,6 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     }
                 }
             });
-
         }
         return element;
     }
@@ -385,47 +424,53 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     private getMarkersLayerHeight() {
         const rowHeight = 20;
         const scrollbarHeight = 10;
-        return this.state.markerCategoryEntries.length <= 1 ? 0 :
-            this.state.collapsedMarkerNodes.length ? rowHeight :
-            this.state.markerCategoryEntries.length * rowHeight + scrollbarHeight;
+        return this.state.markerCategoryEntries.length <= 1
+            ? 0
+            : this.state.collapsedMarkerNodes.length
+            ? rowHeight
+            : this.state.markerCategoryEntries.length * rowHeight + scrollbarHeight;
     }
 
     renderTree(): React.ReactNode {
         // TODO Show header, when we can have entries in-line with timeline-chart
-        return <>
-            <div ref={this.timeGraphTreeRef} className='scrollable' onScroll={() => this.synchronizeTreeScroll()}
-                style={{ height: parseInt(this.props.style.height.toString()) - this.getMarkersLayerHeight() }}
-                tabIndex={0}
+        return (
+            <>
+                <div
+                    ref={this.timeGraphTreeRef}
+                    className="scrollable"
+                    onScroll={() => this.synchronizeTreeScroll()}
+                    style={{ height: parseInt(this.props.style.height.toString()) - this.getMarkersLayerHeight() }}
+                    tabIndex={0}
                 >
-                <EntryTree
-                    collapsedNodes={this.state.collapsedNodes}
-                    showFilter={false}
-                    entries={this.state.timegraphTree}
-                    showCheckboxes={false}
-                    onToggleCollapse={this.onToggleCollapse}
-                    onRowClick={this.onRowClick}
-                    selectedRow={this.state.selectedRow}
-                    showHeader={false}
-                    className='table-tree timegraph-tree'
-                />
-            </div>
-            <div ref={this.markerTreeRef} className='scrollable'
-                style={{ height: this.getMarkersLayerHeight() }}>
-                <EntryTree
-                    collapsedNodes={this.state.collapsedMarkerNodes}
-                    showFilter={false}
-                    entries={this.state.markerCategoryEntries}
-                    showCheckboxes={false}
-                    showCloseIcons={true}
-                    onRowClick={this.onMarkerRowClick}
-                    selectedRow={this.state.selectedMarkerRow}
-                    onToggleCollapse={this.onToggleAnnotationCollapse}
-                    onClose={this.onMarkerCategoryRowClose}
-                    showHeader={false}
-                    className='table-tree timegraph-tree'
-                />
-            </div>
-        </>;
+                    <EntryTree
+                        collapsedNodes={this.state.collapsedNodes}
+                        showFilter={false}
+                        entries={this.state.timegraphTree}
+                        showCheckboxes={false}
+                        onToggleCollapse={this.onToggleCollapse}
+                        onRowClick={this.onRowClick}
+                        selectedRow={this.state.selectedRow}
+                        showHeader={false}
+                        className="table-tree timegraph-tree"
+                    />
+                </div>
+                <div ref={this.markerTreeRef} className="scrollable" style={{ height: this.getMarkersLayerHeight() }}>
+                    <EntryTree
+                        collapsedNodes={this.state.collapsedMarkerNodes}
+                        showFilter={false}
+                        entries={this.state.markerCategoryEntries}
+                        showCheckboxes={false}
+                        showCloseIcons={true}
+                        onRowClick={this.onMarkerRowClick}
+                        selectedRow={this.state.selectedMarkerRow}
+                        onToggleCollapse={this.onToggleAnnotationCollapse}
+                        onClose={this.onMarkerCategoryRowClose}
+                        showHeader={false}
+                        className="table-tree timegraph-tree"
+                    />
+                </div>
+            </>
+        );
     }
 
     renderYAxis(): React.ReactNode {
@@ -433,25 +478,28 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     renderChart(): React.ReactNode {
-        return <React.Fragment>
-            {this.state.outputStatus === ResponseStatus.COMPLETED ?
-                <div id='timegraph-main' className='ps__child--consume' onWheel={ev => { ev.preventDefault(); ev.stopPropagation(); }} style={{ height: this.props.style.height }} >
-                    {this.renderTimeGraphContent()}
-                </div> :
-                <div className='analysis-running'>
-                    {(
-                        <FontAwesomeIcon
-                            icon={faSpinner}
-                            spin
-                            style={{ marginRight: '5px' }}
-                        />
-                    )}
-                    {
-                        'Analysis running'
-                    }
-                </div>
-            }
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                {this.state.outputStatus === ResponseStatus.COMPLETED ? (
+                    <div
+                        id="timegraph-main"
+                        className="ps__child--consume"
+                        onWheel={ev => {
+                            ev.preventDefault();
+                            ev.stopPropagation();
+                        }}
+                        style={{ height: this.props.style.height }}
+                    >
+                        {this.renderTimeGraphContent()}
+                    </div>
+                ) : (
+                    <div className="analysis-running">
+                        {<FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />}
+                        {'Analysis running'}
+                    </div>
+                )}
+            </React.Fragment>
+        );
     }
 
     resultsAreEmpty(): boolean {
@@ -475,11 +523,11 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             const duration = (elementRange.end - elementRange.start).toString();
             const tooltip = await this.tspDataProvider.fetchStateTooltip(element, this.props.viewRange);
             return this.filterTooltip({
-                'Label': label,
+                Label: label,
                 'Start time': start,
                 'End time': end,
-                'Duration': duration,
-                'Row': element.row.model.name,
+                Duration: duration,
+                Row: element.row.model.name,
                 ...tooltip
             });
         } else if (element instanceof TimeGraphAnnotationComponent) {
@@ -499,8 +547,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             if (start === end) {
                 return this.filterTooltip({
                     [category]: label,
-                    'Timestamp': start,
-                    'Row': element.row.model.name,
+                    Timestamp: start,
+                    Row: element.row.model.name,
                     ...tooltip
                 });
             } else {
@@ -508,14 +556,14 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     [category]: label,
                     'Start time': start,
                     'End time': end,
-                    'Row': element.row.model.name,
+                    Row: element.row.model.name,
                     ...tooltip
                 });
             }
         }
     }
 
-    private filterTooltip(fullTooltip: { [key: string]: string; }) {
+    private filterTooltip(fullTooltip: { [key: string]: string }) {
         Object.keys(fullTooltip).forEach(key => {
             // eslint-disable-next-line no-null/no-null
             if (fullTooltip[key as keyof typeof fullTooltip] === null) {
@@ -526,55 +574,67 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private renderTimeGraphContent() {
-        return <div id='main-timegraph-content' ref={this.horizontalContainer} style={{ height: this.props.style.height }} >
-            {this.getChartContainer()}
-            {this.getMarkersContainer()}
-        </div>;
+        return (
+            <div id="main-timegraph-content" ref={this.horizontalContainer} style={{ height: this.props.style.height }}>
+                {this.getChartContainer()}
+                {this.getMarkersContainer()}
+            </div>
+        );
     }
 
     private getMarkersContainer() {
-        return <ReactTimeGraphContainer
-            options={
-                {
+        return (
+            <ReactTimeGraphContainer
+                options={{
                     id: 'timegraph-chart-1',
                     height: this.getMarkersLayerHeight(),
                     width: this.getChartWidth(),
                     backgroundColor: this.props.style.chartBackgroundColor,
                     lineColor: this.props.style.lineColor,
                     classNames: 'horizontal-canvas'
-                }
-            }
-            addWidgetResizeHandler={this.props.addWidgetResizeHandler}
-            removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
-            unitController={this.props.unitController}
-            id='timegraph-chart-1'
-            layers={[this.markersChartLayer, this.markerChartCursors]}
-        />;
-
+                }}
+                addWidgetResizeHandler={this.props.addWidgetResizeHandler}
+                removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
+                unitController={this.props.unitController}
+                id="timegraph-chart-1"
+                layers={[this.markersChartLayer, this.markerChartCursors]}
+            />
+        );
     }
 
     private getChartContainer() {
-        const grid = new TimeGraphChartGrid('timeGraphGrid', this.props.style.rowHeight, this.props.backgroundTheme === 'light' ? 0xdddddd : 0x34383C);
-        const selectionRange = new TimeGraphChartSelectionRange('chart-selection-range', { color: this.props.style.cursorColor });
-        return <ReactTimeGraphContainer
-            options={
-                {
+        const grid = new TimeGraphChartGrid(
+            'timeGraphGrid',
+            this.props.style.rowHeight,
+            this.props.backgroundTheme === 'light' ? 0xdddddd : 0x34383c
+        );
+        const selectionRange = new TimeGraphChartSelectionRange('chart-selection-range', {
+            color: this.props.style.cursorColor
+        });
+        return (
+            <ReactTimeGraphContainer
+                options={{
                     id: this.props.traceId + this.props.outputDescriptor.id + 'focusContainer',
                     height: parseInt(this.props.style.height.toString()) - this.getMarkersLayerHeight(),
                     width: this.getChartWidth(),
                     backgroundColor: this.props.style.chartBackgroundColor,
-                    lineColor: this.props.backgroundTheme === 'light' ? 0xdddddd : 0x34383C,
+                    lineColor: this.props.backgroundTheme === 'light' ? 0xdddddd : 0x34383c,
                     classNames: 'horizontal-canvas'
-                }
-            }
-            addWidgetResizeHandler={this.props.addWidgetResizeHandler}
-            removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
-            unitController={this.props.unitController}
-            id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
-            layers={[
-                grid, this.chartLayer, selectionRange, this.chartCursors, this.arrowLayer, this.rangeEventsLayer
-            ]}
-        />;
+                }}
+                addWidgetResizeHandler={this.props.addWidgetResizeHandler}
+                removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
+                unitController={this.props.unitController}
+                id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
+                layers={[
+                    grid,
+                    this.chartLayer,
+                    selectionRange,
+                    this.chartCursors,
+                    this.arrowLayer,
+                    this.rangeEventsLayer
+                ]}
+            />
+        );
     }
 
     setFocus(): void {
@@ -586,19 +646,21 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     protected getVerticalScrollbar(): JSX.Element {
-        return <ReactTimeGraphContainer
-            id='vscroll'
-            options={{
-                id: 'vscroll',
-                width: 10,
-                height: parseInt(this.props.style.height.toString()),
-                backgroundColor: this.props.style.naviBackgroundColor
-            }}
-            addWidgetResizeHandler={this.props.addWidgetResizeHandler}
-            removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
-            unitController={this.props.unitController}
-            layers={[this.vscrollLayer]}
-        ></ReactTimeGraphContainer>;
+        return (
+            <ReactTimeGraphContainer
+                id="vscroll"
+                options={{
+                    id: 'vscroll',
+                    width: 10,
+                    height: parseInt(this.props.style.height.toString()),
+                    backgroundColor: this.props.style.naviBackgroundColor
+                }}
+                addWidgetResizeHandler={this.props.addWidgetResizeHandler}
+                removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
+                unitController={this.props.unitController}
+                layers={[this.vscrollLayer]}
+            ></ReactTimeGraphContainer>
+        );
     }
 
     private async onElementSelected(element: TimeGraphStateComponent | undefined) {
@@ -611,29 +673,43 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
 
     private getTimegraphRowIds() {
         return {
-            rowIds: getAllExpandedNodeIds(listToTree(this.state.timegraphTree, this.state.columns), this.state.collapsedNodes)
+            rowIds: getAllExpandedNodeIds(
+                listToTree(this.state.timegraphTree, this.state.columns),
+                this.state.collapsedNodes
+            )
         };
     }
 
     private async fetchTimegraphData(range: TimelineChart.TimeGraphRange, resolution: number, rowIds?: number[]) {
         if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')!.style.visibility = 'visible';
+            document.getElementById(
+                this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner'
+            )!.style.visibility = 'visible';
         }
 
         const ids = rowIds ? rowIds : this.getTimegraphRowIds().rowIds;
         const { start, end } = range;
         const newRange: TimelineChart.TimeGraphRange = range;
         const nbTimes = Math.ceil(Number(end - start) / resolution) + 1;
-        const timeGraphData: TimelineChart.TimeGraphModel = await this.tspDataProvider.getData(ids, this.state.timegraphTree,
-            this.props.range, newRange, nbTimes, this.props.markerCategories, this.props.markerSetId);
+        const timeGraphData: TimelineChart.TimeGraphModel = await this.tspDataProvider.getData(
+            ids,
+            this.state.timegraphTree,
+            this.props.range,
+            newRange,
+            nbTimes,
+            this.props.markerCategories,
+            this.props.markerSetId
+        );
         this.updateMarkersData(timeGraphData.rangeEvents, newRange, nbTimes);
         this.arrowLayer.addArrows(timeGraphData.arrows, this.getTimegraphRowIds().rowIds);
         this.rangeEventsLayer.addRangeEvents(timeGraphData.rangeEvents);
 
         if (document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            document.getElementById(this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner')!.style.visibility = 'hidden';
+            document.getElementById(
+                this.props.traceId + this.props.outputDescriptor.id + 'handleSpinner'
+            )!.style.visibility = 'hidden';
         }
         this.setState({ dataRows: timeGraphData.rows });
 
@@ -650,7 +726,11 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         };
     }
 
-    private updateMarkersData(rangeEvents: TimelineChart.TimeGraphAnnotation[], newRange: TimelineChart.TimeGraphRange, newResolution: number) {
+    private updateMarkersData(
+        rangeEvents: TimelineChart.TimeGraphAnnotation[],
+        newRange: TimelineChart.TimeGraphRange,
+        newResolution: number
+    ) {
         const annotationEntries: Entry[] = [];
         const markers: Map<string, TimelineChart.TimeGraphState[]> = new Map();
         const categories: string[] = [];
@@ -736,7 +816,10 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private getMarkersRowIds() {
-        const rows = (this.state.collapsedMarkerNodes.length !== 0 || !!!this.state.markerLayerData) ? [] : this.state.markerLayerData.rows;
+        const rows =
+            this.state.collapsedMarkerNodes.length !== 0 || !!!this.state.markerLayerData
+                ? []
+                : this.state.markerLayerData.rows;
         const rowIds: number[] = [];
         rows.forEach(row => {
             rowIds.push(row.id);
@@ -748,7 +831,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
 
     private async fetchMarkersData(range: TimelineChart.TimeGraphRange, resolution: number) {
         if (this.state.collapsedMarkerNodes.length !== 0 || !!!this.state.markerLayerData) {
-            return  {
+            return {
                 rows: [],
                 range,
                 resolution
@@ -758,7 +841,6 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private getRowStyle(row?: TimelineChart.TimeGraphRowModel) {
-
         let backgroundColor = 0x979797;
 
         if (row?.selected) {
@@ -770,7 +852,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         return {
             backgroundColor,
             backgroundOpacity: row?.selected ? 0.5 : 0,
-            lineColor: this.props.backgroundTheme === 'light' ? 0xD3D3D3 : 0x3F4146,
+            lineColor: this.props.backgroundTheme === 'light' ? 0xd3d3d3 : 0x3f4146,
             lineThickness: 1
         };
     }
@@ -805,7 +887,10 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             const metadata = state.data;
             if (metadata && metadata.style) {
                 const elementStyle: OutputElementStyle = metadata.style;
-                const backgroundColor = this.styleProvider.getColorStyle(elementStyle, StyleProperties.BACKGROUND_COLOR);
+                const backgroundColor = this.styleProvider.getColorStyle(
+                    elementStyle,
+                    StyleProperties.BACKGROUND_COLOR
+                );
                 const heightFactor = this.styleProvider.getNumberStyle(elementStyle, StyleProperties.HEIGHT);
                 let height = this.props.style.rowHeight * 0.8;
                 if (heightFactor) {
@@ -828,8 +913,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     color: backgroundColor ? backgroundColor.color : 0x000000,
                     opacity: backgroundColor ? backgroundColor.alpha : 1.0,
                     height: height,
-                    borderWidth: state.selected ? 2 : (borderWidth ? borderWidth : 0),
-                    borderColor: state.selected ? 0xeef20c : (borderColor ? borderColor.color : 0x000000)
+                    borderWidth: state.selected ? 2 : borderWidth ? borderWidth : 0,
+                    borderColor: state.selected ? 0xeef20c : borderColor ? borderColor.color : 0x000000
                 };
             }
             return undefined;
@@ -838,31 +923,41 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private getDefaultStateStyle(state: TimelineChart.TimeGraphState) {
-        const styleProvider = new StyleProvider(this.props.outputDescriptor.id, this.props.traceId, this.props.tspClient);
+        const styleProvider = new StyleProvider(
+            this.props.outputDescriptor.id,
+            this.props.traceId,
+            this.props.tspClient
+        );
         const styles = styleProvider.getStylesTmp();
         const backupStyles: TimeGraphStateStyle[] = [
             {
-                color: 0x3891A6,
+                color: 0x3891a6,
                 height: this.props.style.rowHeight * 0.8
-            }, {
-                color: 0x4C5B5C,
-                height: this.props.style.rowHeight * 0.7
-            }, {
-                color: 0xFDE74C,
-                height: this.props.style.rowHeight * 0.6
-            }, {
-                color: 0xDB5461,
-                height: this.props.style.rowHeight * 0.5
-            }, {
-                color: 0xE3655B,
-                height: this.props.style.rowHeight * 0.4
-            }, {
-                color: 0xEA8F87,
-                height: this.props.style.rowHeight * 0.9
-            }, {
-                color: 0xDE636F,
-                height: this.props.style.rowHeight * 0.3
             },
+            {
+                color: 0x4c5b5c,
+                height: this.props.style.rowHeight * 0.7
+            },
+            {
+                color: 0xfde74c,
+                height: this.props.style.rowHeight * 0.6
+            },
+            {
+                color: 0xdb5461,
+                height: this.props.style.rowHeight * 0.5
+            },
+            {
+                color: 0xe3655b,
+                height: this.props.style.rowHeight * 0.4
+            },
+            {
+                color: 0xea8f87,
+                height: this.props.style.rowHeight * 0.9
+            },
+            {
+                color: 0xde636f,
+                height: this.props.style.rowHeight * 0.3
+            }
         ];
 
         let style: TimeGraphStateStyle | undefined = backupStyles[0];
@@ -872,7 +967,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             const outputStyle = modelData.style;
             if (!outputStyle) {
                 return {
-                    color: 0xCACACA,
+                    color: 0xcacaca,
                     height: this.props.style.rowHeight * 0.5,
                     borderWidth: state.selected ? 2 : 0,
                     borderColor: 0xeef20c
@@ -892,7 +987,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
 
             style = this.styleMap.get(stateStyle.parentKey);
             if (style === undefined) {
-                style = backupStyles[(Math.abs(hash(stateStyle.parentKey)) as number % backupStyles.length)];
+                style = backupStyles[(Math.abs(hash(stateStyle.parentKey)) as number) % backupStyles.length];
                 this.styleMap.set(stateStyle.parentKey, style);
             }
             return {
@@ -905,7 +1000,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
 
         style = this.styleMap.get(val);
         if (!style) {
-            style = backupStyles[(this.styleMap.size % backupStyles.length)];
+            style = backupStyles[this.styleMap.size % backupStyles.length];
             this.styleMap.set(val, style);
         }
         return {
@@ -925,7 +1020,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 const symbolType = this.styleProvider.getStyle(elementStyle, StyleProperties.SYMBOL_TYPE);
                 const color = this.styleProvider.getColorStyle(elementStyle, StyleProperties.COLOR);
                 const heightFactor = this.styleProvider.getNumberStyle(elementStyle, StyleProperties.HEIGHT);
-                let symbolSize = this.props.style.rowHeight * 0.8 / 2;
+                let symbolSize = (this.props.style.rowHeight * 0.8) / 2;
                 if (heightFactor) {
                     symbolSize = heightFactor * symbolSize;
                 }
@@ -957,7 +1052,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             ids.forEach(parentIds => {
                 const exist = this.state.collapsedNodes.find(expandId => expandId === parentIds);
                 if (exist !== undefined) {
-                     newList = newList.filter(collapsed => parentIds !== collapsed);
+                    newList = newList.filter(collapsed => parentIds !== collapsed);
                 }
             });
             const retVal = newList.length === this.state.collapsedNodes.length;
@@ -972,7 +1067,11 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
      *  @param {number} id TreeNode id number
      */
     public onRowClick = (id: number): void => {
-        const rowIndex = getIndexOfNode(id, listToTree(this.state.timegraphTree, this.state.columns), this.state.collapsedNodes);
+        const rowIndex = getIndexOfNode(
+            id,
+            listToTree(this.state.timegraphTree, this.state.columns),
+            this.state.collapsedNodes
+        );
         this.chartLayer.selectAndReveal(rowIndex);
         if (this.rowController.selectedRow?.id !== id) {
             // This highlights the left side if the row is loading.
@@ -981,15 +1080,24 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     };
 
     public onMarkerRowClick = (id: number): void => {
-        const rowIndex = getIndexOfNode(id, listToTree(this.state.markerCategoryEntries, this.state.columns), this.state.collapsedNodes);
+        const rowIndex = getIndexOfNode(
+            id,
+            listToTree(this.state.markerCategoryEntries, this.state.columns),
+            this.state.collapsedNodes
+        );
         this.markersChartLayer.selectAndReveal(rowIndex);
     };
 
     public onSelectionChange = (row: TimelineChart.TimeGraphRowModel): void => this.setState({ selectedRow: row.id });
-    public onMarkerSelectionChange = (row: TimelineChart.TimeGraphRowModel): void => this.setState({ selectedMarkerRow: row.id });
+    public onMarkerSelectionChange = (row: TimelineChart.TimeGraphRowModel): void =>
+        this.setState({ selectedMarkerRow: row.id });
 
     private selectAndReveal(item: TimeGraphEntry) {
-        const rowIndex = getIndexOfNode(item.id, listToTree(this.state.timegraphTree, this.state.columns), this.state.collapsedNodes);
+        const rowIndex = getIndexOfNode(
+            item.id,
+            listToTree(this.state.timegraphTree, this.state.columns),
+            this.state.collapsedNodes
+        );
         this.chartLayer.selectAndReveal(rowIndex);
     }
 }

--- a/packages/react-components/src/components/tooltip-component.tsx
+++ b/packages/react-components/src/components/tooltip-component.tsx
@@ -6,12 +6,11 @@ type MaybePromise<T> = T | Promise<T>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface TooltipComponentState<T = any> {
     element?: T;
-    func?: ((element: T) => MaybePromise<{ [key: string]: string } | undefined>);
+    func?: (element: T) => MaybePromise<{ [key: string]: string } | undefined>;
     content?: string;
 }
 
 export class TooltipComponent extends React.Component<unknown, TooltipComponentState> {
-
     private static readonly HOURGLASS_NOT_DONE = '&#x23f3;';
 
     timerId?: NodeJS.Timeout;
@@ -26,50 +25,53 @@ export class TooltipComponent extends React.Component<unknown, TooltipComponentS
     }
 
     render(): React.ReactNode {
-        return <div role={ 'tooltip-component-role' }
-            onMouseEnter={() => {
-                if (this.timerId) {
-                    clearTimeout(this.timerId);
-                    this.timerId = undefined;
-                }
-            }}
-            onMouseLeave={() => {
-                ReactTooltip.hide();
-                this.setState({ content: undefined });
-            }}
-            >
-            <ReactTooltip
-                className="react-tooltip"
-                id="tooltip-component"
-                effect='float'
-                type='info'
-                place='bottom'
-                html={true}
-                delayShow={500}
-                delayUpdate={500}
-                afterShow={() => {
+        return (
+            <div
+                role={'tooltip-component-role'}
+                onMouseEnter={() => {
                     if (this.timerId) {
                         clearTimeout(this.timerId);
                         this.timerId = undefined;
                     }
-                    if (this.state.content === undefined) {
-                        this.fetchContent(this.state.element);
-                    }
                 }}
-                clickable={true}
-                scrollHide={true}
-                arrowColor='transparent'
-                overridePosition={({ left, top }, currentEvent, currentTarget, refNode, place) => {
-                    left += (place === 'left') ? -10 : (place === 'right') ? 10 : 0;
-                    top += (place === 'top') ? -10 : 0;
-                    return { left, top };
+                onMouseLeave={() => {
+                    ReactTooltip.hide();
+                    this.setState({ content: undefined });
                 }}
-                getContent={() => this.getContent()}
-            />
-        </div>;
+            >
+                <ReactTooltip
+                    className="react-tooltip"
+                    id="tooltip-component"
+                    effect="float"
+                    type="info"
+                    place="bottom"
+                    html={true}
+                    delayShow={500}
+                    delayUpdate={500}
+                    afterShow={() => {
+                        if (this.timerId) {
+                            clearTimeout(this.timerId);
+                            this.timerId = undefined;
+                        }
+                        if (this.state.content === undefined) {
+                            this.fetchContent(this.state.element);
+                        }
+                    }}
+                    clickable={true}
+                    scrollHide={true}
+                    arrowColor="transparent"
+                    overridePosition={({ left, top }, currentEvent, currentTarget, refNode, place) => {
+                        left += place === 'left' ? -10 : place === 'right' ? 10 : 0;
+                        top += place === 'top' ? -10 : 0;
+                        return { left, top };
+                    }}
+                    getContent={() => this.getContent()}
+                />
+            </div>
+        );
     }
 
-    setElement<T>(element: T, func?: ((element: T) => MaybePromise<{ [key: string]: string } | undefined>)): void {
+    setElement<T>(element: T, func?: (element: T) => MaybePromise<{ [key: string]: string } | undefined>): void {
         if (element !== this.state.element && this.state.element) {
             if (this.state.content) {
                 if (this.timerId === undefined) {
@@ -104,7 +106,7 @@ export class TooltipComponent extends React.Component<unknown, TooltipComponentS
             const tooltipInfo = await this.state.func(element);
             let content = '<table>';
             if (tooltipInfo) {
-                Object.entries(tooltipInfo).forEach(([k, v]) => content += this.tooltipRow(k, v));
+                Object.entries(tooltipInfo).forEach(([k, v]) => (content += this.tooltipRow(k, v)));
             }
             content += '</table>';
             if (this.state.element === element) {

--- a/packages/react-components/src/components/tooltip-xy-component.tsx
+++ b/packages/react-components/src/components/tooltip-xy-component.tsx
@@ -4,21 +4,21 @@ type MaybePromise<T> = T | Promise<T>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface TooltipXYComponentState<T = any> {
-    tooltipData?: TooltipData,
-    onDisplay: boolean,
-    inTooltip: boolean
+    tooltipData?: TooltipData;
+    onDisplay: boolean;
+    inTooltip: boolean;
 }
 
 interface TooltipData {
-    title?: string,
+    title?: string;
     dataPoints?: [];
-    top?: number,
-    bottom?: number,
-    right?: number,
-    left?: number,
-    opacity?: number,
-    transition?: string,
-    zeros?: number
+    top?: number;
+    bottom?: number;
+    right?: number;
+    left?: number;
+    opacity?: number;
+    transition?: string;
+    zeros?: number;
 }
 
 export class TooltipXYComponent extends React.Component<unknown, TooltipXYComponentState> {
@@ -32,14 +32,16 @@ export class TooltipXYComponent extends React.Component<unknown, TooltipXYCompon
         this.state = {
             tooltipData: undefined,
             onDisplay: false,
-            inTooltip: false,
+            inTooltip: false
         };
         this.divRef = React.createRef();
     }
 
     render(): React.ReactNode {
         const leftPos = this.state.tooltipData?.left ? this.state.tooltipData.left + this.horizontalSpace : undefined;
-        const rightPos = this.state.tooltipData?.right ? this.state.tooltipData.right + this.horizontalSpace : undefined;
+        const rightPos = this.state.tooltipData?.right
+            ? this.state.tooltipData.right + this.horizontalSpace
+            : undefined;
         let zeros = 0;
         let allZeros = false;
         if (this.state.tooltipData?.zeros && this.state.tooltipData.zeros > 0) {
@@ -79,33 +81,43 @@ export class TooltipXYComponent extends React.Component<unknown, TooltipXYCompon
                     right: rightPos,
                     left: leftPos,
                     opacity: this.state.tooltipData?.opacity ? this.state.tooltipData.opacity : 0,
-                    transition: this.state.tooltipData?.transition ? 'opacity ' + this.state.tooltipData.transition : 'opacity 0.3s',
+                    transition: this.state.tooltipData?.transition
+                        ? 'opacity ' + this.state.tooltipData.transition
+                        : 'opacity 0.3s',
                     zIndex: 999
                 }}
             >
-                <p style={{margin: '0 0 5px 0'}}>{this.state.tooltipData?.title}</p>
-                <ul style={{padding: '0'}}>
-                    {this.state.tooltipData?.dataPoints?.map((point: { color: string, background: string, label: string, value: string }, i: number) =>
-                        <li key={i} style={{listStyle: 'none', display: 'flex', marginBottom: 5}}>
-                            <div style={{
-                                height: '10px',
-                                width: '10px',
-                                margin: 'auto 0',
-                                border: 'solid thin',
-                                borderColor: point.color,
-                                backgroundColor: point.background
-                                }}
-                            ></div>
-                            <span style={{marginLeft: '5px'}}>{point.label} {point.value}</span>
-                        </li>
+                <p style={{ margin: '0 0 5px 0' }}>{this.state.tooltipData?.title}</p>
+                <ul style={{ padding: '0' }}>
+                    {this.state.tooltipData?.dataPoints?.map(
+                        (point: { color: string; background: string; label: string; value: string }, i: number) => (
+                            <li key={i} style={{ listStyle: 'none', display: 'flex', marginBottom: 5 }}>
+                                <div
+                                    style={{
+                                        height: '10px',
+                                        width: '10px',
+                                        margin: 'auto 0',
+                                        border: 'solid thin',
+                                        borderColor: point.color,
+                                        backgroundColor: point.background
+                                    }}
+                                ></div>
+                                <span style={{ marginLeft: '5px' }}>
+                                    {point.label} {point.value}
+                                </span>
+                            </li>
+                        )
                     )}
                 </ul>
-                {allZeros ?
-                    <p style={{marginBottom: 0}}>All values: 0</p>
-                    :
-                    zeros > 0 &&
-                    <p style={{marginBottom: 0}}>{this.state.tooltipData?.zeros} other{zeros > 1 ? 's' : ''}: 0</p>
-                }
+                {allZeros ? (
+                    <p style={{ marginBottom: 0 }}>All values: 0</p>
+                ) : (
+                    zeros > 0 && (
+                        <p style={{ marginBottom: 0 }}>
+                            {this.state.tooltipData?.zeros} other{zeros > 1 ? 's' : ''}: 0
+                        </p>
+                    )
+                )}
             </div>
         );
     }
@@ -122,7 +134,7 @@ export class TooltipXYComponent extends React.Component<unknown, TooltipXYCompon
             this.setState({ onDisplay: false });
             setTimeout(() => {
                 if (!this.state.inTooltip) {
-                    this.setState({tooltipData: { opacity: 0, transition: '0s' }, inTooltip: false });
+                    this.setState({ tooltipData: { opacity: 0, transition: '0s' }, inTooltip: false });
                 }
             }, 500);
         }

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -55,7 +55,7 @@ export interface TraceContextState {
     currentRange: TimeRange;
     currentViewRange: TimeRange;
     currentTimeSelection: TimeRange | undefined;
-    experiment: Experiment
+    experiment: Experiment;
     traceIndexing: boolean;
     style: OutputComponentStyle;
     backgroundTheme: string;
@@ -67,7 +67,7 @@ export interface PersistedState {
     currentRange: TimeRangeString;
     currentViewRange: TimeRangeString;
     currentTimeSelection?: TimeRangeString;
-    unitControllerViewRange: { start: string, end: string };
+    unitControllerViewRange: { start: string; end: string };
     storedTimescaleLayout: Layout[];
     storedNonTimescaleLayout: Layout[];
     pinnedView: OutputDescriptor | undefined;
@@ -91,7 +91,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     private readonly DEFAULT_CHART_OFFSET = 200;
     private readonly MIN_COMPONENT_HEIGHT: number = 2;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private chartPersistedState: { output: OutputDescriptor, payload?: any} | undefined = undefined;
+    private chartPersistedState: { output: OutputDescriptor; payload?: any } | undefined = undefined;
 
     private unitController: TimeGraphUnitController;
     private historyHandler: UnitControllerHistoryHandler;
@@ -131,8 +131,16 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         let curPinnedView = undefined;
         if (this.props.experiment) {
             const experiment = this.props.experiment;
-            traceRange = new TimeRange(experiment.start - this.props.experiment.start, experiment.end - this.props.experiment.start, this.props.experiment.start);
-            viewRange = new TimeRange(experiment.start - this.props.experiment.start, experiment.end - this.props.experiment.start, this.props.experiment.start);
+            traceRange = new TimeRange(
+                experiment.start - this.props.experiment.start,
+                experiment.end - this.props.experiment.start,
+                this.props.experiment.start
+            );
+            viewRange = new TimeRange(
+                experiment.start - this.props.experiment.start,
+                experiment.end - this.props.experiment.start,
+                this.props.experiment.start
+            );
             if (this.props.persistedState) {
                 const {
                     currentRange: storedRange,
@@ -163,7 +171,9 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             currentTimeSelection: timeSelection,
             experiment: this.props.experiment,
             pinnedView: curPinnedView,
-            traceIndexing: ((this.props.experiment.indexingStatus === this.INDEXING_RUNNING_STATUS) || (this.props.experiment.indexingStatus === this.INDEXING_CLOSED_STATUS)),
+            traceIndexing:
+                this.props.experiment.indexingStatus === this.INDEXING_RUNNING_STATUS ||
+                this.props.experiment.indexingStatus === this.INDEXING_CLOSED_STATUS,
             style: {
                 width: 0, // width will be set by resize handler
                 chartOffset: this.DEFAULT_CHART_OFFSET,
@@ -175,7 +185,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                 cursorColor: 0x259fd8,
                 lineColor: this.props.backgroundTheme === 'light' ? 0x757575 : 0xbbbbbb
             },
-            backgroundTheme: this.props.backgroundTheme,
+            backgroundTheme: this.props.backgroundTheme
         };
         const absoluteRange = traceRange.getDuration();
         this.unitController = new TimeGraphUnitController(absoluteRange, { start: BigInt(0), end: absoluteRange });
@@ -195,8 +205,12 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             const { start, end } = this.props.persistedState.currentTimeSelection;
             this.unitController.selectionRange = { start: BigInt(start), end: BigInt(end) };
         }
-        this.unitController.onSelectionRangeChange(range => { this.handleTimeSelectionChange(range); });
-        this.unitController.onViewRangeChanged(viewRangeParam => { this.handleViewRangeChange(viewRangeParam); });
+        this.unitController.onSelectionRangeChange(range => {
+            this.handleTimeSelectionChange(range);
+        });
+        this.unitController.onViewRangeChanged(viewRangeParam => {
+            this.handleViewRangeChange(viewRangeParam);
+        });
         this.tooltipComponent = React.createRef();
         this.tooltipXYComponent = React.createRef();
         this.traceContextContainer = React.createRef();
@@ -228,7 +242,10 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             const { start, end } = this.props.persistedState.unitControllerViewRange;
             this.unitController.viewRange = { start: BigInt(start), end: BigInt(end) };
         } else {
-            this.unitController.viewRange = { start: BigInt(0), end: this.state.experiment.end - this.state.timeOffset };
+            this.unitController.viewRange = {
+                start: BigInt(0),
+                end: this.state.experiment.end - this.state.timeOffset
+            };
         }
         this.historyHandler.clear();
         this.historyHandler.addCurrentState();
@@ -247,7 +264,11 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                         timeOffset: updatedExperiment.start,
                         experiment: updatedExperiment,
                         traceIndexing: isIndexing,
-                        currentRange: new TimeRange(updatedExperiment.start - updatedExperiment.start, updatedExperiment.end - updatedExperiment.start, updatedExperiment.start)
+                        currentRange: new TimeRange(
+                            updatedExperiment.start - updatedExperiment.start,
+                            updatedExperiment.end - updatedExperiment.start,
+                            updatedExperiment.start
+                        )
                     });
 
                     // Update status bar
@@ -311,33 +332,39 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         if (prevProps.outputs.length < this.props.outputs.length) {
             // added a new output - scroll to bottom
             this.scrollToBottom();
-        } else if (prevProps.outputs.length === this.props.outputs.length &&
-            prevState.pinnedView === undefined && this.state.pinnedView !== undefined) {
+        } else if (
+            prevProps.outputs.length === this.props.outputs.length &&
+            prevState.pinnedView === undefined &&
+            this.state.pinnedView !== undefined
+        ) {
             // one of the existing outputs is pinned to top - scroll to top
             this.scrollToPinnedView();
-        } else if (prevProps.outputs.length === this.props.outputs.length &&
-            prevState.pinnedView !== undefined && this.state.pinnedView === undefined) {
-                // one of the existing outputs is unpinned - scroll to unpinned output
-                this.scrollToUnPinnedView(prevState.pinnedView);
-            }
+        } else if (
+            prevProps.outputs.length === this.props.outputs.length &&
+            prevState.pinnedView !== undefined &&
+            this.state.pinnedView === undefined
+        ) {
+            // one of the existing outputs is unpinned - scroll to unpinned output
+            this.scrollToUnPinnedView(prevState.pinnedView);
+        }
     }
 
     private scrollToBottom(): void {
         if (this.props.outputs.length) {
             const bottomOutputId = this.props.outputs[this.props.outputs.length - 1].id;
-            document.getElementById(this.state.experiment.UUID+bottomOutputId)?.focus();
+            document.getElementById(this.state.experiment.UUID + bottomOutputId)?.focus();
         }
     }
 
     private scrollToPinnedView(): void {
         if (this.state.pinnedView) {
-            document.getElementById(this.state.experiment.UUID+this.state.pinnedView.id)?.focus();
+            document.getElementById(this.state.experiment.UUID + this.state.pinnedView.id)?.focus();
         }
     }
 
     private scrollToUnPinnedView(view: OutputDescriptor) {
         if (view) {
-            document.getElementById(this.state.experiment.UUID+view.id)?.focus();
+            document.getElementById(this.state.experiment.UUID + view.id)?.focus();
         }
     }
 
@@ -352,23 +379,34 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     private zoomButton(zoomIn: boolean) {
         let position = (this.unitController.viewRange.end + this.unitController.viewRange.start) / BigInt(2);
         if (this.unitController.selectionRange) {
-            const positionMiddleSelection = (this.unitController.selectionRange.end + this.unitController.selectionRange.start) / BigInt(2);
-            if (positionMiddleSelection >= this.unitController.viewRange.start && positionMiddleSelection <= this.unitController.viewRange.end) {
+            const positionMiddleSelection =
+                (this.unitController.selectionRange.end + this.unitController.selectionRange.start) / BigInt(2);
+            if (
+                positionMiddleSelection >= this.unitController.viewRange.start &&
+                positionMiddleSelection <= this.unitController.viewRange.end
+            ) {
                 position = positionMiddleSelection;
             }
         }
         const startDistance = position - this.unitController.viewRange.start;
         const zoomFactor = zoomIn ? 0.8 : 1.25;
-        const newDuration = BIMath.clamp(Number(this.unitController.viewRangeLength) * zoomFactor,
-            BigInt(2), this.unitController.absoluteRange);
+        const newDuration = BIMath.clamp(
+            Number(this.unitController.viewRangeLength) * zoomFactor,
+            BigInt(2),
+            this.unitController.absoluteRange
+        );
         const newStartRange = BIMath.max(0, position - BIMath.round(Number(startDistance) * zoomFactor));
         const newEndRange = newStartRange + newDuration;
         this.unitController.viewRange = { start: newStartRange, end: newEndRange };
     }
 
     private onResize() {
-        const newWidth = this.traceContextContainer.current ? this.traceContextContainer.current.clientWidth - this.SCROLLBAR_PADDING : 0;
-        const bounds = this.traceContextContainer.current ? this.traceContextContainer.current.getBoundingClientRect() : { left: this.DEFAULT_COMPONENT_LEFT };
+        const newWidth = this.traceContextContainer.current
+            ? this.traceContextContainer.current.clientWidth - this.SCROLLBAR_PADDING
+            : 0;
+        const bounds = this.traceContextContainer.current
+            ? this.traceContextContainer.current.getBoundingClientRect()
+            : { left: this.DEFAULT_COMPONENT_LEFT };
         this.setState(prevState => ({ style: { ...prevState.style, width: newWidth, componentLeft: bounds.left } }));
         this.widgetResizeHandlers.forEach(h => h());
     }
@@ -379,7 +417,6 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     }
 
     private handleTimeSelectionChange(range?: TimelineChart.TimeGraphRange) {
-
         if (range) {
             const t1 = range.start + this.state.timeOffset;
             const t2 = range.end + this.state.timeOffset;
@@ -392,13 +429,16 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             const { start, end } = range;
             const payload = {
                 experimentUUID: this.props.experiment.UUID,
-                timeRange: new TimeRange(start, end),
+                timeRange: new TimeRange(start, end)
             } as TimeRangeUpdatePayload;
             signalManager().fireSelectionRangeUpdated(payload);
 
-            this.setState(prevState => ({
-                currentTimeSelection: new TimeRange(range.start, range.end, prevState.timeOffset)
-            }), () => this.updateHistory());
+            this.setState(
+                prevState => ({
+                    currentTimeSelection: new TimeRange(range.start, range.end, prevState.timeOffset)
+                }),
+                () => this.updateHistory()
+            );
         }
     }
 
@@ -410,9 +450,12 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         } as TimeRangeUpdatePayload;
         signalManager().fireViewRangeUpdated(payload);
 
-        this.setState(prevState => ({
-            currentViewRange: new TimeRange(viewRange.start, viewRange.end, prevState.timeOffset)
-        }), () => this.updateHistory());
+        this.setState(
+            prevState => ({
+                currentViewRange: new TimeRange(viewRange.start, viewRange.end, prevState.timeOffset)
+            }),
+            () => this.updateHistory()
+        );
     }
 
     private emitTimeRangeData = (): void => {
@@ -448,16 +491,21 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     }
 
     render(): JSX.Element {
-        const shouldRenderOutputs = (this.state.style.width > 0 && (this.props.outputs.length || this.props.overviewDescriptor));
-        return <div className='trace-context-container'
-            onContextMenu={event => this.onContextMenu(event)}
-            onKeyDown={event => this.onKeyDown(event)}
-            onKeyUp={event => this.onKeyUp(event)}
-            ref={this.traceContextContainer}>
-            <TooltipComponent ref={this.tooltipComponent} />
-            <TooltipXYComponent ref={this.tooltipXYComponent} />
-            {shouldRenderOutputs ? this.renderOutputs() : this.renderPlaceHolder()}
-        </div>;
+        const shouldRenderOutputs =
+            this.state.style.width > 0 && (this.props.outputs.length || this.props.overviewDescriptor);
+        return (
+            <div
+                className="trace-context-container"
+                onContextMenu={event => this.onContextMenu(event)}
+                onKeyDown={event => this.onKeyDown(event)}
+                onKeyUp={event => this.onKeyUp(event)}
+                ref={this.traceContextContainer}
+            >
+                <TooltipComponent ref={this.tooltipComponent} />
+                <TooltipXYComponent ref={this.tooltipXYComponent} />
+                {shouldRenderOutputs ? this.renderOutputs() : this.renderPlaceHolder()}
+            </div>
+        );
     }
 
     private onKeyDown(event: React.KeyboardEvent) {
@@ -524,141 +572,213 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             }
         }
 
-        const pinnedViewTimeScale = this.state.pinnedView?.type === 'TIME_GRAPH' || this.state.pinnedView?.type === 'TREE_TIME_XY';
+        const pinnedViewTimeScale =
+            this.state.pinnedView?.type === 'TIME_GRAPH' || this.state.pinnedView?.type === 'TREE_TIME_XY';
         const timeScaleChartExists = timeScaleCharts.length > 0 || pinnedViewTimeScale;
 
-        return <React.Fragment>
-            {
-                // Syntax to use ReactGridLayout with Custom Components, while passing resized dimensions to children:
-                // https://github.com/STRML/react-grid-layout/issues/299#issuecomment-524959229
-            }
-            {
-                this.props.overviewDescriptor && this._storedOverviewLayout &&
-                // Margin required to have the close button clickable, else overlapped by the tooltip container
-                <div style={{marginTop: '30px'}}>
-                    {this.renderGridLayout([this.props.overviewDescriptor] , [this._storedOverviewLayout], true)}
-                </div>
-            }
-            {this.state.pinnedView !== undefined && this._storedPinnedViewLayout !== undefined &&
-                !pinnedViewTimeScale &&
-                <div className='pinned-views-layout' style={{marginTop: (!this.props.overviewDescriptor) ? '30px' : '0px'}}>
-                    {this.renderGridLayout([this.state.pinnedView], [this._storedPinnedViewLayout])}
-                </div>
-            }
-            {timeScaleChartExists &&
-                <>
-                    <div style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING }}>
-                        <TimeAxisComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth, verticalAlign: 'bottom' }}
-                            addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />
+        return (
+            <React.Fragment>
+                {
+                    // Syntax to use ReactGridLayout with Custom Components, while passing resized dimensions to children:
+                    // https://github.com/STRML/react-grid-layout/issues/299#issuecomment-524959229
+                }
+                {this.props.overviewDescriptor && this._storedOverviewLayout && (
+                    // Margin required to have the close button clickable, else overlapped by the tooltip container
+                    <div style={{ marginTop: '30px' }}>
+                        {this.renderGridLayout([this.props.overviewDescriptor], [this._storedOverviewLayout], true)}
                     </div>
-                </>
-            }
-            {this.state.pinnedView !== undefined && this._storedPinnedViewLayout !== undefined &&
-                pinnedViewTimeScale &&
-                <div className='pinned-views-layout'>
-                    {this.renderGridLayout([this.state.pinnedView], [this._storedPinnedViewLayout])}
-                </div>
-            }
-            <div className='outputs-grid-layout'>
-            {timeScaleCharts.length > 0 &&
-                <>
-                    {this.renderGridLayout(timeScaleCharts, this._storedTimescaleLayout)}
-                </>
-            }
-            {timeScaleChartExists &&
-                <>
-                    <div className='sticky-div' style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING }}>
-                        <TimeNavigatorComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth }}
-                            addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />
-                    </div>
-                </>
-            }
+                )}
+                {this.state.pinnedView !== undefined &&
+                    this._storedPinnedViewLayout !== undefined &&
+                    !pinnedViewTimeScale && (
+                        <div
+                            className="pinned-views-layout"
+                            style={{ marginTop: !this.props.overviewDescriptor ? '30px' : '0px' }}
+                        >
+                            {this.renderGridLayout([this.state.pinnedView], [this._storedPinnedViewLayout])}
+                        </div>
+                    )}
+                {timeScaleChartExists && (
+                    <>
+                        <div style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING }}>
+                            <TimeAxisComponent
+                                unitController={this.unitController}
+                                style={{ ...this.state.style, width: chartWidth, verticalAlign: 'bottom' }}
+                                addWidgetResizeHandler={this.addWidgetResizeHandler}
+                                removeWidgetResizeHandler={this.removeWidgetResizeHandler}
+                            />
+                        </div>
+                    </>
+                )}
+                {this.state.pinnedView !== undefined &&
+                    this._storedPinnedViewLayout !== undefined &&
+                    pinnedViewTimeScale && (
+                        <div className="pinned-views-layout">
+                            {this.renderGridLayout([this.state.pinnedView], [this._storedPinnedViewLayout])}
+                        </div>
+                    )}
+                <div className="outputs-grid-layout">
+                    {timeScaleCharts.length > 0 && (
+                        <>{this.renderGridLayout(timeScaleCharts, this._storedTimescaleLayout)}</>
+                    )}
+                    {timeScaleChartExists && (
+                        <>
+                            <div
+                                className="sticky-div"
+                                style={{
+                                    marginLeft: this.state.style.chartOffset,
+                                    marginRight: this.SCROLLBAR_PADDING
+                                }}
+                            >
+                                <TimeNavigatorComponent
+                                    unitController={this.unitController}
+                                    style={{ ...this.state.style, width: chartWidth }}
+                                    addWidgetResizeHandler={this.addWidgetResizeHandler}
+                                    removeWidgetResizeHandler={this.removeWidgetResizeHandler}
+                                />
+                            </div>
+                        </>
+                    )}
 
-            {nonTimeScaleCharts.length > 0 &&
-                <div style={{marginTop: (!timeScaleChartExists && this.state.pinnedView === undefined && !this.props.overviewDescriptor) ? '30px' : '0px'}}>
-                    {this.renderGridLayout(nonTimeScaleCharts, this._storedNonTimescaleLayout)}
+                    {nonTimeScaleCharts.length > 0 && (
+                        <div
+                            style={{
+                                marginTop:
+                                    !timeScaleChartExists &&
+                                    this.state.pinnedView === undefined &&
+                                    !this.props.overviewDescriptor
+                                        ? '30px'
+                                        : '0px'
+                            }}
+                        >
+                            {this.renderGridLayout(nonTimeScaleCharts, this._storedNonTimescaleLayout)}
+                        </div>
+                    )}
                 </div>
-            }
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 
     private renderGridLayout(outputs: OutputDescriptor[], layout: Layout[], isOverview?: boolean) {
         const rowHeight = isOverview ? this.DEFAULT_OVERVIEW_ROWHEIGHT : this.DEFAULT_COMPONENT_ROWHEIGHT;
-        return <ResponsiveGridLayout margin={[0, 5]} isResizable={true} isDraggable={true} resizeHandles={['se', 's', 'sw']}
-        onLayoutChange={this.onLayoutChange} layouts={{ lg: layout }} cols={{ lg: 1 }} breakpoints={{ lg: 1200 }}
-        rowHeight={rowHeight}
-        draggableHandle={'.title-bar-label'}>
-            {outputs.map(output => {
-                let onOutputRemove;
-                let responseType;
-                if (isOverview) {
-                    onOutputRemove = this.props.onOverviewRemove;
-                    responseType = 'OVERVIEW';
-                }
-                else {
-                    onOutputRemove = this.props.onOutputRemove;
-                    responseType = output.type;
-                }
+        return (
+            <ResponsiveGridLayout
+                margin={[0, 5]}
+                isResizable={true}
+                isDraggable={true}
+                resizeHandles={['se', 's', 'sw']}
+                onLayoutChange={this.onLayoutChange}
+                layouts={{ lg: layout }}
+                cols={{ lg: 1 }}
+                breakpoints={{ lg: 1200 }}
+                rowHeight={rowHeight}
+                draggableHandle={'.title-bar-label'}
+            >
+                {outputs.map(output => {
+                    let onOutputRemove;
+                    let responseType;
+                    if (isOverview) {
+                        onOutputRemove = this.props.onOverviewRemove;
+                        responseType = 'OVERVIEW';
+                    } else {
+                        onOutputRemove = this.props.onOutputRemove;
+                        responseType = output.type;
+                    }
 
-                const outputProps: AbstractOutputProps = {
-                    tspClient: this.props.tspClient,
-                    tooltipComponent: this.tooltipComponent.current,
-                    tooltipXYComponent: this.tooltipXYComponent.current,
-                    traceId: this.state.experiment.UUID,
-                    traceName: this.props.experiment.name,
-                    outputDescriptor: output,
-                    markerCategories: this.props.markerCategoriesMap.get(output.id),
-                    markerSetId: this.props.markerSetId,
-                    range: this.state.currentRange,
-                    nbEvents: this.state.experiment.nbEvents,
-                    viewRange: this.state.currentViewRange,
-                    selectionRange: this.state.currentTimeSelection,
-                    style: this.state.style,
-                    onOutputRemove: onOutputRemove,
-                    unitController: this.unitController,
-                    outputWidth: this.state.style.width,
-                    backgroundTheme: this.state.backgroundTheme,
-                    setChartOffset: this.setChartOffset,
-                    pinned: this.state.pinnedView ? (this.state.pinnedView === output) : undefined
-                };
-                switch (responseType) {
-                    case 'OVERVIEW':
-                        return <TraceOverviewComponent key={this.OVERVIEW_OUTPUT_GRID_LAYOUT_ID}
-                        experiment={this.props.experiment}
-                        {...outputProps}></TraceOverviewComponent>;
-                    case 'TIME_GRAPH':
-                        if (this.chartPersistedState && this.chartPersistedState.output.id === output.id) {
-                            outputProps.persistChartState = this.chartPersistedState.payload;
-                            this.chartPersistedState = undefined;
-                        }
-                        return <TimegraphOutputComponent key={output.id} {...outputProps}
-                            addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler}
-                            className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
-                            />;
-                    case 'TREE_TIME_XY':
-                        if (this.chartPersistedState && this.chartPersistedState.output.id === output.id) {
-                            outputProps.persistChartState = this.chartPersistedState.payload;
-                            this.chartPersistedState = undefined;
-                        }
-                        return <XYOutputComponent key={output.id} {...outputProps} className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}/>;
-                    case 'TABLE':
-                        return <TableOutputComponent key={output.id} {...outputProps} className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}/>;
-                    case 'DATA_TREE':
-                        return <DataTreeOutputComponent key={output.id} {...outputProps} className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}/>;
-                    default:
-                        return <NullOutputComponent key={output.id} {...outputProps} className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}/>;
-                }
-            })}
-        </ResponsiveGridLayout>;
+                    const outputProps: AbstractOutputProps = {
+                        tspClient: this.props.tspClient,
+                        tooltipComponent: this.tooltipComponent.current,
+                        tooltipXYComponent: this.tooltipXYComponent.current,
+                        traceId: this.state.experiment.UUID,
+                        traceName: this.props.experiment.name,
+                        outputDescriptor: output,
+                        markerCategories: this.props.markerCategoriesMap.get(output.id),
+                        markerSetId: this.props.markerSetId,
+                        range: this.state.currentRange,
+                        nbEvents: this.state.experiment.nbEvents,
+                        viewRange: this.state.currentViewRange,
+                        selectionRange: this.state.currentTimeSelection,
+                        style: this.state.style,
+                        onOutputRemove: onOutputRemove,
+                        unitController: this.unitController,
+                        outputWidth: this.state.style.width,
+                        backgroundTheme: this.state.backgroundTheme,
+                        setChartOffset: this.setChartOffset,
+                        pinned: this.state.pinnedView ? this.state.pinnedView === output : undefined
+                    };
+                    switch (responseType) {
+                        case 'OVERVIEW':
+                            return (
+                                <TraceOverviewComponent
+                                    key={this.OVERVIEW_OUTPUT_GRID_LAYOUT_ID}
+                                    experiment={this.props.experiment}
+                                    {...outputProps}
+                                ></TraceOverviewComponent>
+                            );
+                        case 'TIME_GRAPH':
+                            if (this.chartPersistedState && this.chartPersistedState.output.id === output.id) {
+                                outputProps.persistChartState = this.chartPersistedState.payload;
+                                this.chartPersistedState = undefined;
+                            }
+                            return (
+                                <TimegraphOutputComponent
+                                    key={output.id}
+                                    {...outputProps}
+                                    addWidgetResizeHandler={this.addWidgetResizeHandler}
+                                    removeWidgetResizeHandler={this.removeWidgetResizeHandler}
+                                    className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
+                                />
+                            );
+                        case 'TREE_TIME_XY':
+                            if (this.chartPersistedState && this.chartPersistedState.output.id === output.id) {
+                                outputProps.persistChartState = this.chartPersistedState.payload;
+                                this.chartPersistedState = undefined;
+                            }
+                            return (
+                                <XYOutputComponent
+                                    key={output.id}
+                                    {...outputProps}
+                                    className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
+                                />
+                            );
+                        case 'TABLE':
+                            return (
+                                <TableOutputComponent
+                                    key={output.id}
+                                    {...outputProps}
+                                    className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
+                                />
+                            );
+                        case 'DATA_TREE':
+                            return (
+                                <DataTreeOutputComponent
+                                    key={output.id}
+                                    {...outputProps}
+                                    className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
+                                />
+                            );
+                        default:
+                            return (
+                                <NullOutputComponent
+                                    key={output.id}
+                                    {...outputProps}
+                                    className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
+                                />
+                            );
+                    }
+                })}
+            </ResponsiveGridLayout>
+        );
     }
 
     get persistedState(): PersistedState {
         const { currentRange, currentViewRange, currentTimeSelection, pinnedView } = this.state;
-        const { _storedNonTimescaleLayout: storedNonTimescaleLayout,
+        const {
+            _storedNonTimescaleLayout: storedNonTimescaleLayout,
             _storedTimescaleLayout: storedTimescaleLayout,
             _storedPinnedViewLayout: storedPinnedViewLayout,
-            _storedOverviewLayout: storedOverviewLayout } = this;
+            _storedOverviewLayout: storedOverviewLayout
+        } = this;
         const { start: ucStart, end: ucEnd } = this.unitController.viewRange;
         return {
             outputs: this.props.outputs,
@@ -680,11 +800,13 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             this._storedTimescaleLayout = [];
             this._storedNonTimescaleLayout = [];
         }
-        return <div className='no-output-placeholder'>
-            {'Trace loaded successfully.'}
-            <br />
-            {'To see available views, open the Trace Viewer.'}
-        </div>;
+        return (
+            <div className="no-output-placeholder">
+                {'Trace loaded successfully.'}
+                <br />
+                {'To see available views, open the Trace Viewer.'}
+            </div>
+        );
     }
 
     private undoHistory = (): void => {
@@ -704,7 +826,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         if (experimentUUID === this.props.experiment.UUID && timeRange) {
             this.unitController.selectionRange = {
                 start: timeRange.getStart(),
-                end: timeRange.getEnd(),
+                end: timeRange.getEnd()
             };
         }
     };
@@ -738,7 +860,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
 
             if (this.state.pinnedView && output.id === this._storedPinnedViewLayout?.i) {
                 existingPinnedLayout = this._storedPinnedViewLayout;
-            } else if (this.state.pinnedView?.id === output.id){
+            } else if (this.state.pinnedView?.id === output.id) {
                 let prevLayout: Layout | undefined = undefined;
                 if (output.type === 'TIME_GRAPH' || output.type === 'TREE_TIME_XY') {
                     prevLayout = this._storedTimescaleLayout.find(layout => layout.i === output.id);
@@ -759,30 +881,32 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             } else if (curChartNonTimeLine) {
                 existingNonTimeScaleLayouts.push(curChartNonTimeLine);
             } else if (output.type === 'TIME_GRAPH' || output.type === 'TREE_TIME_XY') {
-                const prevLayout = this._storedPinnedViewLayout?.i === output.id ? this._storedPinnedViewLayout : undefined;
+                const prevLayout =
+                    this._storedPinnedViewLayout?.i === output.id ? this._storedPinnedViewLayout : undefined;
                 newTimeScaleLayouts.push({
                     i: output.id,
                     x: 0,
                     y: 1,
                     w: 1,
                     h: prevLayout ? prevLayout.h : this.DEFAULT_COMPONENT_HEIGHT,
-                    minH: this.MIN_COMPONENT_HEIGHT,
+                    minH: this.MIN_COMPONENT_HEIGHT
                 });
             } else {
-                const prevLayout = this._storedPinnedViewLayout?.i === output.id ? this._storedPinnedViewLayout : undefined;
+                const prevLayout =
+                    this._storedPinnedViewLayout?.i === output.id ? this._storedPinnedViewLayout : undefined;
                 newNonTimeScaleLayouts.push({
                     i: output.id,
                     x: 0,
                     y: 1,
                     w: 1,
                     h: prevLayout ? prevLayout.h : this.DEFAULT_COMPONENT_HEIGHT,
-                    minH: this.MIN_COMPONENT_HEIGHT,
+                    minH: this.MIN_COMPONENT_HEIGHT
                 });
             }
         }
 
-        existingTimeScaleLayouts.sort((a,b) => (a.y > b.y) ? 1 : -1);
-        existingNonTimeScaleLayouts.sort((a,b) => (a.y > b.y) ? 1 : -1);
+        existingTimeScaleLayouts.sort((a, b) => (a.y > b.y ? 1 : -1));
+        existingNonTimeScaleLayouts.sort((a, b) => (a.y > b.y ? 1 : -1));
 
         existingTimeScaleLayouts = existingTimeScaleLayouts.concat(newTimeScaleLayouts);
         existingNonTimeScaleLayouts = existingNonTimeScaleLayouts.concat(newNonTimeScaleLayouts);

--- a/packages/react-components/src/components/trace-overview-component.tsx
+++ b/packages/react-components/src/components/trace-overview-component.tsx
@@ -8,11 +8,13 @@ type XYoutputOverviewProps = AbstractOutputProps & {
 };
 
 export class TraceOverviewComponent extends React.Component<XYoutputOverviewProps> {
-    constructor(props: XYoutputOverviewProps){
+    constructor(props: XYoutputOverviewProps) {
         super(props);
     }
 
     render(): JSX.Element {
-        return <XYOutputOverviewComponent key={this.props.outputDescriptor.id} {...this.props}></XYOutputOverviewComponent>;
+        return (
+            <XYOutputOverviewComponent key={this.props.outputDescriptor.id} {...this.props}></XYOutputOverviewComponent>
+        );
     }
 }

--- a/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
+++ b/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
@@ -5,17 +5,21 @@ import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 import { AvailableViewsComponent } from './utils/available-views-component';
 
 export interface TraceOverviewSelectionComponentProps extends DialogComponentProps {
-    tspClient: TspClient,
-    traceID: string
+    tspClient: TspClient;
+    traceID: string;
 }
 
 export interface TraceOverviewSelectionComponentState {
-    outputDescriptors: OutputDescriptor[]
+    outputDescriptors: OutputDescriptor[];
 }
 
-export class TraceOverviewSelectionDialogComponent extends AbstractDialogComponent<TraceOverviewSelectionComponentProps, TraceOverviewSelectionComponentState> {
+export class TraceOverviewSelectionDialogComponent extends AbstractDialogComponent<
+    TraceOverviewSelectionComponentProps,
+    TraceOverviewSelectionComponentState
+> {
     private selectedOutput: OutputDescriptor | undefined;
-    protected handleOutputClicked = (selectedOutput: OutputDescriptor): void => this.doHandleOutputClicked(selectedOutput);
+    protected handleOutputClicked = (selectedOutput: OutputDescriptor): void =>
+        this.doHandleOutputClicked(selectedOutput);
 
     constructor(props: TraceOverviewSelectionComponentProps) {
         super(props);
@@ -28,18 +32,18 @@ export class TraceOverviewSelectionDialogComponent extends AbstractDialogCompone
 
     protected renderDialogBody(): React.ReactElement {
         if (!this.state.outputDescriptors) {
-            return (<div>
-                Loading available outputs...
-            </div>);
+            return <div>Loading available outputs...</div>;
         }
         return (
             <div id="trace-overview-selection-dialog-content-container">
                 <AvailableViewsComponent
                     traceID={this.props.traceID}
-                    onOutputClicked={e => {this.doHandleOutputClicked(e);}}
+                    onOutputClicked={e => {
+                        this.doHandleOutputClicked(e);
+                    }}
                     outputDescriptors={this.state.outputDescriptors}
-                    listRowWidth='95%'
-                    listRowPadding='10px'
+                    listRowWidth="95%"
+                    listRowPadding="10px"
                 ></AvailableViewsComponent>
             </div>
         );
@@ -47,12 +51,14 @@ export class TraceOverviewSelectionDialogComponent extends AbstractDialogCompone
 
     protected renderFooter(): React.ReactElement {
         return (
-           <button className="theia-button secondary" onClick={this.props.onCloseDialog}>Close</button>
+            <button className="theia-button secondary" onClick={this.props.onCloseDialog}>
+                Close
+            </button>
         );
     }
 
     private async getAvailableOutputDescriptors() {
-        if (this.props.traceID){
+        if (this.props.traceID) {
             const result = await this.props.tspClient.experimentOutputs(this.props.traceID);
             const descriptors = result.getModel();
             const overviewOutputDescriptors = descriptors?.filter(output => output.type === 'TREE_TIME_XY');

--- a/packages/react-components/src/components/utils/__tests__/time-axis-component.test.tsx
+++ b/packages/react-components/src/components/utils/__tests__/time-axis-component.test.tsx
@@ -5,54 +5,78 @@ import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-cont
 import { OutputComponentStyle } from '../output-component-style';
 
 describe('Time axis component', () => {
-
-  let axisComponent: any;
+    let axisComponent: any;
     const ref = (el: TimeAxisComponent | undefined | null): void => {
-      axisComponent = el;
+        axisComponent = el;
     };
 
-  beforeEach(() => {
-    axisComponent = null;
-  });
+    beforeEach(() => {
+        axisComponent = null;
+    });
 
-  afterEach(() => {
-    cleanup();
-    jest.clearAllMocks();
-  });
+    afterEach(() => {
+        cleanup();
+        jest.clearAllMocks();
+    });
 
-  it('renders with provided style', () => {
-    const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
-    const style: OutputComponentStyle = {
-      width: 600,
-      chartOffset: 200,
-      componentLeft: 0,
-      height: 100,
-      rowHeight: 100,
-      naviBackgroundColor: 0xf4f7fb,
-      chartBackgroundColor: 0xf4f7fb,
-      cursorColor: 0x259fd8,
-      lineColor: 0x757575,
-    }
-    render(<div><TimeAxisComponent unitController={unitController} style={{...style, verticalAlign: 'bottom' }} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null} ref={ref}/></div>);
-    expect(axisComponent).toBeTruthy();
-    expect(axisComponent instanceof TimeAxisComponent).toBe(true);
-  });
+    it('renders with provided style', () => {
+        const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), {
+            start: BigInt(0),
+            end: BigInt(10)
+        });
+        const style: OutputComponentStyle = {
+            width: 600,
+            chartOffset: 200,
+            componentLeft: 0,
+            height: 100,
+            rowHeight: 100,
+            naviBackgroundColor: 0xf4f7fb,
+            chartBackgroundColor: 0xf4f7fb,
+            cursorColor: 0x259fd8,
+            lineColor: 0x757575
+        };
+        render(
+            <div>
+                <TimeAxisComponent
+                    unitController={unitController}
+                    style={{ ...style, verticalAlign: 'bottom' }}
+                    addWidgetResizeHandler={() => null}
+                    removeWidgetResizeHandler={() => null}
+                    ref={ref}
+                />
+            </div>
+        );
+        expect(axisComponent).toBeTruthy();
+        expect(axisComponent instanceof TimeAxisComponent).toBe(true);
+    });
 
-  it('creates canvas', () => {
-    const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
-    const style: OutputComponentStyle = {
-      width: 600,
-      chartOffset: 200,
-      componentLeft: 0,
-      height: 100,
-      rowHeight: 100,
-      naviBackgroundColor: 0xf4f7fb,
-      chartBackgroundColor: 0xf4f7fb,
-      cursorColor: 0x259fd8,
-      lineColor: 0x757575
-    }
+    it('creates canvas', () => {
+        const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), {
+            start: BigInt(0),
+            end: BigInt(10)
+        });
+        const style: OutputComponentStyle = {
+            width: 600,
+            chartOffset: 200,
+            componentLeft: 0,
+            height: 100,
+            rowHeight: 100,
+            naviBackgroundColor: 0xf4f7fb,
+            chartBackgroundColor: 0xf4f7fb,
+            cursorColor: 0x259fd8,
+            lineColor: 0x757575
+        };
 
-    const { container } = render(<div><TimeAxisComponent unitController={unitController} style={{...style, verticalAlign: 'bottom' }} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null}/></div>);
-    expect(container).toMatchSnapshot();
-  });
+        const { container } = render(
+            <div>
+                <TimeAxisComponent
+                    unitController={unitController}
+                    style={{ ...style, verticalAlign: 'bottom' }}
+                    addWidgetResizeHandler={() => null}
+                    removeWidgetResizeHandler={() => null}
+                />
+            </div>
+        );
+        expect(container).toMatchSnapshot();
+    });
 });

--- a/packages/react-components/src/components/utils/__tests__/time-navigator-component.test.tsx
+++ b/packages/react-components/src/components/utils/__tests__/time-navigator-component.test.tsx
@@ -4,47 +4,72 @@ import { TimeNavigatorComponent } from '../time-navigator-component';
 import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
 
 describe('Time axis component', () => {
+    let axisComponent: any;
+    const ref = (el: TimeNavigatorComponent | undefined | null): void => {
+        axisComponent = el;
+    };
 
-  let axisComponent: any;
-  const ref = (el: TimeNavigatorComponent | undefined | null): void => {
-    axisComponent = el;
-  };
+    beforeEach(() => {
+        axisComponent = null;
+    });
 
-  beforeEach(() => {
-    axisComponent = null;
-  });
+    afterEach(() => {
+        cleanup();
+        jest.clearAllMocks();
+    });
 
-  afterEach(() => {
-    cleanup();
-    jest.clearAllMocks();
-  });
+    it('renders with provided style', () => {
+        const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), {
+            start: BigInt(0),
+            end: BigInt(10)
+        });
+        const style = {
+            width: 600,
+            chartOffset: 200,
+            naviBackgroundColor: 0xf4f7fb,
+            cursorColor: 0x259fd8,
+            lineColor: 0x757575
+        };
 
-  it('renders with provided style', () => {
-    const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
-    const style = {
-      width: 600,
-      chartOffset: 200,
-      naviBackgroundColor: 0xf4f7fb,
-      cursorColor: 0x259fd8,
-      lineColor: 0x757575
-    }
+        render(
+            <div>
+                <TimeNavigatorComponent
+                    unitController={unitController}
+                    style={style}
+                    addWidgetResizeHandler={() => null}
+                    removeWidgetResizeHandler={() => null}
+                    ref={ref}
+                />
+            </div>
+        );
+        expect(axisComponent).toBeTruthy();
+        expect(axisComponent instanceof TimeNavigatorComponent).toBe(true);
+    });
 
-    render(<div><TimeNavigatorComponent unitController={unitController} style={style} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null} ref={ref}/></div>);
-    expect(axisComponent).toBeTruthy();
-    expect(axisComponent instanceof TimeNavigatorComponent).toBe(true);
-  });
+    it('creates canvas', () => {
+        const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), {
+            start: BigInt(0),
+            end: BigInt(10)
+        });
+        const style = {
+            width: 600,
+            chartOffset: 200,
+            naviBackgroundColor: 0xf4f7fb,
+            cursorColor: 0x259fd8,
+            lineColor: 0x757575
+        };
 
-  it('creates canvas', () => {
-    const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
-    const style = {
-      width: 600,
-      chartOffset: 200,
-      naviBackgroundColor: 0xf4f7fb,
-      cursorColor: 0x259fd8,
-      lineColor: 0x757575
-    }
-
-    const { container} = render(<div><TimeNavigatorComponent unitController={unitController} style={style} addWidgetResizeHandler={() => null} removeWidgetResizeHandler={() => null} ref={ref}/></div>);
-    expect(container).toMatchSnapshot();
-  });
+        const { container } = render(
+            <div>
+                <TimeNavigatorComponent
+                    unitController={unitController}
+                    style={style}
+                    addWidgetResizeHandler={() => null}
+                    removeWidgetResizeHandler={() => null}
+                    ref={ref}
+                />
+            </div>
+        );
+        expect(container).toMatchSnapshot();
+    });
 });

--- a/packages/react-components/src/components/utils/available-views-component.tsx
+++ b/packages/react-components/src/components/utils/available-views-component.tsx
@@ -5,29 +5,35 @@ import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 
 export interface AvailableViewsComponentProps {
-    traceID: string | undefined,
-    outputDescriptors: OutputDescriptor[],
-    onContextMenuEvent?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>, output: OutputDescriptor | undefined) => void,
-    onOutputClicked: (selectedOutput: OutputDescriptor) => void,
-    listRowWidth?: string,
-    listRowPadding?: string,
-    highlightAfterSelection?: boolean
+    traceID: string | undefined;
+    outputDescriptors: OutputDescriptor[];
+    onContextMenuEvent?: (
+        event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+        output: OutputDescriptor | undefined
+    ) => void;
+    onOutputClicked: (selectedOutput: OutputDescriptor) => void;
+    listRowWidth?: string;
+    listRowPadding?: string;
+    highlightAfterSelection?: boolean;
 }
 
 export interface AvailableViewsComponentState {
     lastSelectedOutputIndex: number;
 }
 
-export class AvailableViewsComponent  extends React.Component<AvailableViewsComponentProps, AvailableViewsComponentState>{
+export class AvailableViewsComponent extends React.Component<
+    AvailableViewsComponentProps,
+    AvailableViewsComponentState
+> {
     static LIST_MARGIN = 2;
     static LINE_HEIGHT = 16;
-    static ROW_HEIGHT = (2 * AvailableViewsComponent.LINE_HEIGHT) + AvailableViewsComponent.LIST_MARGIN;
+    static ROW_HEIGHT = 2 * AvailableViewsComponent.LINE_HEIGHT + AvailableViewsComponent.LIST_MARGIN;
 
     private _forceUpdateKey = false;
     protected handleOutputClicked = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOutputClicked(e);
     private _onExperimentSelected = (experiment: Experiment): void => this.doHandleExperimentSelectedSignal(experiment);
 
-    constructor(props: AvailableViewsComponentProps){
+    constructor(props: AvailableViewsComponentProps) {
         super(props);
         signalManager().on(Signals.EXPERIMENT_SELECTED, this._onExperimentSelected);
         this.state = { lastSelectedOutputIndex: -1 };
@@ -47,9 +53,9 @@ export class AvailableViewsComponent  extends React.Component<AvailableViewsComp
         }
         const totalHeight = this.getTotalHeight();
         return (
-            <div className='trace-explorer-panel-content disable-select' style={{height: totalHeight}}>
+            <div className="trace-explorer-panel-content disable-select" style={{ height: totalHeight }}>
                 <AutoSizer>
-                    {({ width }) =>
+                    {({ width }) => (
                         <List
                             key={key}
                             height={totalHeight}
@@ -58,7 +64,7 @@ export class AvailableViewsComponent  extends React.Component<AvailableViewsComp
                             rowHeight={AvailableViewsComponent.ROW_HEIGHT}
                             rowRenderer={this.renderRowOutputs}
                         />
-                    }
+                    )}
                 </AutoSizer>
             </div>
         );
@@ -90,40 +96,45 @@ export class AvailableViewsComponent  extends React.Component<AvailableViewsComp
             props.style.paddingRight = this.props.listRowPadding;
         }
 
-        return <div className={traceContainerClassName}
-            title={outputName + ':\n' + outputDescription}
-            id={`${traceContainerClassName}-${props.index}`}
-            key={props.key}
-            style={props.style}
-            onClick={this.handleOutputClicked}
-            onContextMenu={event => { this.doHandleContextMenuEvent(event, output); }}
-            data-id={`${props.index}`}
-        >
-            <div style={{width: '100%'}}>
-                <h4 className='outputs-element-name'>
-                    {outputName}
-                </h4>
-                <div className='outputs-element-description child-element'>
-                    {outputDescription}
+        return (
+            <div
+                className={traceContainerClassName}
+                title={outputName + ':\n' + outputDescription}
+                id={`${traceContainerClassName}-${props.index}`}
+                key={props.key}
+                style={props.style}
+                onClick={this.handleOutputClicked}
+                onContextMenu={event => {
+                    this.doHandleContextMenuEvent(event, output);
+                }}
+                data-id={`${props.index}`}
+            >
+                <div style={{ width: '100%' }}>
+                    <h4 className="outputs-element-name">{outputName}</h4>
+                    <div className="outputs-element-description child-element">{outputDescription}</div>
                 </div>
             </div>
-        </div>;
+        );
     }
 
-    private doHandleContextMenuEvent(event: React.MouseEvent<HTMLDivElement, MouseEvent>, output: OutputDescriptor | undefined) {
-        if (this.props.onContextMenuEvent)
-            {this.props.onContextMenuEvent(event, output);}
+    private doHandleContextMenuEvent(
+        event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+        output: OutputDescriptor | undefined
+    ) {
+        if (this.props.onContextMenuEvent) {
+            this.props.onContextMenuEvent(event, output);
+        }
     }
 
     protected doHandleExperimentSelectedSignal(experiment: Experiment | undefined): void {
-        if ((this.props.traceID !== experiment?.UUID) || this.props.outputDescriptors.length === 0) {
+        if (this.props.traceID !== experiment?.UUID || this.props.outputDescriptors.length === 0) {
             this.setState({ lastSelectedOutputIndex: -1 });
         }
     }
 
     private doHandleOutputClicked(e: React.MouseEvent<HTMLDivElement>) {
         const index = Number(e.currentTarget.getAttribute('data-id'));
-        this.setState({lastSelectedOutputIndex: index});
+        this.setState({ lastSelectedOutputIndex: index });
         const selectedOutput = this.props.outputDescriptors[index];
 
         this.props.onOutputClicked(selectedOutput);
@@ -132,7 +143,7 @@ export class AvailableViewsComponent  extends React.Component<AvailableViewsComp
     protected getTotalHeight(): number {
         let totalHeight = 0;
         const outputDescriptors = this.props.outputDescriptors;
-        outputDescriptors?.forEach(() => totalHeight += AvailableViewsComponent.ROW_HEIGHT);
+        outputDescriptors?.forEach(() => (totalHeight += AvailableViewsComponent.ROW_HEIGHT));
         return totalHeight;
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/entry-tree.test.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/entry-tree.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { EntryTree } from '../entry-tree';
 import { create } from 'react-test-renderer';
-import { render, fireEvent } from "@testing-library/react";
-import { within } from "@testing-library/dom";
+import { render, fireEvent } from '@testing-library/react';
+import { within } from '@testing-library/dom';
 
 const mockOnChecked = jest.fn();
 const mockOnCollapse = jest.fn();
@@ -10,19 +10,20 @@ const mockOnClose = jest.fn();
 const mockOnClick = jest.fn();
 
 test('Empty tree', () => {
-    const tree = create(<EntryTree
-        entries={[]}
-        collapsedNodes={[]}
-        checkedSeries={[]}
-        showCheckboxes={true}
-        showFilter={false}
-        onToggleCheck={mockOnChecked}
-        onToggleCollapse={mockOnCollapse}
-        onClose={mockOnClose}
-        onRowClick={mockOnClick}
-        showCloseIcons={false}
-    />)
-        .toJSON();
+    const tree = create(
+        <EntryTree
+            entries={[]}
+            collapsedNodes={[]}
+            checkedSeries={[]}
+            showCheckboxes={true}
+            showFilter={false}
+            onToggleCheck={mockOnChecked}
+            onToggleCollapse={mockOnCollapse}
+            onClose={mockOnClose}
+            onRowClick={mockOnClick}
+            showCloseIcons={false}
+        />
+    ).toJSON();
     expect(tree).toMatchSnapshot();
 });
 
@@ -31,69 +32,83 @@ test('one level of entries', () => {
         id: 0,
         parentId: -1,
         labels: ['entry1']
-
     };
     const entry2 = {
         id: 1,
         parentId: -1,
         labels: ['entry2', 'entry2 column2']
-
     };
-    const treeWithoutCheckboxes = create(<EntryTree
-        entries={[entry1, entry2]}
-        collapsedNodes={[]}
-        checkedSeries={[]}
-        showCheckboxes={false}
-        showFilter={false}
-        onToggleCheck={mockOnChecked}
-        onToggleCollapse={mockOnCollapse}
-        showCloseIcons={false}
-        onClose={mockOnClose}
-        onRowClick={mockOnClick}
-        showHeader={true}
-        headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-    />)
-        .toJSON();
+    const treeWithoutCheckboxes = create(
+        <EntryTree
+            entries={[entry1, entry2]}
+            collapsedNodes={[]}
+            checkedSeries={[]}
+            showCheckboxes={false}
+            showFilter={false}
+            onToggleCheck={mockOnChecked}
+            onToggleCollapse={mockOnCollapse}
+            showCloseIcons={false}
+            onClose={mockOnClose}
+            onRowClick={mockOnClick}
+            showHeader={true}
+            headers={[
+                { title: 'Sortable column', sortable: true },
+                { title: 'Unsortable column', sortable: false }
+            ]}
+        />
+    ).toJSON();
     expect(treeWithoutCheckboxes).toMatchSnapshot();
 
-    const treeWithCheckboxes = create(<EntryTree
-        entries={[entry1, entry2]}
-        collapsedNodes={[]}
-        checkedSeries={[]}
-        showCheckboxes={true}
-        showFilter={false}
-        onToggleCheck={mockOnChecked}
-        onToggleCollapse={mockOnCollapse}
-        showCloseIcons={false}
-        onClose={mockOnClose}
-        onRowClick={mockOnClick}
-        showHeader={true}
-        headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-    />)
+    const treeWithCheckboxes = create(
+        <EntryTree
+            entries={[entry1, entry2]}
+            collapsedNodes={[]}
+            checkedSeries={[]}
+            showCheckboxes={true}
+            showFilter={false}
+            onToggleCheck={mockOnChecked}
+            onToggleCollapse={mockOnCollapse}
+            showCloseIcons={false}
+            onClose={mockOnClose}
+            onRowClick={mockOnClick}
+            showHeader={true}
+            headers={[
+                { title: 'Sortable column', sortable: true },
+                { title: 'Unsortable column', sortable: false }
+            ]}
+        />
+    );
     expect(treeWithCheckboxes).toMatchSnapshot();
 
-    const treeWithoutHeaders = create(<EntryTree
-        entries={[entry1, entry2]}
-        collapsedNodes={[]}
-        checkedSeries={[]}
-        showCheckboxes={true}
-        showFilter={false}
-        onToggleCheck={mockOnChecked}
-        onToggleCollapse={mockOnCollapse}
-        onClose={mockOnClose}
-        onRowClick={mockOnClick}
-        showCloseIcons={false}
-        showHeader={false}
-        headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-    />)
+    const treeWithoutHeaders = create(
+        <EntryTree
+            entries={[entry1, entry2]}
+            collapsedNodes={[]}
+            checkedSeries={[]}
+            showCheckboxes={true}
+            showFilter={false}
+            onToggleCheck={mockOnChecked}
+            onToggleCollapse={mockOnCollapse}
+            onClose={mockOnClose}
+            onRowClick={mockOnClick}
+            showCloseIcons={false}
+            showHeader={false}
+            headers={[
+                { title: 'Sortable column', sortable: true },
+                { title: 'Unsortable column', sortable: false }
+            ]}
+        />
+    );
     expect(treeWithoutHeaders).toMatchSnapshot();
 });
 
-window.ResizeObserver = window.ResizeObserver || jest.fn().mockImplementation(() => ({
-    disconnect: jest.fn(),
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-}));
+window.ResizeObserver =
+    window.ResizeObserver ||
+    jest.fn().mockImplementation(() => ({
+        disconnect: jest.fn(),
+        observe: jest.fn(),
+        unobserve: jest.fn()
+    }));
 
 describe('Entry with children', () => {
     const parent = {
@@ -123,81 +138,98 @@ describe('Entry with children', () => {
     };
 
     test('All unchecked', () => {
-        const tree = create(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[]}
-            checkedSeries={[]}
-            showCheckboxes={true}
-            showFilter={false}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
-            .toJSON();
+        const tree = create(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[]}
+                checkedSeries={[]}
+                showCheckboxes={true}
+                showFilter={false}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        ).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('Check one grandchild', () => {
-        const tree = create(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[]}
-            showCheckboxes={true}
-            showFilter={false}
-            checkedSeries={[grandchild1.id]}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
-            .toJSON();
+        const tree = create(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[]}
+                showCheckboxes={true}
+                showFilter={false}
+                checkedSeries={[grandchild1.id]}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        ).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('Collapse one child', () => {
-        const tree = create(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[child2.id]}
-            checkedSeries={[]}
-            showCheckboxes={true}
-            showFilter={false}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
-            .toJSON();
+        const tree = create(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[child2.id]}
+                checkedSeries={[]}
+                showCheckboxes={true}
+                showFilter={false}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        ).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('Check series', () => {
         mockOnChecked.mockClear();
-        let { getByText } = render(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[]}
-            checkedSeries={[]}
-            showCheckboxes={true}
-            showFilter={false}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
+        let { getByText } = render(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[]}
+                checkedSeries={[]}
+                showCheckboxes={true}
+                showFilter={false}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        );
         // Check a parent and make sure all its children were selected too
         const element = getByText(child2.labels[0]);
-        const image = within(element).getAllByRole("img", {hidden: true})[1];
+        const image = within(element).getAllByRole('img', { hidden: true })[1];
         fireEvent.click(image as HTMLElement);
         expect(mockOnChecked).toHaveBeenCalledTimes(1);
         expect(mockOnChecked).toHaveBeenCalledWith([child2.id, grandchild1.id, grandchild2.id]);
@@ -205,7 +237,7 @@ describe('Entry with children', () => {
 
         // Check a child and make sure all its children were selected too
         const childElement = getByText(grandchild1.labels[0]);
-        const image2 = within(childElement).getByRole("img", {hidden: true});
+        const image2 = within(childElement).getByRole('img', { hidden: true });
         fireEvent.click(image2 as HTMLElement);
         expect(mockOnChecked).toHaveBeenCalledTimes(1);
         expect(mockOnChecked).toHaveBeenCalledWith([grandchild1.id]);
@@ -215,94 +247,112 @@ describe('Entry with children', () => {
         fireEvent.click(image as HTMLElement);
         expect(mockOnChecked).toHaveBeenCalledTimes(1);
         expect(mockOnChecked).toHaveBeenCalledWith([child2.id, grandchild1.id, grandchild2.id]);
-
     });
 
     test('Check series with previous selected', () => {
         mockOnChecked.mockClear();
-        let { getByText } = render(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[]}
-            showCheckboxes={true}
-            showFilter={false}
-            checkedSeries={[grandchild2.id]}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
+        let { getByText } = render(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[]}
+                showCheckboxes={true}
+                showFilter={false}
+                checkedSeries={[grandchild2.id]}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        );
         // Check a parent and make sure all its children were selected too
         const element = getByText(child2.labels[0]);
-        const image = within(element).getAllByRole("img", {hidden: true})[1];
+        const image = within(element).getAllByRole('img', { hidden: true })[1];
         fireEvent.click(image as HTMLElement);
-        expect(mockOnChecked).toHaveBeenCalledTimes(1)
-        expect(mockOnChecked).toHaveBeenCalledWith([child2.id, grandchild1.id])
+        expect(mockOnChecked).toHaveBeenCalledTimes(1);
+        expect(mockOnChecked).toHaveBeenCalledWith([child2.id, grandchild1.id]);
     });
 
     test('Collapse items', () => {
-        mockOnCollapse.mockClear()
-        const { getByText } = render(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[]}
-            checkedSeries={[]}
-            showCheckboxes={true}
-            showFilter={false}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
+        mockOnCollapse.mockClear();
+        const { getByText } = render(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[]}
+                checkedSeries={[]}
+                showCheckboxes={true}
+                showFilter={false}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        );
         // Click on the collapse icon of the element and make sure the function is called
         const element = getByText(child2.labels[0]);
-        const collapseImage = within(element).getAllByRole("img", {hidden: true})[0];
+        const collapseImage = within(element).getAllByRole('img', { hidden: true })[0];
         fireEvent.click(collapseImage as HTMLElement);
-        expect(mockOnCollapse).toHaveBeenCalledTimes(1)
-        expect(mockOnCollapse).toHaveBeenCalledWith(child2.id, expect.anything())
+        expect(mockOnCollapse).toHaveBeenCalledTimes(1);
+        expect(mockOnCollapse).toHaveBeenCalledWith(child2.id, expect.anything());
     });
 
     test('With filter element', () => {
-        const tree = create(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[]}
-            checkedSeries={[]}
-            showCheckboxes={true}
-            showFilter={true}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
-            .toJSON();
+        const tree = create(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[]}
+                checkedSeries={[]}
+                showCheckboxes={true}
+                showFilter={true}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        ).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     test('Filter items behavior', () => {
-        const { getByPlaceholderText, queryByText } = render(<EntryTree
-            entries={[child1, parent, child2, grandchild1, grandchild2]}
-            collapsedNodes={[]}
-            checkedSeries={[]}
-            showCheckboxes={true}
-            showFilter={true}
-            onToggleCheck={mockOnChecked}
-            onToggleCollapse={mockOnCollapse}
-            onClose={mockOnClose}
-            onRowClick={mockOnClick}
-            showCloseIcons={false}
-            showHeader={true}
-            headers={[{title: 'Sortable column', sortable: true}, {title: 'Unsortable column', sortable: false}]}
-        />)
+        const { getByPlaceholderText, queryByText } = render(
+            <EntryTree
+                entries={[child1, parent, child2, grandchild1, grandchild2]}
+                collapsedNodes={[]}
+                checkedSeries={[]}
+                showCheckboxes={true}
+                showFilter={true}
+                onToggleCheck={mockOnChecked}
+                onToggleCollapse={mockOnCollapse}
+                onClose={mockOnClose}
+                onRowClick={mockOnClick}
+                showCloseIcons={false}
+                showHeader={true}
+                headers={[
+                    { title: 'Sortable column', sortable: true },
+                    { title: 'Unsortable column', sortable: false }
+                ]}
+            />
+        );
         // Enter a filter and make sure only visible elements are present
-        const filterEl = getByPlaceholderText("Filter");
-        fireEvent.change(filterEl, {target: { value: grandchild2.labels[0]}});
+        const filterEl = getByPlaceholderText('Filter');
+        fireEvent.change(filterEl, { target: { value: grandchild2.labels[0] } });
 
         let treeEl = queryByText(parent.labels[0]);
         expect(treeEl).toBeTruthy();
@@ -320,8 +370,8 @@ describe('Entry with children', () => {
         expect(treeEl).toBeTruthy();
 
         // Remove the filter
-        const filterEl2 = getByPlaceholderText("Filter");
-        fireEvent.change(filterEl2, {target: { value: ""}});
+        const filterEl2 = getByPlaceholderText('Filter');
+        fireEvent.change(filterEl2, { target: { value: '' } });
 
         treeEl = queryByText(parent.labels[0]);
         expect(treeEl).toBeTruthy();

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/table-row.test.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/table-row.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { TreeNode } from '../tree-node';
 import { TableRow } from '../table-row';
 import { create } from 'react-test-renderer';
-import { render, fireEvent } from "@testing-library/react";
-import { within } from "@testing-library/dom";
+import { render, fireEvent } from '@testing-library/react';
+import { within } from '@testing-library/dom';
 
 const mockOnChecked = jest.fn();
 const mockOnCollapse = jest.fn();
@@ -11,7 +11,7 @@ const mockOnClose = jest.fn();
 const mockOnClick = jest.fn();
 const mockOnContext = jest.fn();
 
-const cell1Text = "cell1 - text";
+const cell1Text = 'cell1 - text';
 const testTreeNode = {
     id: 5,
     parentId: -1,
@@ -21,104 +21,133 @@ const testTreeNode = {
 } as TreeNode;
 
 test('Checked status', () => {
-    const treeNodeUnchecked = create(<TableRow
-        node={testTreeNode}
-        getCheckedStatus={id => 0}
-        level={0}
-        isCheckable={true}
-        collapsedNodes={[]}
-        onToggleCollapse={mockOnCollapse}
-        onRowClick={mockOnClick}
-        onContextMenu={mockOnContext}
-        onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
-        .toJSON();
+    const treeNodeUnchecked = create(
+        <TableRow
+            node={testTreeNode}
+            getCheckedStatus={id => 0}
+            level={0}
+            isCheckable={true}
+            collapsedNodes={[]}
+            onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
+            onToggleCheck={mockOnChecked}
+            isClosable={false}
+            onClose={mockOnClose}
+        />
+    ).toJSON();
     expect(treeNodeUnchecked).toMatchSnapshot();
 
-    const treeNodeChecked = create(<TableRow
-        node={testTreeNode}
-        getCheckedStatus={id => 1}
-        level={0}
-        isCheckable={true}
-        collapsedNodes={[]}
-        onToggleCollapse={mockOnCollapse}
-        onRowClick={mockOnClick}
-        onContextMenu={mockOnContext}
-        onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
-        .toJSON();
+    const treeNodeChecked = create(
+        <TableRow
+            node={testTreeNode}
+            getCheckedStatus={id => 1}
+            level={0}
+            isCheckable={true}
+            collapsedNodes={[]}
+            onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
+            onToggleCheck={mockOnChecked}
+            isClosable={false}
+            onClose={mockOnClose}
+        />
+    ).toJSON();
     expect(treeNodeChecked).toMatchSnapshot();
 
-    const treeNodePartialCheck = create(<TableRow
-        node={testTreeNode}
-        getCheckedStatus={id => 2}
-        level={0}
-        isCheckable={true}
-        collapsedNodes={[]}
-        onToggleCollapse={mockOnCollapse}
-        onRowClick={mockOnClick}
-        onContextMenu={mockOnContext}
-        onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
-        .toJSON();
+    const treeNodePartialCheck = create(
+        <TableRow
+            node={testTreeNode}
+            getCheckedStatus={id => 2}
+            level={0}
+            isCheckable={true}
+            collapsedNodes={[]}
+            onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
+            onToggleCheck={mockOnChecked}
+            isClosable={false}
+            onClose={mockOnClose}
+        />
+    ).toJSON();
     expect(treeNodePartialCheck).toMatchSnapshot();
 });
 
 test('Uncheckable', () => {
-    const uncheckableTree = create(<TableRow
-        node={testTreeNode}
-        level={0}
-        isCheckable={false}
-        getCheckedStatus={id => 0}
-        collapsedNodes={[]}
-        onToggleCollapse={mockOnCollapse}
-        onRowClick={mockOnClick}
-        onContextMenu={mockOnContext}
-        onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
-        .toJSON();
+    const uncheckableTree = create(
+        <TableRow
+            node={testTreeNode}
+            level={0}
+            isCheckable={false}
+            getCheckedStatus={id => 0}
+            collapsedNodes={[]}
+            onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
+            onToggleCheck={mockOnChecked}
+            isClosable={false}
+            onClose={mockOnClose}
+        />
+    ).toJSON();
     expect(uncheckableTree).toMatchSnapshot();
 });
 
 test('Levels', () => {
-    const lessPadding = create(<TableRow
-        node={testTreeNode}
-        getCheckedStatus={id => 0}
-        level={1}
-        isCheckable={true}
-        collapsedNodes={[]}
-        onToggleCollapse={mockOnCollapse}
-        onRowClick={mockOnClick}
-        onContextMenu={mockOnContext}
-        onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
-        .toJSON();
+    const lessPadding = create(
+        <TableRow
+            node={testTreeNode}
+            getCheckedStatus={id => 0}
+            level={1}
+            isCheckable={true}
+            collapsedNodes={[]}
+            onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
+            onToggleCheck={mockOnChecked}
+            isClosable={false}
+            onClose={mockOnClose}
+        />
+    ).toJSON();
     expect(lessPadding).toMatchSnapshot();
 
-    const morePadding = create(<TableRow
-        node={testTreeNode}
-        getCheckedStatus={id => 0}
-        level={10}
-        isCheckable={true}
-        collapsedNodes={[]}
-        onToggleCollapse={mockOnCollapse}
-        onRowClick={mockOnClick}
-        onContextMenu={mockOnContext}
-        onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
-        .toJSON();
+    const morePadding = create(
+        <TableRow
+            node={testTreeNode}
+            getCheckedStatus={id => 0}
+            level={10}
+            isCheckable={true}
+            collapsedNodes={[]}
+            onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
+            onToggleCheck={mockOnChecked}
+            isClosable={false}
+            onClose={mockOnClose}
+        />
+    ).toJSON();
     expect(morePadding).toMatchSnapshot();
 });
 
 test('Toggle check', async () => {
     mockOnChecked.mockClear();
-    let { getByText } = render(<TableRow
-        node={testTreeNode}
-        getCheckedStatus={id => 0}
-        level={0}
-        isCheckable={true}
-        collapsedNodes={[]}
-        onToggleCollapse={mockOnCollapse}
-        onRowClick={mockOnClick}
-        onContextMenu={mockOnContext}
-        onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}    />)
+    let { getByText } = render(
+        <TableRow
+            node={testTreeNode}
+            getCheckedStatus={id => 0}
+            level={0}
+            isCheckable={true}
+            collapsedNodes={[]}
+            onToggleCollapse={mockOnCollapse}
+            onRowClick={mockOnClick}
+            onContextMenu={mockOnContext}
+            onToggleCheck={mockOnChecked}
+            isClosable={false}
+            onClose={mockOnClose}
+        />
+    );
     const element = getByText(cell1Text);
-    let {getByRole} = within(element);
-    const image = getByRole("img",  {hidden: true});
+    let { getByRole } = within(element);
+    const image = getByRole('img', { hidden: true });
     fireEvent.click(image as HTMLElement);
     expect(mockOnChecked).toHaveBeenCalledTimes(1);
     expect(mockOnChecked).toHaveBeenCalledWith(testTreeNode.id);
@@ -129,8 +158,7 @@ test('Toggle check', async () => {
 });
 
 describe('with children', () => {
-    
-    const parentText = "parent text";
+    const parentText = 'parent text';
     const child1 = {
         id: 2,
         parentId: 1,
@@ -152,65 +180,74 @@ describe('with children', () => {
         children: [child1, child2],
         isRoot: true
     } as TreeNode;
-    
+
     test('With children', () => {
-        
-        let nodeWithChildren = create(<TableRow
-            node={parentNode}
-            getCheckedStatus={id => 0}
-            level={0}
-            isCheckable={true}
-            collapsedNodes={[]}
-            onToggleCollapse={mockOnCollapse}
-            onRowClick={mockOnClick}
-            onContextMenu={mockOnContext}
-            onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
-            .toJSON();
+        let nodeWithChildren = create(
+            <TableRow
+                node={parentNode}
+                getCheckedStatus={id => 0}
+                level={0}
+                isCheckable={true}
+                collapsedNodes={[]}
+                onToggleCollapse={mockOnCollapse}
+                onRowClick={mockOnClick}
+                onContextMenu={mockOnContext}
+                onToggleCheck={mockOnChecked}
+                isClosable={false}
+                onClose={mockOnClose}
+            />
+        ).toJSON();
         expect(nodeWithChildren).toMatchSnapshot();
-    })
+    });
 
     test('With children collapsed', () => {
-        
-        let nodeWithChildren = create(<TableRow
-            node={parentNode}
-            getCheckedStatus={id => 0}
-            level={0}
-            isCheckable={true}
-            collapsedNodes={[parentNode.id]}
-            onToggleCollapse={mockOnCollapse}
-            onRowClick={mockOnClick}
-            onContextMenu={mockOnContext}
-            onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
-            .toJSON();
+        let nodeWithChildren = create(
+            <TableRow
+                node={parentNode}
+                getCheckedStatus={id => 0}
+                level={0}
+                isCheckable={true}
+                collapsedNodes={[parentNode.id]}
+                onToggleCollapse={mockOnCollapse}
+                onRowClick={mockOnClick}
+                onContextMenu={mockOnContext}
+                onToggleCheck={mockOnChecked}
+                isClosable={false}
+                onClose={mockOnClose}
+            />
+        ).toJSON();
         expect(nodeWithChildren).toMatchSnapshot();
-    })
+    });
 
     test('Toggle collapse', () => {
         mockOnCollapse.mockClear();
-       
-        let { getByText } = render(<TableRow
-            node={parentNode}
-            getCheckedStatus={id => 0}
-            level={0}
-            isCheckable={true}
-            collapsedNodes={[]}
-            onToggleCollapse={mockOnCollapse}
-            onRowClick={mockOnClick}
-            onContextMenu={mockOnContext}
-            onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
-        const element = getByText(parentText);
-        const collapsedEl = within(element).getAllByRole("img", {hidden: true})[0];
-        fireEvent.click(collapsedEl as HTMLElement);
-        expect(mockOnCollapse).toHaveBeenCalledTimes(1)
-        expect(mockOnCollapse).toHaveBeenCalledWith(parentNode.id)  
-    });
 
+        let { getByText } = render(
+            <TableRow
+                node={parentNode}
+                getCheckedStatus={id => 0}
+                level={0}
+                isCheckable={true}
+                collapsedNodes={[]}
+                onToggleCollapse={mockOnCollapse}
+                onRowClick={mockOnClick}
+                onContextMenu={mockOnContext}
+                onToggleCheck={mockOnChecked}
+                isClosable={false}
+                onClose={mockOnClose}
+            />
+        );
+        const element = getByText(parentText);
+        const collapsedEl = within(element).getAllByRole('img', { hidden: true })[0];
+        fireEvent.click(collapsedEl as HTMLElement);
+        expect(mockOnCollapse).toHaveBeenCalledTimes(1);
+        expect(mockOnCollapse).toHaveBeenCalledWith(parentNode.id);
+    });
 });
 
 describe('Multiple labels', () => {
-    
-    const parentText = "parent 1 text";
-    const parentText2 = "parent 2 text";
+    const parentText = 'parent 1 text';
+    const parentText2 = 'parent 2 text';
     const child1 = {
         id: 2,
         parentId: 1,
@@ -232,21 +269,23 @@ describe('Multiple labels', () => {
         children: [child1, child2],
         isRoot: true
     } as TreeNode;
-    
-    test('With children and labels', () => {
-        
-        let nodeWithChildren = create(<TableRow
-            node={parentNode}
-            getCheckedStatus={id => 0}
-            level={0}
-            isCheckable={true}
-            collapsedNodes={[]}
-            onToggleCollapse={mockOnCollapse}
-            onRowClick={mockOnClick}
-            onContextMenu={mockOnContext}
-            onToggleCheck={mockOnChecked} isClosable={false} onClose={mockOnClose}        />)
-            .toJSON();
-        expect(nodeWithChildren).toMatchSnapshot();
-    })
 
+    test('With children and labels', () => {
+        let nodeWithChildren = create(
+            <TableRow
+                node={parentNode}
+                getCheckedStatus={id => 0}
+                level={0}
+                isCheckable={true}
+                collapsedNodes={[]}
+                onToggleCollapse={mockOnCollapse}
+                onRowClick={mockOnClick}
+                onContextMenu={mockOnContext}
+                onToggleCheck={mockOnChecked}
+                isClosable={false}
+                onClose={mockOnClose}
+            />
+        ).toJSON();
+        expect(nodeWithChildren).toMatchSnapshot();
+    });
 });

--- a/packages/react-components/src/components/utils/filter-tree/__tests__/utils.test.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/utils.test.tsx
@@ -1,4 +1,4 @@
-import { listToTree } from "../utils";
+import { listToTree } from '../utils';
 
 describe('listToTree', () => {
     const parent = {
@@ -28,39 +28,44 @@ describe('listToTree', () => {
     };
 
     test('Basic case, empty headers', () => {
-        const expectedTree = ({
+        const expectedTree = {
             labels: parent.labels,
             isRoot: true,
             id: parent.id,
             parentId: parent.parentId,
-            children: [{
-                labels: child1.labels,
-                isRoot: false,
-                id: child1.id,
-                parentId: child1.parentId,
-                children: []
-            }, {
-                labels: child2.labels,
-                isRoot: false,
-                id: child2.id,
-                parentId: child2.parentId,
-                children: [{
-                    labels: grandchild1.labels,
+            children: [
+                {
+                    labels: child1.labels,
                     isRoot: false,
-                    id: grandchild1.id,
-                    parentId: grandchild1.parentId,
+                    id: child1.id,
+                    parentId: child1.parentId,
                     children: []
-                }, {
-                    labels: grandchild2.labels,
+                },
+                {
+                    labels: child2.labels,
                     isRoot: false,
-                    id: grandchild2.id,
-                    parentId: grandchild2.parentId,
-                    children: []
-                }]
-            }]
-        });
+                    id: child2.id,
+                    parentId: child2.parentId,
+                    children: [
+                        {
+                            labels: grandchild1.labels,
+                            isRoot: false,
+                            id: grandchild1.id,
+                            parentId: grandchild1.parentId,
+                            children: []
+                        },
+                        {
+                            labels: grandchild2.labels,
+                            isRoot: false,
+                            id: grandchild2.id,
+                            parentId: grandchild2.parentId,
+                            children: []
+                        }
+                    ]
+                }
+            ]
+        };
         const tree = listToTree([child1, parent, child2, grandchild1, grandchild2], []);
-        expect(tree).toMatchObject([expectedTree]);  
+        expect(tree).toMatchObject([expectedTree]);
     });
-
 });

--- a/packages/react-components/src/components/utils/filter-tree/checkbox-component.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/checkbox-component.tsx
@@ -30,8 +30,10 @@ export class CheckboxComponent extends React.Component<CheckboxProps> {
     };
 
     render(): JSX.Element {
-        return <div style={{ paddingRight: 5, display: 'inline' }} onClick={this.handleClick}>
+        return (
+            <div style={{ paddingRight: 5, display: 'inline' }} onClick={this.handleClick}>
                 {this.renderCheckbox(this.props.checkedStatus)}
-            </div>;
+            </div>
+        );
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/column-header.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/column-header.tsx
@@ -1,9 +1,9 @@
 import { DataType } from 'tsp-typescript-client/lib/models/data-type';
 
 export default interface ColumnHeader {
-    title: string,
-    tooltip?: string,
-    sortable?: boolean,
-    resizable?: boolean,
-    dataType?: DataType
+    title: string;
+    tooltip?: string;
+    sortable?: boolean;
+    resizable?: boolean;
+    dataType?: DataType;
 }

--- a/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
@@ -27,10 +27,12 @@ interface EntryTreeProps {
 export class EntryTree extends React.Component<EntryTreeProps> {
     static defaultProps: Partial<EntryTreeProps> = {
         showFilter: true,
-        onOrderChange: () => { /* Nothing to do */ },
+        onOrderChange: () => {
+            /* Nothing to do */
+        },
         showHeader: true,
         className: 'table-tree',
-        headers: [{title: 'Name', sortable: true}]
+        headers: [{ title: 'Name', sortable: true }]
     };
 
     constructor(props: EntryTreeProps) {
@@ -38,13 +40,12 @@ export class EntryTree extends React.Component<EntryTreeProps> {
     }
 
     shouldComponentUpdate = (nextProps: EntryTreeProps): boolean =>
-        (this.props.checkedSeries !== nextProps.checkedSeries || this.props.entries !== nextProps.entries
-            || this.props.collapsedNodes !== nextProps.collapsedNodes || this.props.selectedRow !== nextProps.selectedRow);
+        this.props.checkedSeries !== nextProps.checkedSeries ||
+        this.props.entries !== nextProps.entries ||
+        this.props.collapsedNodes !== nextProps.collapsedNodes ||
+        this.props.selectedRow !== nextProps.selectedRow;
 
     render(): JSX.Element {
-        return <FilterTree
-            nodes={listToTree(this.props.entries, this.props.headers)}
-            {...this.props}
-        />;
+        return <FilterTree nodes={listToTree(this.props.entries, this.props.headers)} {...this.props} />;
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/filter.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/filter.tsx
@@ -5,10 +5,9 @@ interface FilterProps {
 }
 
 interface FilterState {
-    width: number
+    width: number;
 }
 export class Filter extends React.Component<FilterProps, FilterState> {
-
     private ref: React.RefObject<HTMLDivElement>;
     private resizeObserver: ResizeObserver;
 
@@ -37,14 +36,11 @@ export class Filter extends React.Component<FilterProps, FilterState> {
     }
 
     render(): JSX.Element {
-        return <div ref={this.ref} onChange={this.props.onChange} id="input-filter-container">
-            <i id="input-filter-icon" className='codicon codicon-filter'></i>
-            <input
-                id="input-filter-tree"
-                type="text"
-                placeholder="Filter"
-                style={{width: this.state.width}}
-            />
-        </div>;
+        return (
+            <div ref={this.ref} onChange={this.props.onChange} id="input-filter-container">
+                <i id="input-filter-icon" className="codicon codicon-filter"></i>
+                <input id="input-filter-tree" type="text" placeholder="Filter" style={{ width: this.state.width }} />
+            </div>
+        );
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/icons.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/icons.tsx
@@ -1,29 +1,39 @@
 import * as React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronDown, faChevronRight, faCheckSquare, faSquare, faMinusSquare, faSort, faSortDown, faSortUp, faTimes } from '@fortawesome/free-solid-svg-icons';
+import {
+    faChevronDown,
+    faChevronRight,
+    faCheckSquare,
+    faSquare,
+    faMinusSquare,
+    faSort,
+    faSortDown,
+    faSortUp,
+    faTimes
+} from '@fortawesome/free-solid-svg-icons';
 
 interface iconsShape {
-    expand: React.ReactNode,
-    collapse: React.ReactNode,
-    unchecked: React.ReactNode,
-    checked: React.ReactNode,
-    halfChecked: React.ReactNode,
-    sort: React.ReactNode,
-    sortDown: React.ReactNode,
-    sortUp: React.ReactNode,
-    close: React.ReactNode
+    expand: React.ReactNode;
+    collapse: React.ReactNode;
+    unchecked: React.ReactNode;
+    checked: React.ReactNode;
+    halfChecked: React.ReactNode;
+    sort: React.ReactNode;
+    sortDown: React.ReactNode;
+    sortUp: React.ReactNode;
+    close: React.ReactNode;
 }
 
 const icons: iconsShape = {
-    expand: <FontAwesomeIcon icon={faChevronRight}/>,
-    collapse: <FontAwesomeIcon icon={faChevronDown}/>,
-    unchecked: <FontAwesomeIcon icon={faSquare}/>,
-    checked: <FontAwesomeIcon icon={faCheckSquare}/>,
-    halfChecked: <FontAwesomeIcon icon={faMinusSquare}/>,
-    sort: <FontAwesomeIcon icon={faSort}/>,
-    sortDown: <FontAwesomeIcon icon={faSortDown}/>,
-    sortUp: <FontAwesomeIcon icon={faSortUp}/>,
-    close: <FontAwesomeIcon icon={faTimes}/>
+    expand: <FontAwesomeIcon icon={faChevronRight} />,
+    collapse: <FontAwesomeIcon icon={faChevronDown} />,
+    unchecked: <FontAwesomeIcon icon={faSquare} />,
+    checked: <FontAwesomeIcon icon={faCheckSquare} />,
+    halfChecked: <FontAwesomeIcon icon={faMinusSquare} />,
+    sort: <FontAwesomeIcon icon={faSort} />,
+    sortDown: <FontAwesomeIcon icon={faSortDown} />,
+    sortUp: <FontAwesomeIcon icon={faSortUp} />,
+    close: <FontAwesomeIcon icon={faTimes} />
 };
 
 export default icons;

--- a/packages/react-components/src/components/utils/filter-tree/message.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/message.tsx
@@ -14,8 +14,10 @@ export class Message extends React.Component<MessageProps> {
     };
 
     render(): JSX.Element {
-        return <React.Fragment>
-            <span>{this.props.error}</span>
-        </React.Fragment>;
+        return (
+            <React.Fragment>
+                <span>{this.props.error}</span>
+            </React.Fragment>
+        );
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/sort.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/sort.tsx
@@ -2,8 +2,8 @@ import icons from './icons';
 import { TreeNode } from './tree-node';
 
 interface SortState {
-    asc: React.ReactNode,
-    desc: React.ReactNode,
+    asc: React.ReactNode;
+    desc: React.ReactNode;
     default: React.ReactNode;
 }
 
@@ -59,7 +59,7 @@ export const sortNodes = (nodes: TreeNode[], sortConfig: SortConfig[]): TreeNode
                     comp = value1.localeCompare(value2);
                 }
             }
-            return (orderToSort.sortState === sortState.asc) ? comp : -comp;
+            return orderToSort.sortState === sortState.asc ? comp : -comp;
         });
         sortedNodes.forEach((node: TreeNode) => {
             if (node.children.length) {
@@ -82,7 +82,7 @@ const parseValue = (valueString: string): number | undefined => {
         const unit = valueArray[1];
         if (unit === 'ns' || unit === '%') {
             factor = 1;
-        } else if (unit === 'us' || unit === ('\u00B5' + 's')) {
+        } else if (unit === 'us' || unit === '\u00B5' + 's') {
             factor = 1000;
         } else if (unit === 'ms') {
             factor = 1000 * 1000;
@@ -98,4 +98,3 @@ const parseValue = (valueString: string): number | undefined => {
     }
     return undefined;
 };
-

--- a/packages/react-components/src/components/utils/filter-tree/table-body.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-body.tsx
@@ -21,23 +21,17 @@ export class TableBody extends React.Component<TableBodyProps> {
         super(props);
     }
 
-    createRow = (node: TreeNode): React.ReactNode =>
-        <TableRow
-            {...this.props}
-            key={'row-' + node.id}
-            node={node}
-            level={0}
-        />;
+    createRow = (node: TreeNode): React.ReactNode => (
+        <TableRow {...this.props} key={'row-' + node.id} node={node} level={0} />
+    );
 
     renderRows = (): React.ReactNode => this.props.nodes.map((node: TreeNode) => this.createRow(node));
 
     render(): React.ReactNode | undefined {
-        if (!this.props.nodes) { return undefined; }
+        if (!this.props.nodes) {
+            return undefined;
+        }
 
-        return (
-            <tbody>
-                {this.renderRows()}
-            </tbody>
-        );
+        return <tbody>{this.renderRows()}</tbody>;
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-cell.tsx
@@ -16,7 +16,7 @@ export class TableCell extends React.Component<TableCellProps> {
         const content = node.labels[index];
 
         return (
-            <td key={this.props.index+'-td-'+this.props.node.id}>
+            <td key={this.props.index + '-td-' + this.props.node.id}>
                 <span>
                     {this.props.children}
                     {content}

--- a/packages/react-components/src/components/utils/filter-tree/table-header.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-header.tsx
@@ -75,42 +75,46 @@ export class TableHeader extends React.Component<TableHeaderProps> {
     };
 
     /* Capitalize first character and add non-breaking spaces to make room for icons in default width calcluation */
-    toHeaderTitle = (name: string): string => (name.charAt(0).toUpperCase() + name.slice(1) + '\xa0\xa0\xa0\xa0\xa0');
+    toHeaderTitle = (name: string): string => name.charAt(0).toUpperCase() + name.slice(1) + '\xa0\xa0\xa0\xa0\xa0';
 
     renderSortIcon = (column: string): React.ReactNode | undefined => {
         if (this.props.sortableColumns.includes(column)) {
             const state = this.props.sortConfig.find((config: SortConfig) => config.column === column);
-            return state
-                ? <span className='sort-icon'>{state.sortState}</span>
-                : undefined;
+            return state ? <span className="sort-icon">{state.sortState}</span> : undefined;
         }
         return undefined;
     };
 
     renderResizeIcon = (index: number): React.ReactNode =>
-        (this.props.columns[index].resizable)
-            ? <span className='resize-handle' onMouseDown={ev => this.handleResizeMouseDown(ev, index)} onDoubleClick={ev => this.handleResizeDoubleClick(ev, index)}>|</span>
-            : undefined;
+        this.props.columns[index].resizable ? (
+            <span
+                className="resize-handle"
+                onMouseDown={ev => this.handleResizeMouseDown(ev, index)}
+                onDoubleClick={ev => this.handleResizeDoubleClick(ev, index)}
+            >
+                |
+            </span>
+        ) : undefined;
 
     renderHeader = (): React.ReactNode => {
-        const header = this.props.columns.map((column: ColumnHeader, index) =>
-            <th key={'th-'+index} onClick={ev => this.handleSortChange(column.title, ev)}>
+        const header = this.props.columns.map((column: ColumnHeader, index) => (
+            <th key={'th-' + index} onClick={ev => this.handleSortChange(column.title, ev)}>
                 <span>
                     {this.toHeaderTitle(column.title)}
                     {this.renderResizeIcon(index)}
                     {this.renderSortIcon(column.title)}
                 </span>
             </th>
-        );
-        header.push(<th key={'th-filler'} className='filler'/>);
+        ));
+        header.push(<th key={'th-filler'} className="filler" />);
         return header;
     };
 
     render(): React.ReactNode {
-        return <thead>
-            <tr>
-                {this.renderHeader()}
-            </tr>
-        </thead>;
+        return (
+            <thead>
+                <tr>{this.renderHeader()}</tr>
+            </thead>
+        );
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-row.tsx
@@ -36,58 +36,55 @@ export class TableRow extends React.Component<TableRowProps> {
 
     renderToggleCollapse = (): React.ReactNode => {
         const width = (this.props.level + 1) * 12;
-        return (
-            (this.props.node.children.length === 0)
-                ? <div style={{ width, paddingRight: 5, display: 'inline-block' }} />
-                : <div style={{ width, paddingRight: 5, textAlign: 'right', display: 'inline-block' }} onClick={this.handleCollapse}>
-                    {(this.isCollapsed() ? icons.expand : icons.collapse)}</div>
+        return this.props.node.children.length === 0 ? (
+            <div style={{ width, paddingRight: 5, display: 'inline-block' }} />
+        ) : (
+            <div
+                style={{ width, paddingRight: 5, textAlign: 'right', display: 'inline-block' }}
+                onClick={this.handleCollapse}
+            >
+                {this.isCollapsed() ? icons.expand : icons.collapse}
+            </div>
         );
     };
 
     renderCheckbox = (): React.ReactNode => {
         const checkedStatus = this.props.getCheckedStatus(this.props.node.id);
-        return this.props.isCheckable
-            ? <CheckboxComponent
+        return this.props.isCheckable ? (
+            <CheckboxComponent
                 key={this.props.node.id}
                 id={this.props.node.id}
                 checkedStatus={checkedStatus}
                 onToggleCheck={this.props.onToggleCheck}
             />
-            : undefined;
+        ) : undefined;
     };
 
     renderCloseButton = (): React.ReactNode =>
-        (this.props.isClosable && this.props.node.id)
-            ? <div style={{ paddingRight: 5, display: 'inline' }} onClick={this.handleClose}>{icons.close}</div>
-            : undefined;
+        this.props.isClosable && this.props.node.id ? (
+            <div style={{ paddingRight: 5, display: 'inline' }} onClick={this.handleClose}>
+                {icons.close}
+            </div>
+        ) : undefined;
 
     renderRow = (): React.ReactNode => {
-        const { node} = this.props;
-        const row = node.labels.map((_label: string, index) =>
-            <TableCell
-                key={node.id + '-' + index}
-                index={index}
-                node={node}
-            >
-                { (index === 0) ? this.renderToggleCollapse() : undefined }
-                { (index === 0) ? this.renderCheckbox() : undefined }
-                { (index === 0) ? this.renderCloseButton() : undefined }
+        const { node } = this.props;
+        const row = node.labels.map((_label: string, index) => (
+            <TableCell key={node.id + '-' + index} index={index} node={node}>
+                {index === 0 ? this.renderToggleCollapse() : undefined}
+                {index === 0 ? this.renderCheckbox() : undefined}
+                {index === 0 ? this.renderCloseButton() : undefined}
             </TableCell>
-        );
-        row.push(<td key={node.id + '-filler'} className='filler'/>);
+        ));
+        row.push(<td key={node.id + '-filler'} className="filler" />);
         return row;
     };
 
     renderChildren = (): React.ReactNode | undefined => {
         if (this.props.node.children.length && !this.isCollapsed()) {
-            return this.props.node.children.map((child: TreeNode) =>
-                <TableRow
-                    {...this.props}
-                    key={child.id}
-                    node={child}
-                    level={this.props.level + 1}
-                />
-            );
+            return this.props.node.children.map((child: TreeNode) => (
+                <TableRow {...this.props} key={child.id} node={child} level={this.props.level + 1} />
+            ));
         }
         return undefined;
     };
@@ -107,18 +104,18 @@ export class TableRow extends React.Component<TableRowProps> {
     };
 
     render(): React.ReactNode | undefined {
-        if (!this.props.node) { return undefined; }
+        if (!this.props.node) {
+            return undefined;
+        }
         const children = this.renderChildren();
         const { node, selectedRow } = this.props;
         const className = selectedRow === node.id ? 'selected' : '';
 
         return (
             <React.Fragment>
-                <tr
-                    className={className}
-                    onClick={this.onClick}
-                    onContextMenu={this.onContextMenu}
-                >{this.renderRow()}</tr>
+                <tr className={className} onClick={this.onClick} onContextMenu={this.onContextMenu}>
+                    {this.renderRow()}
+                </tr>
                 {children}
             </React.Fragment>
         );

--- a/packages/react-components/src/components/utils/filter-tree/table.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table.tsx
@@ -26,7 +26,6 @@ interface TableProps {
 }
 
 export class Table extends React.Component<TableProps> {
-
     private sortableColumns: string[];
 
     constructor(props: TableProps) {
@@ -58,20 +57,22 @@ export class Table extends React.Component<TableProps> {
     };
 
     render(): JSX.Element {
-        const gridTemplateColumns = this.props.headers.map(() => 'max-content').join(' ').concat(' minmax(0px, 1fr)');
+        const gridTemplateColumns = this.props.headers
+            .map(() => 'max-content')
+            .join(' ')
+            .concat(' minmax(0px, 1fr)');
         return (
             <div>
                 <table style={{ gridTemplateColumns: gridTemplateColumns }} className={this.props.className}>
-                    {this.props.showHeader && <TableHeader
-                        columns={this.props.headers}
-                        sortableColumns={this.sortableColumns}
-                        onSort={this.onSortChange}
-                        sortConfig={this.props.sortConfig}
-                    />}
-                    <TableBody
-                        {...this.props}
-                        nodes={sortNodes(this.props.nodes, this.props.sortConfig)}
-                    />
+                    {this.props.showHeader && (
+                        <TableHeader
+                            columns={this.props.headers}
+                            sortableColumns={this.sortableColumns}
+                            onSort={this.onSortChange}
+                            sortConfig={this.props.sortConfig}
+                        />
+                    )}
+                    <TableBody {...this.props} nodes={sortNodes(this.props.nodes, this.props.sortConfig)} />
                 </table>
             </div>
         );

--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -12,11 +12,11 @@ interface FilterTreeProps {
     nodes: TreeNode[];
     showCheckboxes: boolean;
     showCloseIcons: boolean;
-    showFilter: boolean;                    // Optional
-    checkedSeries: number[];                // Optional
+    showFilter: boolean; // Optional
+    checkedSeries: number[]; // Optional
     collapsedNodes: number[];
     selectedRow?: number;
-    onToggleCheck: (ids: number[]) => void;     // Optional
+    onToggleCheck: (ids: number[]) => void; // Optional
     onClose: (id: number) => void;
     onRowClick: (id: number) => void;
     onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
@@ -36,8 +36,12 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     static defaultProps: Partial<FilterTreeProps> = {
         checkedSeries: [],
         showFilter: true,
-        onToggleCheck: () => { /* Nothing to do */ },
-        onOrderChange: () => { /* Nothing to do */ },
+        onToggleCheck: () => {
+            /* Nothing to do */
+        },
+        onOrderChange: () => {
+            /* Nothing to do */
+        }
     };
 
     constructor(props: FilterTreeProps) {
@@ -133,7 +137,9 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
         const checkedNode = this.getNode(this.props.nodes, id);
         if (checkedNode) {
             const childrenIds = this.getAllChildrenIds(checkedNode, []);
-            const visibleChildrenIds = childrenIds.filter((childId: number) => this.getNode(this.state.filteredNodes, childId) !== undefined);
+            const visibleChildrenIds = childrenIds.filter(
+                (childId: number) => this.getNode(this.state.filteredNodes, childId) !== undefined
+            );
             if (!this.isNodeChecked(id)) {
                 if (checkedNode.children.length) {
                     const childIdsToCheck = visibleChildrenIds.filter(childId => !this.isNodeChecked(childId));
@@ -179,7 +185,9 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     };
 
     isEveryChildChecked = (node: TreeNode): boolean => {
-        const visibleNodes = node.children.filter((child: TreeNode) => this.getNode(this.state.filteredNodes, child.id) !== undefined);
+        const visibleNodes = node.children.filter(
+            (child: TreeNode) => this.getNode(this.state.filteredNodes, child.id) !== undefined
+        );
         let allChildrenChecked = false;
         if (visibleNodes.length) {
             allChildrenChecked = visibleNodes.every((child: TreeNode) => {
@@ -206,13 +214,14 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
         return ids;
     };
 
-    isSomeChildChecked = (node: TreeNode): boolean => node.children.some((child: TreeNode) => {
-        let isChecked = this.isNodeChecked(child.id);
-        if (child.children.length) {
-            isChecked = isChecked || this.isSomeChildChecked(child);
-        }
-        return isChecked;
-    });
+    isSomeChildChecked = (node: TreeNode): boolean =>
+        node.children.some((child: TreeNode) => {
+            let isChecked = this.isNodeChecked(child.id);
+            if (child.children.length) {
+                isChecked = isChecked || this.isSomeChildChecked(child);
+            }
+            return isChecked;
+        });
 
     isCollapsed = (id: number): boolean => this.props.collapsedNodes.includes(id);
 
@@ -242,18 +251,21 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     };
 
     filterTree = (nodes: TreeNode[], matchedIds: number[]): TreeNode[] =>
-        nodes.filter((node: TreeNode) => matchedIds.indexOf(node.id) > -1)
+        nodes
+            .filter((node: TreeNode) => matchedIds.indexOf(node.id) > -1)
             .map((node: TreeNode) => ({
                 ...node,
                 children: node.children ? this.filterTree(node.children, matchedIds) : []
             }));
 
-    renderFilterTree = (): JSX.Element => <React.Fragment>
-        <Filter onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.handleFilterChanged(e.target.value)} />
-        {this.renderTable(this.state.filteredNodes)}
-    </React.Fragment>;
+    renderFilterTree = (): JSX.Element => (
+        <React.Fragment>
+            <Filter onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.handleFilterChanged(e.target.value)} />
+            {this.renderTable(this.state.filteredNodes)}
+        </React.Fragment>
+    );
 
-    renderTable = (nodes: TreeNode[]): JSX.Element =>
+    renderTable = (nodes: TreeNode[]): JSX.Element => (
         <Table
             nodes={nodes}
             selectedRow={this.props.selectedRow}
@@ -272,18 +284,20 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             showHeader={this.props.showHeader}
             headers={this.props.headers}
             className={this.props.className}
-        />;
+        />
+    );
 
     render(): JSX.Element | undefined {
-        if (!this.props.nodes) { return undefined; }
+        if (!this.props.nodes) {
+            return undefined;
+        }
         const rootNodes = this.getRootNodes();
         if (rootNodes && rootNodes.length) {
-            return <React.Fragment>
-                {this.props.showFilter
-                    ? this.renderFilterTree()
-                    : this.renderTable(rootNodes)
-                }
-            </React.Fragment>;
+            return (
+                <React.Fragment>
+                    {this.props.showFilter ? this.renderFilterTree() : this.renderTable(rootNodes)}
+                </React.Fragment>
+            );
         } else {
             return <Message></Message>;
         }

--- a/packages/react-components/src/components/utils/filter-tree/utils.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/utils.tsx
@@ -4,18 +4,18 @@ import ColumnHeader from './column-header';
 
 const entryToTreeNode = (entry: Entry, headers: ColumnHeader[]) => {
     // TODO Instead of padding the labels, ColumnHeader should use a getter function  instead of just assuming strings, this will allow to get the legend for XY charts
-    const labels = ((entry.labels) && (entry.labels.length > 0)) ? entry.labels : [''];
+    const labels = entry.labels && entry.labels.length > 0 ? entry.labels : [''];
     // Pad the labels to match the header count
     for (let i = labels.length; i <= headers.length - 1; i++) {
         labels[i] = '';
     }
-    return ({
+    return {
         labels: labels,
         isRoot: false,
         id: entry.id,
         parentId: entry.parentId,
         children: []
-    } as TreeNode);
+    } as TreeNode;
 };
 
 export const listToTree = (list: Entry[], headers: ColumnHeader[]): TreeNode[] => {
@@ -28,7 +28,7 @@ export const listToTree = (list: Entry[], headers: ColumnHeader[]): TreeNode[] =
     // Create the tree in the order it has been received
     list.forEach(entry => {
         const node = lookup[entry.id];
-        if ((entry.parentId !== undefined) && (entry.parentId !== -1)) {
+        if (entry.parentId !== undefined && entry.parentId !== -1) {
             const parent: TreeNode = lookup[entry.parentId];
             if (parent) {
                 if (parent.id !== node.id) {
@@ -47,7 +47,7 @@ export const listToTree = (list: Entry[], headers: ColumnHeader[]): TreeNode[] =
     return rootNodes;
 };
 
-export const getAllExpandedNodeIds = (nodes: TreeNode[],collapsedNodes: number[]): number[] => {
+export const getAllExpandedNodeIds = (nodes: TreeNode[], collapsedNodes: number[]): number[] => {
     const visibleIds: number[] = [];
     nodes.forEach((node: TreeNode) => {
         visibleIds.push(node.id);
@@ -66,9 +66,7 @@ export const getIndexOfNode = (id: number, nodes: TreeNode[], collapsedNodes: nu
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const validateNumArray = (arr: any | undefined): boolean => {
     if (arr && Array.isArray(arr)) {
-        return (arr.length > 0 &&
-            arr.every( value => typeof value === 'number')
-        );
+        return arr.length > 0 && arr.every(value => typeof value === 'number');
     }
     return false;
 };

--- a/packages/react-components/src/components/utils/pagination-bar-component.tsx
+++ b/packages/react-components/src/components/utils/pagination-bar-component.tsx
@@ -21,40 +21,49 @@ enum Direction {
 
 export class PaginationBarComponent extends React.Component<PaginationBarProps> {
     render(): JSX.Element {
-        const currentPage = this.props.gridApi?.paginationGetCurrentPage() ? this.props.gridApi?.paginationGetCurrentPage() + 1 : 1;
+        const currentPage = this.props.gridApi?.paginationGetCurrentPage()
+            ? this.props.gridApi?.paginationGetCurrentPage() + 1
+            : 1;
         const firstRowRaw = (currentPage - 1) * this.props.paginationPageSize + 1;
         const firstRow = numberFormat(firstRowRaw);
-        const lastRow = currentPage === this.props.paginationTotalPages + 1 ?
-            numberFormat(this.props.nbEvents) :
-            numberFormat(firstRowRaw + this.props.paginationPageSize - 1);
+        const lastRow =
+            currentPage === this.props.paginationTotalPages + 1
+                ? numberFormat(this.props.nbEvents)
+                : numberFormat(firstRowRaw + this.props.paginationPageSize - 1);
 
-        return <div className='pagination-bar'>
-            <span style={{ margin: 'auto 10px auto auto'}}>
-                {firstRow} to {lastRow} of {numberFormat(this.props.nbEvents)}
-            </span>
+        return (
+            <div className="pagination-bar">
+                <span style={{ margin: 'auto 10px auto auto' }}>
+                    {firstRow} to {lastRow} of {numberFormat(this.props.nbEvents)}
+                </span>
 
-            <button className='pagination-button' onClick={() => this.paginationJumpTo(Direction.FIRST)}>
-                <FontAwesomeIcon icon={faChevronLeft} />
-                <FontAwesomeIcon icon={faChevronLeft} />
-            </button>
+                <button className="pagination-button" onClick={() => this.paginationJumpTo(Direction.FIRST)}>
+                    <FontAwesomeIcon icon={faChevronLeft} />
+                    <FontAwesomeIcon icon={faChevronLeft} />
+                </button>
 
-            <button className='pagination-button' onClick={() => this.paginationJumpTo(Direction.PREVIOUS)}>
-                <FontAwesomeIcon icon={faChevronLeft} />
-            </button>
+                <button className="pagination-button" onClick={() => this.paginationJumpTo(Direction.PREVIOUS)}>
+                    <FontAwesomeIcon icon={faChevronLeft} />
+                </button>
 
-            <span style={{ margin: 'auto 10px' }}>
-                Page {currentPage} of {this.props.paginationTotalPages + 1}
-            </span>
+                <span style={{ margin: 'auto 10px' }}>
+                    Page {currentPage} of {this.props.paginationTotalPages + 1}
+                </span>
 
-            <button className='pagination-button' onClick={() => this.paginationJumpTo(Direction.NEXT)}>
-                <FontAwesomeIcon icon={faChevronRight} />
-            </button>
+                <button className="pagination-button" onClick={() => this.paginationJumpTo(Direction.NEXT)}>
+                    <FontAwesomeIcon icon={faChevronRight} />
+                </button>
 
-            <button className='pagination-button' style={{ marginRight: '10px' }} onClick={() => this.paginationJumpTo(Direction.LAST)}>
-                <FontAwesomeIcon icon={faChevronRight} />
-                <FontAwesomeIcon icon={faChevronRight} />
-            </button>
-        </div>;
+                <button
+                    className="pagination-button"
+                    style={{ marginRight: '10px' }}
+                    onClick={() => this.paginationJumpTo(Direction.LAST)}
+                >
+                    <FontAwesomeIcon icon={faChevronRight} />
+                    <FontAwesomeIcon icon={faChevronRight} />
+                </button>
+            </div>
+        );
     }
 
     private paginationJumpTo(direction: Direction): void {

--- a/packages/react-components/src/components/utils/time-axis-component.tsx
+++ b/packages/react-components/src/components/utils/time-axis-component.tsx
@@ -7,11 +7,11 @@ import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-cont
 interface TimeAxisProps {
     unitController: TimeGraphUnitController;
     style: {
-        width: number,
-        chartBackgroundColor: number,
-        cursorColor: number,
-        lineColor: number,
-        verticalAlign: string
+        width: number;
+        chartBackgroundColor: number;
+        cursorColor: number;
+        lineColor: number;
+        verticalAlign: string;
     };
     addWidgetResizeHandler: (handler: () => void) => void;
     removeWidgetResizeHandler: (handler: () => void) => void;
@@ -19,20 +19,23 @@ interface TimeAxisProps {
 
 export class TimeAxisComponent extends React.Component<TimeAxisProps> {
     render(): JSX.Element {
-        return <ReactTimeGraphContainer
-            id='timegraph-axis'
-            options={{
-                id: 'timegraph-axis',
-                width: this.props.style.width,
-                height: 30,
-                backgroundColor: this.props.style.chartBackgroundColor,
-                lineColor: this.props.style.lineColor,
-                classNames: 'horizontal-canvas'
-            }}
-            addWidgetResizeHandler={this.props.addWidgetResizeHandler}
-            removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
-            unitController={this.props.unitController}
-            layers={[this.getAxisLayer(), this.getAxisCursors()]} />;
+        return (
+            <ReactTimeGraphContainer
+                id="timegraph-axis"
+                options={{
+                    id: 'timegraph-axis',
+                    width: this.props.style.width,
+                    height: 30,
+                    backgroundColor: this.props.style.chartBackgroundColor,
+                    lineColor: this.props.style.lineColor,
+                    classNames: 'horizontal-canvas'
+                }}
+                addWidgetResizeHandler={this.props.addWidgetResizeHandler}
+                removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
+                unitController={this.props.unitController}
+                layers={[this.getAxisLayer(), this.getAxisCursors()]}
+            />
+        );
     }
 
     protected getAxisLayer(): TimeGraphAxis {

--- a/packages/react-components/src/components/utils/time-navigator-component.tsx
+++ b/packages/react-components/src/components/utils/time-navigator-component.tsx
@@ -6,10 +6,10 @@ import { TimeGraphNavigator } from 'timeline-chart/lib/layer/time-graph-navigato
 interface TimeNavigatorProps {
     unitController: TimeGraphUnitController;
     style: {
-        width: number,
-        naviBackgroundColor: number,
-        cursorColor: number,
-        lineColor: number
+        width: number;
+        naviBackgroundColor: number;
+        cursorColor: number;
+        lineColor: number;
     };
     addWidgetResizeHandler: (handler: () => void) => void;
     removeWidgetResizeHandler: (handler: () => void) => void;
@@ -18,18 +18,21 @@ interface TimeNavigatorProps {
 export class TimeNavigatorComponent extends React.Component<TimeNavigatorProps> {
     render(): JSX.Element {
         const navi = new TimeGraphNavigator('timeGraphNavigator');
-        return <ReactTimeGraphContainer
-            id='time-navigator'
-            options={{
-                id: 'time-navigator',
-                width: this.props.style.width,
-                height: 10,
-                backgroundColor: this.props.style.naviBackgroundColor,
-                classNames: 'horizontal-canvas'
-            }}
-            addWidgetResizeHandler={this.props.addWidgetResizeHandler}
-            removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
-            unitController={this.props.unitController}
-            layers={[navi]} />;
+        return (
+            <ReactTimeGraphContainer
+                id="time-navigator"
+                options={{
+                    id: 'time-navigator',
+                    width: this.props.style.width,
+                    height: 10,
+                    backgroundColor: this.props.style.naviBackgroundColor,
+                    classNames: 'horizontal-canvas'
+                }}
+                addWidgetResizeHandler={this.props.addWidgetResizeHandler}
+                removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
+                unitController={this.props.unitController}
+                layers={[navi]}
+            />
+        );
     }
 }

--- a/packages/react-components/src/components/utils/timegraph-container-component.tsx
+++ b/packages/react-components/src/components/utils/timegraph-container-component.tsx
@@ -6,13 +6,13 @@ import { debounce } from 'lodash';
 
 export namespace ReactTimeGraphContainer {
     export interface Props {
-        id: string,
-        options: TimeGraphContainerOptions,
-        unitController: TimeGraphUnitController,
-        layers: TimeGraphLayer[],
-        children?: never[],
-        addWidgetResizeHandler: (handler: () => void) => void
-        removeWidgetResizeHandler: (handler: () => void) => void
+        id: string;
+        options: TimeGraphContainerOptions;
+        unitController: TimeGraphUnitController;
+        layers: TimeGraphLayer[];
+        children?: never[];
+        addWidgetResizeHandler: (handler: () => void) => void;
+        removeWidgetResizeHandler: (handler: () => void) => void;
     }
 }
 
@@ -20,7 +20,7 @@ export class ReactTimeGraphContainer extends React.Component<ReactTimeGraphConta
     protected ref: HTMLCanvasElement | undefined;
     protected container?: TimeGraphContainer;
 
-    private _resizeHandler: { (): void; (): void; (): void; } | undefined;
+    private _resizeHandler: { (): void; (): void; (): void } | undefined;
 
     componentDidMount(): void {
         const { options, unitController, layers } = this.props;
@@ -42,26 +42,42 @@ export class ReactTimeGraphContainer extends React.Component<ReactTimeGraphConta
     }
 
     shouldComponentUpdate(nextProps: ReactTimeGraphContainer.Props): boolean {
-        return nextProps.options.height !== this.props.options.height
-            || nextProps.options.width !== this.props.options.width
-            || nextProps.options.backgroundColor !== this.props.options.backgroundColor;
+        return (
+            nextProps.options.height !== this.props.options.height ||
+            nextProps.options.width !== this.props.options.width ||
+            nextProps.options.backgroundColor !== this.props.options.backgroundColor
+        );
     }
 
     componentDidUpdate(prevProps: ReactTimeGraphContainer.Props): void {
-        if ((prevProps.options.height !== this.props.options.height
-            || prevProps.options.backgroundColor !== this.props.options.backgroundColor)
-            && this.container) {
-            this.container.updateCanvas(this.props.options.width, this.props.options.height, this.props.options.backgroundColor, this.props.options.lineColor);
+        if (
+            (prevProps.options.height !== this.props.options.height ||
+                prevProps.options.backgroundColor !== this.props.options.backgroundColor) &&
+            this.container
+        ) {
+            this.container.updateCanvas(
+                this.props.options.width,
+                this.props.options.height,
+                this.props.options.backgroundColor,
+                this.props.options.lineColor
+            );
         }
     }
 
     render(): JSX.Element {
-        return <canvas ref={ ref => this.ref = ref || undefined } onWheel={ e => e.preventDefault() } tabIndex={ 0 }></canvas>;
+        return (
+            <canvas ref={ref => (this.ref = ref || undefined)} onWheel={e => e.preventDefault()} tabIndex={0}></canvas>
+        );
     }
 
     private resize(): void {
         if (this.container) {
-            this.container.updateCanvas(this.props.options.width, this.props.options.height, this.props.options.backgroundColor, this.props.options.lineColor);
+            this.container.updateCanvas(
+                this.props.options.width,
+                this.props.options.height,
+                this.props.options.backgroundColor,
+                this.props.options.lineColor
+            );
         }
     }
 }

--- a/packages/react-components/src/components/utils/unit-controller-history-handler.ts
+++ b/packages/react-components/src/components/utils/unit-controller-history-handler.ts
@@ -73,7 +73,7 @@ export class UnitControllerHistoryHandler {
         const { selectionRange, viewRange } = this.history[this.index];
         this.unitController.selectionRange = selectionRange;
         this.unitController.viewRange = viewRange;
-        setTimeout(() => this.restoring = false, 500);
+        setTimeout(() => (this.restoring = false), 500);
     }
 
     private isEntryDuplicate(item: HistoryItem): boolean {
@@ -88,7 +88,7 @@ export class UnitControllerHistoryHandler {
             if (oneIsDifferent) {
                 return;
             }
-            oneIsDifferent = (value1 !== value2);
+            oneIsDifferent = value1 !== value2;
         };
         check(itemSR?.start, prevSR?.start);
         check(itemSR?.end, prevSR?.end);
@@ -104,5 +104,4 @@ export class UnitControllerHistoryHandler {
     private get canUndo(): boolean {
         return this.index > 1;
     }
-
 }

--- a/packages/react-components/src/components/utils/xy-output-component-utils.tsx
+++ b/packages/react-components/src/components/utils/xy-output-component-utils.tsx
@@ -2,46 +2,46 @@ import { TimeRange } from 'traceviewer-base/src/utils/time-range';
 import { AbstractOutputProps } from '../abstract-output-component';
 
 export interface XYChartFactoryParams {
-    viewRange: TimeRange,
-    allMax: number,
-    allMin: number,
-    isScatterPlot: boolean
+    viewRange: TimeRange;
+    allMax: number;
+    allMin: number;
+    isScatterPlot: boolean;
 }
 
 export interface XYOutputMargin {
-    top: number,
-    right: number,
-    bottom: number,
-    left: number
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
 }
 
 export interface GetClosestPointParam {
-    dataPoints: XYPoint[],
-    mousePosition: XYPoint,
-    chartWidth: number,
-    chartHeight: number,
-    range: TimeRange,
-    margin: XYOutputMargin,
-    allMax: number,
-    allMin: number,
+    dataPoints: XYPoint[];
+    mousePosition: XYPoint;
+    chartWidth: number;
+    chartHeight: number;
+    range: TimeRange;
+    margin: XYOutputMargin;
+    allMax: number;
+    allMin: number;
 }
 
 export interface DrawSelectionParams {
-    ctx: CanvasRenderingContext2D | null,
-    chartArea: Chart.ChartArea | undefined | null,
-    startPixel: number,
-    endPixel: number,
-    isBarPlot: boolean,
-    props: AbstractOutputProps,
-    invertSelection: boolean
+    ctx: CanvasRenderingContext2D | null;
+    chartArea: Chart.ChartArea | undefined | null;
+    startPixel: number;
+    endPixel: number;
+    isBarPlot: boolean;
+    props: AbstractOutputProps;
+    invertSelection: boolean;
 }
 
 export interface XYPoint {
-    x: number,
-    y: number
+    x: number;
+    y: number;
 }
 
-export function xyChartFactory(params: XYChartFactoryParams):  Chart.ChartOptions {
+export function xyChartFactory(params: XYChartFactoryParams): Chart.ChartOptions {
     const baseOptions: Chart.ChartOptions = getDefaultChartOptions(params);
 
     // If the chart is a line chart
@@ -52,7 +52,7 @@ export function xyChartFactory(params: XYChartFactoryParams):  Chart.ChartOption
     return getScatterChartOptions(baseOptions);
 }
 
-function getLineChartOptions(lineOptions: Chart.ChartOptions): Chart.ChartOptions{
+function getLineChartOptions(lineOptions: Chart.ChartOptions): Chart.ChartOptions {
     if (lineOptions.elements && lineOptions.elements.point && lineOptions.elements.line && lineOptions.scales) {
         lineOptions.elements.point.radius = 0;
         lineOptions.elements.line.borderWidth = 0;
@@ -62,7 +62,7 @@ function getLineChartOptions(lineOptions: Chart.ChartOptions): Chart.ChartOption
     return lineOptions;
 }
 
-function getScatterChartOptions(scatterOptions: Chart.ChartOptions): Chart.ChartOptions{
+function getScatterChartOptions(scatterOptions: Chart.ChartOptions): Chart.ChartOptions {
     if (scatterOptions.elements && scatterOptions.elements.point) {
         scatterOptions.elements.point.radius = 2;
     }
@@ -87,7 +87,7 @@ function getDefaultChartOptions(params: XYChartFactoryParams): Chart.ChartOption
         tooltips: {
             intersect: false,
             mode: 'index',
-            enabled: false,
+            enabled: false
         },
         layout: {
             padding: {
@@ -98,32 +98,36 @@ function getDefaultChartOptions(params: XYChartFactoryParams): Chart.ChartOption
             }
         },
         scales: {
-            xAxes: [{
-                id: 'time-axis',
-                display: false,
-                ticks: {
-                    min: Number(params.viewRange?.getStart() - offset),
-                    max: Number(params.viewRange?.getEnd() - offset)
+            xAxes: [
+                {
+                    id: 'time-axis',
+                    display: false,
+                    ticks: {
+                        min: Number(params.viewRange?.getStart() - offset),
+                        max: Number(params.viewRange?.getEnd() - offset)
+                    }
                 }
-            }],
-            yAxes: [{
-                display: false,
-                stacked: false,
-                ticks: {
-                    max: params.allMax > 0 ? params.allMax : 100,
-                    min: params.allMin
+            ],
+            yAxes: [
+                {
+                    display: false,
+                    stacked: false,
+                    ticks: {
+                        max: params.allMax > 0 ? params.allMax : 100,
+                        min: params.allMin
+                    }
                 }
-            }]
+            ]
         },
         animation: { duration: 0 },
-        events: ['mousedown'],
+        events: ['mousedown']
     };
 
     return lineOptions;
 }
 
 export function drawSelection(params: DrawSelectionParams): void {
-    const { startPixel, endPixel, isBarPlot, chartArea, props, ctx, invertSelection} = params;
+    const { startPixel, endPixel, isBarPlot, chartArea, props, ctx, invertSelection } = params;
     const minPixel = Math.min(startPixel, endPixel);
     const maxPixel = Math.max(startPixel, endPixel);
     const initialPoint = isBarPlot ? 0 : chartArea?.left ?? 0;
@@ -152,9 +156,8 @@ export function drawSelection(params: DrawSelectionParams): void {
         ctx.globalAlpha = 0.2;
         if (!invertSelection) {
             ctx.fillRect(minPixel, 0, maxPixel - minPixel, finalPoint);
-        }
-        else {
-            const leftSideWidth = - minPixel;
+        } else {
+            const leftSideWidth = -minPixel;
             const rightSideWidth = (chartArea?.right ? chartArea.right : 0) - maxPixel;
 
             ctx.fillRect(minPixel, 0, leftSideWidth, finalPoint);
@@ -181,7 +184,7 @@ export function getClosestPointForScatterPlot(params: GetClosestPointParam): XYP
         const distY = params.chartHeight - params.mousePosition.y - y;
         const hypotenuse = distX * distX + distY * distY;
 
-        if (min_hypotenuse > hypotenuse){
+        if (min_hypotenuse > hypotenuse) {
             closestPoint = point;
             min_hypotenuse = hypotenuse;
         }
@@ -195,6 +198,6 @@ export function getClosestPointForScatterPlot(params: GetClosestPointParam): XYP
     return undefined;
 }
 
-export function numberFormat(rawNumber: number): string{
+export function numberFormat(rawNumber: number): string {
     return new Intl.NumberFormat().format(rawNumber);
 }

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -5,7 +5,15 @@ import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/respon
 import Chart = require('chart.js');
 import { BIMath } from 'timeline-chart/lib/bigint-utils';
 import { scaleLinear } from 'd3-scale';
-import { AbstractXYOutputComponent, AbstractXYOutputState, FLAG_PAN_LEFT, FLAG_PAN_RIGHT, FLAG_ZOOM_IN, FLAG_ZOOM_OUT, MouseButton } from './abstract-xy-output-component';
+import {
+    AbstractXYOutputComponent,
+    AbstractXYOutputState,
+    FLAG_PAN_LEFT,
+    FLAG_PAN_RIGHT,
+    FLAG_ZOOM_IN,
+    FLAG_ZOOM_OUT,
+    MouseButton
+} from './abstract-xy-output-component';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
 import { validateNumArray } from './utils/filter-tree/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -22,8 +30,12 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
             outputStatus: ResponseStatus.RUNNING,
             selectedSeriesId: [],
             xyTree: [],
-            checkedSeries: validateNumArray(this.props.persistChartState?.checkedSeries) ? this.props.persistChartState.checkedSeries as number[] : [],
-            collapsedNodes: validateNumArray(this.props.persistChartState?.collapsedNodes) ? this.props.persistChartState.collapsedNodes as number[] : [],
+            checkedSeries: validateNumArray(this.props.persistChartState?.checkedSeries)
+                ? (this.props.persistChartState.checkedSeries as number[])
+                : [],
+            collapsedNodes: validateNumArray(this.props.persistChartState?.collapsedNodes)
+                ? (this.props.persistChartState.collapsedNodes as number[])
+                : [],
             orderedNodes: [],
             xyData: {},
             columns: [{ title: 'Name', sortable: true }],
@@ -34,53 +46,51 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
         };
         this.addPinViewOptions(() => ({
             checkedSeries: this.state.checkedSeries,
-            collapsedNodes: this.state.collapsedNodes,
+            collapsedNodes: this.state.collapsedNodes
         }));
         this.addOptions('Export table to CSV...', () => this.exportOutput());
     }
 
     renderChart(): React.ReactNode {
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyData?.datasets?.length === 0) {
-            return <React.Fragment>
-                <div className='chart-message'>
-                    Select a checkbox to see analysis results
-                </div>
-            </React.Fragment>;
+            return (
+                <React.Fragment>
+                    <div className="chart-message">Select a checkbox to see analysis results</div>
+                </React.Fragment>
+            );
         }
-        return <React.Fragment>
-            <div
-                id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
-                className='xy-main'
-                tabIndex={0}
-                onKeyDown={event => this.onKeyDown(event)}
-                onKeyUp={event => this.onKeyUp(event)}
-                onWheel={event => this.onWheel(event)}
-                onMouseMove={event => this.onMouseMove(event)}
-                onContextMenu={event => event.preventDefault()}
-                onMouseLeave={event => this.onMouseLeave(event)}
-                onMouseDown={event => this.onMouseDown(event)}
-                style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
-                ref={this.divRef}
-            >
-                {this.isBarPlot ? this.drawD3Chart() : this.chooseChart()}
-            </div>
-            {(this.state.outputStatus === ResponseStatus.RUNNING) &&
+        return (
+            <React.Fragment>
                 <div
                     id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
-                    className='analysis-running-overflow'
-                    style={{ width: this.getChartWidth() }}
+                    className="xy-main"
+                    tabIndex={0}
+                    onKeyDown={event => this.onKeyDown(event)}
+                    onKeyUp={event => this.onKeyUp(event)}
+                    onWheel={event => this.onWheel(event)}
+                    onMouseMove={event => this.onMouseMove(event)}
+                    onContextMenu={event => event.preventDefault()}
+                    onMouseLeave={event => this.onMouseLeave(event)}
+                    onMouseDown={event => this.onMouseDown(event)}
+                    style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
+                    ref={this.divRef}
                 >
-                    <div>
-                        <FontAwesomeIcon
-                            icon={faSpinner}
-                            spin
-                            style={{ marginRight: '5px' }}
-                        />
-                        <span>Analysis running</span>
-                    </div>
+                    {this.isBarPlot ? this.drawD3Chart() : this.chooseChart()}
                 </div>
-            }
-        </React.Fragment>;
+                {this.state.outputStatus === ResponseStatus.RUNNING && (
+                    <div
+                        id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
+                        className="analysis-running-overflow"
+                        style={{ width: this.getChartWidth() }}
+                    >
+                        <div>
+                            <FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />
+                            <span>Analysis running</span>
+                        </div>
+                    </div>
+                )}
+            </React.Fragment>
+        );
     }
 
     private drawD3Chart(): JSX.Element {
@@ -112,9 +122,7 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
             const start = this.getXForTime(this.state.xyData.labels[0]);
             const end = this.getXForTime(this.state.xyData.labels[xDomain]);
 
-            const xScale = scaleLinear()
-                .domain([start, end].map(Number))
-                .range([0, chartWidth]);
+            const xScale = scaleLinear().domain([start, end].map(Number)).range([0, chartWidth]);
 
             if (this.chartRef.current) {
                 const ctx = this.chartRef.current.getContext('2d');
@@ -136,7 +144,7 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
                         row.forEach((tupple: any) => {
                             ctx.beginPath();
                             const xPos = this.getXForTime(tupple.xValue);
-                            ctx.fillRect(xScale(xPos), chartHeight, 2, - chartHeight + yScale(+tupple.yValue));
+                            ctx.fillRect(xScale(xPos), chartHeight, 2, -chartHeight + yScale(+tupple.yValue));
                             ctx.closePath();
                         });
                     });
@@ -146,13 +154,7 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
             }
         }
 
-        return (
-            <canvas
-                ref={this.chartRef}
-                height={chartHeight}
-                width={chartWidth}
-            />
-        );
+        return <canvas ref={this.chartRef} height={chartHeight} width={chartWidth} />;
     }
 
     protected afterChartDraw(ctx: CanvasRenderingContext2D | null, chartArea?: Chart.ChartArea | null): void {
@@ -175,7 +177,12 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
         }
     }
 
-    private drawSelection(ctx: CanvasRenderingContext2D | null, chartArea: Chart.ChartArea | undefined | null, startPixel: number, endPixel: number) {
+    private drawSelection(
+        ctx: CanvasRenderingContext2D | null,
+        chartArea: Chart.ChartArea | undefined | null,
+        startPixel: number,
+        endPixel: number
+    ) {
         const minPixel = Math.min(startPixel, endPixel);
         const maxPixel = Math.max(startPixel, endPixel);
         const initialPoint = this.isBarPlot ? 0 : chartArea?.left ?? 0;
@@ -224,9 +231,13 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
                     start: this.props.unitController.selectionRange.start,
                     end: startTime
                 };
-            } else if ((event.ctrlKey && !event.shiftKey) || (!(event.shiftKey && event.ctrlKey) && this.clickedMouseButton === MouseButton.MID)) {
+            } else if (
+                (event.ctrlKey && !event.shiftKey) ||
+                (!(event.shiftKey && event.ctrlKey) && this.clickedMouseButton === MouseButton.MID)
+            ) {
                 this.resolution = this.getChartWidth() / Number(this.props.unitController.viewRangeLength);
-                this.mousePanningStart = this.props.unitController.viewRange.start + BIMath.round(event.nativeEvent.x / this.resolution);
+                this.mousePanningStart =
+                    this.props.unitController.viewRange.start + BIMath.round(event.nativeEvent.x / this.resolution);
                 this.isPanning = true;
                 this.setState({ cursor: 'grabbing' });
             } else if (!(event.shiftKey && event.ctrlKey)) {
@@ -244,7 +255,7 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
 
     private panHorizontally(event: React.MouseEvent) {
         const delta = event.nativeEvent.x;
-        const change = Number(this.mousePanningStart) - (delta / this.resolution);
+        const change = Number(this.mousePanningStart) - delta / this.resolution;
         const min = BigInt(0);
         const max = this.props.unitController.absoluteRange - this.props.unitController.viewRangeLength;
         const start = BIMath.clamp(change, min, max);
@@ -362,7 +373,7 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
 
     private onKeyUp(key: React.KeyboardEvent): void {
         if (!this.isSelecting && !this.isPanning) {
-            let keyCursor: (string | undefined) = this.state.cursor ?? 'default';
+            let keyCursor: string | undefined = this.state.cursor ?? 'default';
             if (key.key === 'Shift') {
                 if (key.ctrlKey) {
                     keyCursor = 'grabbing';

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -4,7 +4,14 @@ import * as React from 'react';
 import { drawSelection } from './utils/xy-output-component-utils';
 import { TimeRange } from 'traceviewer-base/src/utils/time-range';
 import { AbstractXYOutputState, MouseButton } from './abstract-xy-output-component';
-import { AbstractXYOutputComponent, FLAG_PAN_LEFT, FLAG_PAN_RIGHT, FLAG_ZOOM_IN, FLAG_ZOOM_OUT, XY_OUTPUT_KEY_ACTIONS } from './abstract-xy-output-component';
+import {
+    AbstractXYOutputComponent,
+    FLAG_PAN_LEFT,
+    FLAG_PAN_RIGHT,
+    FLAG_ZOOM_IN,
+    FLAG_ZOOM_OUT,
+    XY_OUTPUT_KEY_ACTIONS
+} from './abstract-xy-output-component';
 import { Experiment } from 'tsp-typescript-client';
 import { TraceOverviewSelectionDialogComponent } from './trace-overview-selection-dialog-component';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -16,8 +23,8 @@ const COLOR = {
 };
 
 type XYOutputOverviewState = AbstractXYOutputState & {
-    shiftKey: boolean,
-    showModal: boolean
+    shiftKey: boolean;
+    showModal: boolean;
 };
 
 type XYOutputOverviewProps = AbstractOutputProps & {
@@ -45,7 +52,7 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
             collapsedNodes: [],
             orderedNodes: [],
             xyData: {},
-            columns: [{title: 'Name', sortable: true}],
+            columns: [{ title: 'Name', sortable: true }],
             allMax: 0,
             allMin: 0,
             cursor: 'default',
@@ -64,54 +71,49 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
         const selectionDialog = (
             <TraceOverviewSelectionDialogComponent
                 isOpen={this.state.showModal}
-                title='Select overview output source'
+                title="Select overview output source"
                 tspClient={this.props.tspClient}
                 traceID={this.props.traceId}
                 onCloseDialog={this.closeOverviewOutputSelector}
             ></TraceOverviewSelectionDialogComponent>
         );
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyData?.datasets?.length === 0) {
-            return <React.Fragment>
-                {selectionDialog}
-                <div className='chart-message'>
-                    Select a checkbox to see analysis results
-                </div>
-            </React.Fragment>;
+            return (
+                <React.Fragment>
+                    {selectionDialog}
+                    <div className="chart-message">Select a checkbox to see analysis results</div>
+                </React.Fragment>
+            );
         }
-        return <React.Fragment>
-            {selectionDialog}
-            <div
-                id={this.getOutputComponentDomId() + 'focusContainer'}
-                className='xy-main'
-                tabIndex={0}
-                onKeyDown={event => this.onKeyDown(event)}
-                onKeyUp={event => this.onKeyUp(event)}
-                onWheel={event => this.onWheel(event)}
-                onMouseMove={event => this.onMouseMove(event)}
-                onContextMenu={event => event.preventDefault()}
-                onMouseLeave={event => this.onMouseLeave(event)}
-                onMouseDown={event => this.onMouseDown(event)}
-                style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
-                ref={this.divRef}
-            >
-                {this.chooseChart()}
-            </div>
-            {(this.state.outputStatus === ResponseStatus.RUNNING) &&
+        return (
+            <React.Fragment>
+                {selectionDialog}
                 <div
-                    className='analysis-running-overflow'
-                    style={{ width: this.getChartWidth() }}
+                    id={this.getOutputComponentDomId() + 'focusContainer'}
+                    className="xy-main"
+                    tabIndex={0}
+                    onKeyDown={event => this.onKeyDown(event)}
+                    onKeyUp={event => this.onKeyUp(event)}
+                    onWheel={event => this.onWheel(event)}
+                    onMouseMove={event => this.onMouseMove(event)}
+                    onContextMenu={event => event.preventDefault()}
+                    onMouseLeave={event => this.onMouseLeave(event)}
+                    onMouseDown={event => this.onMouseDown(event)}
+                    style={{ height: this.props.style.height, position: 'relative', cursor: this.state.cursor }}
+                    ref={this.divRef}
                 >
-                    <div>
-                        <FontAwesomeIcon
-                            icon={faSpinner}
-                            spin
-                            style={{ marginRight: '5px' }}
-                        />
-                        <span> Analysis running </span>
-                    </div>
+                    {this.chooseChart()}
                 </div>
-            }
-        </React.Fragment>;
+                {this.state.outputStatus === ResponseStatus.RUNNING && (
+                    <div className="analysis-running-overflow" style={{ width: this.getChartWidth() }}>
+                        <div>
+                            <FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />
+                            <span> Analysis running </span>
+                        </div>
+                    </div>
+                )}
+            </React.Fragment>
+        );
     }
 
     protected getDisplayedRange(): TimeRange {
@@ -156,7 +158,7 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
 
             if (this.clickedMouseButton === MouseButton.RIGHT) {
                 const offset = this.props.viewRange.getOffset() ?? BigInt(0);
-                const startPixel = this.getXForTime((this.startPositionMouseRightClick + offset));
+                const startPixel = this.getXForTime(this.startPositionMouseRightClick + offset);
                 const endPixel = this.positionXMove;
                 ctx.strokeStyle = COLOR.VIEW_RANGE;
                 ctx.fillStyle = COLOR.VIEW_RANGE;
@@ -242,7 +244,7 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
 
     private onKeyUp(key: React.KeyboardEvent): void {
         if (key.key === 'Shift') {
-            const change: { cursor?: string, shiftKey: boolean } = { shiftKey: false };
+            const change: { cursor?: string; shiftKey: boolean } = { shiftKey: false };
             if (!this.mouseIsDown) {
                 change.cursor = 'default';
             }
@@ -255,9 +257,9 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
         this.mouseIsDown = true;
         this.clickedMouseButton = event.button;
 
-        if ( this.clickedMouseButton === MouseButton.RIGHT) {
+        if (this.clickedMouseButton === MouseButton.RIGHT) {
             this.onRightButtonClick(event);
-        } else if ( this.clickedMouseButton === MouseButton.MID) {
+        } else if (this.clickedMouseButton === MouseButton.MID) {
             this.onMidButtonClick(event);
         } else {
             this.onLeftButtonClick(event);
@@ -338,7 +340,7 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
         // The user moved out-of-graph on the left side
         if (startPixel < leftLimit) {
             startPixel = leftLimit;
-            endPixel =  this.initialViewRangeEndPosition - this.initialViewRangeStartPosition;
+            endPixel = this.initialViewRangeEndPosition - this.initialViewRangeStartPosition;
         }
         // The user moved out-of-graph on the right side
         else if (endPixel > rightLimit) {
@@ -346,7 +348,7 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
             endPixel = rightLimit;
         }
 
-        if (this.props.unitController.viewRange){
+        if (this.props.unitController.viewRange) {
             this.props.unitController.viewRange = {
                 start: this.getTimeForX(startPixel),
                 end: this.getTimeForX(endPixel)
@@ -390,16 +392,21 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
     }
 
     private closeOverviewOutputSelector(): void {
-        this.setState({showModal: false});
+        this.setState({ showModal: false });
     }
 
     private openOverviewOutputSelector() {
-        this.setState({showModal: true});
+        this.setState({ showModal: true });
     }
 
     private toggleTree() {
-        this.setState({
-            showTree: !this.state.showTree,
-        }, () => {this.closeDropDown();});
+        this.setState(
+            {
+                showTree: !this.state.showTree
+            },
+            () => {
+                this.closeDropDown();
+            }
+        );
     }
 }

--- a/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
@@ -12,15 +12,15 @@ import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 export interface ReactOpenTracesWidgetProps {
-    id: string,
-    title: string,
-    tspClientProvider: ITspClientProvider,
-    contextMenuRenderer?: (event: React.MouseEvent<HTMLDivElement>, experiment: Experiment) => void,
-    onClick?: (event: React.MouseEvent<HTMLDivElement>, experiment: Experiment) => void
+    id: string;
+    title: string;
+    tspClientProvider: ITspClientProvider;
+    contextMenuRenderer?: (event: React.MouseEvent<HTMLDivElement>, experiment: Experiment) => void;
+    onClick?: (event: React.MouseEvent<HTMLDivElement>, experiment: Experiment) => void;
 }
 
 export interface ReactOpenTracesWidgetState {
-    openedExperiments: Array<Experiment>,
+    openedExperiments: Array<Experiment>;
     selectedExperimentIndex: number;
 }
 
@@ -36,10 +36,13 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
     private _selectedExperiment: Experiment | undefined;
     private _experimentManager: ExperimentManager;
 
-    private _onExperimentOpened = (experiment: Experiment): Promise<void> => this.doHandleExperimentOpenedSignal(experiment);
+    private _onExperimentOpened = (experiment: Experiment): Promise<void> =>
+        this.doHandleExperimentOpenedSignal(experiment);
     private _onExperimentClosed = (experiment: Experiment): void => this.doHandleExperimentClosed(experiment);
-    private _onExperimentDeleted = (experiment: Experiment): Promise<void> => this.doHandleExperimentDeletedSignal(experiment);
-    private _onOpenedTracesWidgetActivated = (experiment: Experiment): void => this.doHandleTracesWidgetActivatedSignal(experiment);
+    private _onExperimentDeleted = (experiment: Experiment): Promise<void> =>
+        this.doHandleExperimentDeletedSignal(experiment);
+    private _onOpenedTracesWidgetActivated = (experiment: Experiment): void =>
+        this.doHandleTracesWidgetActivatedSignal(experiment);
     private _onTraceServerStarted = (): Promise<void> => this.doHandleTraceServerStartedSignal();
 
     constructor(props: ReactOpenTracesWidgetProps) {
@@ -96,7 +99,9 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
     protected doHandleTracesWidgetActivatedSignal(experiment: Experiment): void {
         if (this._selectedExperiment?.UUID !== experiment.UUID) {
             this._selectedExperiment = experiment;
-            const selectedIndex = this.state.openedExperiments.findIndex(openedExperiment => openedExperiment.UUID === experiment.UUID);
+            const selectedIndex = this.state.openedExperiments.findIndex(
+                openedExperiment => openedExperiment.UUID === experiment.UUID
+            );
             this.selectExperiment(selectedIndex);
         }
     }
@@ -131,15 +136,19 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
         const key = Number(this._forceUpdateKey);
         return (
             <>
-                <ReactModal isOpen={this._showShareDialog} onRequestClose={this.handleShareModalClose}
-                    ariaHideApp={false} className='sharing-modal' overlayClassName='sharing-overlay'>
+                <ReactModal
+                    isOpen={this._showShareDialog}
+                    onRequestClose={this.handleShareModalClose}
+                    ariaHideApp={false}
+                    className="sharing-modal"
+                    overlayClassName="sharing-overlay"
+                >
                     {this.renderSharingModal()}
                 </ReactModal>
-                <div className='trace-explorer-opened'>
-                    <div className='trace-explorer-panel-content'
-                        onClick={this.updateOpenedExperiments}>
+                <div className="trace-explorer-opened">
+                    <div className="trace-explorer-panel-content" onClick={this.updateOpenedExperiments}>
                         <AutoSizer>
-                            {({ width }) =>
+                            {({ width }) => (
                                 <List
                                     key={key}
                                     height={totalHeight}
@@ -147,7 +156,8 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
                                     rowCount={this.state.openedExperiments.length}
                                     rowHeight={this.getRowHeight}
                                     rowRenderer={this.renderExperimentRow}
-                                />}
+                                />
+                            )}
                         </AutoSizer>
                     </div>
                 </div>
@@ -162,40 +172,57 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
         with experiment name as root and traces (name and path) as children
      */
     protected doRenderExperimentRow(props: ListRowProps): React.ReactNode {
-        const traceName = this.state.openedExperiments.length && props.index < this.state.openedExperiments.length
-            ? this.state.openedExperiments[props.index].name : '';
-        const traceUUID = this.state.openedExperiments.length && props.index < this.state.openedExperiments.length
-            ? this.state.openedExperiments[props.index].UUID : '';
+        const traceName =
+            this.state.openedExperiments.length && props.index < this.state.openedExperiments.length
+                ? this.state.openedExperiments[props.index].name
+                : '';
+        const traceUUID =
+            this.state.openedExperiments.length && props.index < this.state.openedExperiments.length
+                ? this.state.openedExperiments[props.index].UUID
+                : '';
         let traceContainerClassName = 'trace-list-container';
         if (props.index === this.state.selectedExperimentIndex && this.state.selectedExperimentIndex >= 0) {
             traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
         }
-        return <div className={traceContainerClassName}
-            id={`${traceContainerClassName}-${props.index}`}
-            key={props.key}
-            style={props.style}
-            onClick={event => { this.handleClickEvent(event, traceUUID); }}
-            onContextMenu={event => { this.handleContextMenuEvent(event, traceUUID); }}
-            data-id={`${props.index}`}>
-            <div className='trace-element-container'>
-                <div className='trace-element-info' >
-                    <h4 className='trace-element-name'>{traceName}</h4>
-                    {this.renderTracesForExperiment(props.index)}
-                </div>
-                <div className='remove-trace-button-container' title='Remove trace from Trace Viewer'>
-                    <button data-tip data-for="removeTip" className='remove-trace-button'
-                        onClick={event => {this.handleOnExperimentDeleted(event,traceUUID);}}
-                    >
-                        <FontAwesomeIcon icon={faTimes} />
-                    </button>
-                </div>
-                {/* <div className='trace-element-options'>
+        return (
+            <div
+                className={traceContainerClassName}
+                id={`${traceContainerClassName}-${props.index}`}
+                key={props.key}
+                style={props.style}
+                onClick={event => {
+                    this.handleClickEvent(event, traceUUID);
+                }}
+                onContextMenu={event => {
+                    this.handleContextMenuEvent(event, traceUUID);
+                }}
+                data-id={`${props.index}`}
+            >
+                <div className="trace-element-container">
+                    <div className="trace-element-info">
+                        <h4 className="trace-element-name">{traceName}</h4>
+                        {this.renderTracesForExperiment(props.index)}
+                    </div>
+                    <div className="remove-trace-button-container" title="Remove trace from Trace Viewer">
+                        <button
+                            data-tip
+                            data-for="removeTip"
+                            className="remove-trace-button"
+                            onClick={event => {
+                                this.handleOnExperimentDeleted(event, traceUUID);
+                            }}
+                        >
+                            <FontAwesomeIcon icon={faTimes} />
+                        </button>
+                    </div>
+                    {/* <div className='trace-element-options'>
                     <button className='share-context-button' onClick={this.handleShareButtonClick.bind(this, props.index)}>
                         <FontAwesomeIcon icon={faShareSquare} />
                     </button>
                 </div> */}
+                </div>
             </div>
-        </div>;
+        );
     }
 
     protected doHandleOnExperimentDeleted(e: React.MouseEvent<HTMLButtonElement>, traceUUID: string): void {
@@ -208,9 +235,14 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
     protected renderTracesForExperiment(index: number): React.ReactNode {
         const tracePaths = this.state.openedExperiments[index].traces;
         return (
-            <div className='trace-element-path-container'>
+            <div className="trace-element-path-container">
                 {tracePaths.map(trace => (
-                    <div className='trace-element-path child-element' id={trace.UUID} key={trace.UUID} title={trace.path}>
+                    <div
+                        className="trace-element-path child-element"
+                        id={trace.UUID}
+                        key={trace.UUID}
+                        title={trace.path}
+                    >
                         {` > ${trace.name}`}
                     </div>
                 ))}
@@ -243,25 +275,28 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
 
     protected renderSharingModal(): React.ReactNode {
         if (this._sharingLink.length) {
-            return <div className='sharing-container'>
-                <div className='sharing-description'>
-                    {'Copy URL to share your trace context'}
-                </div>
-                <div className='sharing-link-info'>
-                    <div className='sharing-link'>
-                        <textarea rows={1} cols={this._sharingLink.length} readOnly={true} value={this._sharingLink} />
+            return (
+                <div className="sharing-container">
+                    <div className="sharing-description">{'Copy URL to share your trace context'}</div>
+                    <div className="sharing-link-info">
+                        <div className="sharing-link">
+                            <textarea
+                                rows={1}
+                                cols={this._sharingLink.length}
+                                readOnly={true}
+                                value={this._sharingLink}
+                            />
+                        </div>
+                        <div className="sharing-link-copy">
+                            <button className="copy-link-button">
+                                <FontAwesomeIcon icon={faCopy} />
+                            </button>
+                        </div>
                     </div>
-                    <div className='sharing-link-copy'>
-                        <button className='copy-link-button'>
-                            <FontAwesomeIcon icon={faCopy} />
-                        </button>
-                    </div>
                 </div>
-            </div>;
+            );
         }
-        return <div style={{ color: 'white' }}>
-            {'Cannot share this trace'}
-        </div>;
+        return <div style={{ color: 'white' }}>{'Cannot share this trace'}</div>;
     }
 
     protected updateOpenedExperiments = async (): Promise<void> => this.doUpdateOpenedExperiments();
@@ -271,13 +306,16 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
         remoteExperiments.forEach(experiment => {
             this._experimentManager.addExperiment(experiment);
         });
-        const selectedIndex = remoteExperiments.findIndex(experiment => this._selectedExperiment &&
-            experiment.UUID === this._selectedExperiment.UUID);
+        const selectedIndex = remoteExperiments.findIndex(
+            experiment => this._selectedExperiment && experiment.UUID === this._selectedExperiment.UUID
+        );
         // flushSync: force immediate state update instead of waiting for React 18's automatic batching
         flushSync(() => {
             this.setState({ openedExperiments: remoteExperiments, selectedExperimentIndex: selectedIndex });
         });
-        signalManager().fireOpenedTracesChangedSignal(new OpenedTracesUpdatedSignalPayload(remoteExperiments ? remoteExperiments.length : 0));
+        signalManager().fireOpenedTracesChangedSignal(
+            new OpenedTracesUpdatedSignalPayload(remoteExperiments ? remoteExperiments.length : 0)
+        );
     }
 
     protected handleShareButtonClick = (index: number): void => this.doHandleShareButtonClick(index);
@@ -286,13 +324,19 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
         const traceToShare = this.state.openedExperiments[index];
         this._sharingLink = 'https://localhost:3000/share/trace?' + traceToShare.UUID;
         this._showShareDialog = true;
-        signalManager().fireOpenedTracesChangedSignal(new OpenedTracesUpdatedSignalPayload(this.state.openedExperiments ? this.state.openedExperiments.length : 0));
+        signalManager().fireOpenedTracesChangedSignal(
+            new OpenedTracesUpdatedSignalPayload(this.state.openedExperiments ? this.state.openedExperiments.length : 0)
+        );
     }
 
-    protected handleOnExperimentSelected = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOnExperimentSelected(e);
-    protected handleContextMenuEvent = (e: React.MouseEvent<HTMLDivElement>, traceUUID: string): void => this.doHandleContextMenuEvent(e, traceUUID);
-    protected handleClickEvent = (e: React.MouseEvent<HTMLDivElement>, traceUUID: string): void => this.dohandleClickEvent(e, traceUUID);
-    protected handleOnExperimentDeleted = (e: React.MouseEvent<HTMLButtonElement>, traceUUID: string): void => this.doHandleOnExperimentDeleted(e, traceUUID);
+    protected handleOnExperimentSelected = (e: React.MouseEvent<HTMLDivElement>): void =>
+        this.doHandleOnExperimentSelected(e);
+    protected handleContextMenuEvent = (e: React.MouseEvent<HTMLDivElement>, traceUUID: string): void =>
+        this.doHandleContextMenuEvent(e, traceUUID);
+    protected handleClickEvent = (e: React.MouseEvent<HTMLDivElement>, traceUUID: string): void =>
+        this.dohandleClickEvent(e, traceUUID);
+    protected handleOnExperimentDeleted = (e: React.MouseEvent<HTMLButtonElement>, traceUUID: string): void =>
+        this.doHandleOnExperimentDeleted(e, traceUUID);
 
     protected doHandleOnExperimentSelected(e: React.MouseEvent<HTMLDivElement>): void {
         const index = Number(e.currentTarget.getAttribute('data-id'));
@@ -308,7 +352,11 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
     }
 
     private updateSelectedExperiment(): void {
-        if (this.state.openedExperiments && this.state.selectedExperimentIndex >= 0 && this.state.selectedExperimentIndex < this.state.openedExperiments.length) {
+        if (
+            this.state.openedExperiments &&
+            this.state.selectedExperimentIndex >= 0 &&
+            this.state.selectedExperimentIndex < this.state.openedExperiments.length
+        ) {
             this._selectedExperiment = this.state.openedExperiments[this.state.selectedExperimentIndex];
             signalManager().fireExperimentSelectedSignal(this._selectedExperiment);
         }
@@ -317,7 +365,9 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
     protected onWidgetActivated(experiment: Experiment): void {
         if (experiment) {
             this._selectedExperiment = experiment;
-            const selectedIndex = this.state.openedExperiments.findIndex(openedExperiment => openedExperiment.UUID === experiment.UUID);
+            const selectedIndex = this.state.openedExperiments.findIndex(
+                openedExperiment => openedExperiment.UUID === experiment.UUID
+            );
             this.selectExperiment(selectedIndex);
         }
     }
@@ -327,6 +377,8 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
     protected doHandleShareModalClose(): void {
         this._showShareDialog = false;
         this._sharingLink = '';
-        signalManager().fireOpenedTracesChangedSignal(new OpenedTracesUpdatedSignalPayload(this.state.openedExperiments ? this.state.openedExperiments.length : 0));
+        signalManager().fireOpenedTracesChangedSignal(
+            new OpenedTracesUpdatedSignalPayload(this.state.openedExperiments ? this.state.openedExperiments.length : 0)
+        );
     }
 }

--- a/packages/react-components/src/trace-explorer/trace-explorer-placeholder-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-placeholder-widget.tsx
@@ -13,22 +13,22 @@ export class ReactExplorerPlaceholderWidget extends React.Component<ReactPlaceho
     }
 
     render(): React.ReactNode {
-        return <div className='placeholder-container' tabIndex={0}>
-            <div className='center'>{'You have not yet opened a trace.'}</div>
-            <div className='placeholder-open-workspace-button-container'>
-                <button className='plcaeholder-open-workspace-button' title='Select a trace to open'
-                    onClick={this.props.handleOpenTrace} disabled={this.props.loading}>
-                    {this.props.loading && (
-                        <FontAwesomeIcon
-                            icon={faSpinner}
-                            spin
-                            style={{ marginRight: '5px' }}
-                        />
-                    )}
-                    {this.props.loading && <span>Connecting to trace server</span>}
-                    {!this.props.loading && <span>Open Trace</span>}
-                </button>
+        return (
+            <div className="placeholder-container" tabIndex={0}>
+                <div className="center">{'You have not yet opened a trace.'}</div>
+                <div className="placeholder-open-workspace-button-container">
+                    <button
+                        className="plcaeholder-open-workspace-button"
+                        title="Select a trace to open"
+                        onClick={this.props.handleOpenTrace}
+                        disabled={this.props.loading}
+                    >
+                        {this.props.loading && <FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />}
+                        {this.props.loading && <span>Connecting to trace server</span>}
+                        {!this.props.loading && <span>Open Trace</span>}
+                    </button>
+                </div>
             </div>
-        </div>;
+        );
     }
 }

--- a/packages/react-components/src/trace-explorer/trace-explorer-properties-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-properties-widget.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 
 export interface ReactPropertiesWidgetProps {
-    id: string,
-    title: string,
+    id: string;
+    title: string;
     handleSourcecodeLookup: (e: React.MouseEvent<HTMLParagraphElement>) => void;
 }
 
@@ -12,7 +12,6 @@ export interface ReactPropertiesWidgetState {
 }
 
 export class ReactItemPropertiesWidget extends React.Component<ReactPropertiesWidgetProps, ReactPropertiesWidgetState> {
-
     constructor(props: ReactPropertiesWidgetProps) {
         super(props);
         this.state = {
@@ -27,10 +26,8 @@ export class ReactItemPropertiesWidget extends React.Component<ReactPropertiesWi
 
     render(): React.ReactNode {
         return (
-            <div className='trace-explorer-item-properties'>
-                <div className='trace-explorer-panel-content'>
-                    {this.renderTooltip()}
-                </div>
+            <div className="trace-explorer-item-properties">
+                <div className="trace-explorer-panel-content">{this.renderTooltip()}</div>
             </div>
         );
     }
@@ -48,30 +45,36 @@ export class ReactItemPropertiesWidget extends React.Component<ReactPropertiesWi
                         fileLocation = matches[1];
                         line = matches[2];
                     }
-                    tooltipArray.push(<p className='source-code-tooltip'
-                        key={key}
-                        onClick={this.props.handleSourcecodeLookup}
-                        data-id={JSON.stringify({ fileLocation, line })}
-                    >{key + ': ' + sourceCodeInfo}</p>);
+                    tooltipArray.push(
+                        <p
+                            className="source-code-tooltip"
+                            key={key}
+                            onClick={this.props.handleSourcecodeLookup}
+                            data-id={JSON.stringify({ fileLocation, line })}
+                        >
+                            {key + ': ' + sourceCodeInfo}
+                        </p>
+                    );
                 } else {
                     tooltipArray.push(<p key={key}>{key + ': ' + value}</p>);
                 }
             });
         } else {
-            tooltipArray.push(<p key="-1"><i>Select item to view properties</i></p>);
+            tooltipArray.push(
+                <p key="-1">
+                    <i>Select item to view properties</i>
+                </p>
+            );
         }
 
-        return (
-            <React.Fragment>
-                {tooltipArray.map(element => element)}
-            </React.Fragment>);
+        return <React.Fragment>{tooltipArray.map(element => element)}</React.Fragment>;
     }
 
     /** Tooltip Signal and Signal Handlers */
-    protected _onItemProperties = (tooltip: { [key: string]: string }): void => this.doHandleItemPropertiesSignal(tooltip);
+    protected _onItemProperties = (tooltip: { [key: string]: string }): void =>
+        this.doHandleItemPropertiesSignal(tooltip);
 
     private doHandleItemPropertiesSignal(tooltipProps: { [key: string]: string }): void {
-        this.setState({itemProperties: tooltipProps});
+        this.setState({ itemProperties: tooltipProps });
     }
 }
-

--- a/packages/react-components/src/trace-explorer/trace-explorer-time-range-data-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-time-range-data-widget.tsx
@@ -5,17 +5,17 @@ import { Experiment } from 'tsp-typescript-client';
 import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 
 export interface ReactTimeRangeDataWidgetProps {
-    id: string,
-    title: string,
+    id: string;
+    title: string;
 }
 
 export interface ReactTimeRangeDataWidgetState {
-    activeData?: ExperimentTimeRangeData,
-    userInputSelectionStartIsValid: boolean,
-    userInputSelectionEndIsValid: boolean,
-    userInputSelectionStart?: bigint,
-    userInputSelectionEnd?: bigint,
-    inputting: boolean,
+    activeData?: ExperimentTimeRangeData;
+    userInputSelectionStartIsValid: boolean;
+    userInputSelectionEndIsValid: boolean;
+    userInputSelectionStart?: bigint;
+    userInputSelectionEnd?: bigint;
+    inputting: boolean;
 }
 
 export interface ExperimentTimeRangeData {
@@ -23,13 +23,15 @@ export interface ExperimentTimeRangeData {
     // We need to make below values possibly undefined because
     // they come in at different times from different signals
     // when an experiment is selected.
-    absoluteRange?: { start: bigint, end: bigint };
-    viewRange?: { start: bigint, end: bigint };
-    selectionRange?: { start: bigint, end: bigint };
+    absoluteRange?: { start: bigint; end: bigint };
+    viewRange?: { start: bigint; end: bigint };
+    selectionRange?: { start: bigint; end: bigint };
 }
 
-export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeDataWidgetProps, ReactTimeRangeDataWidgetState> {
-
+export class ReactTimeRangeDataWidget extends React.Component<
+    ReactTimeRangeDataWidgetProps,
+    ReactTimeRangeDataWidgetState
+> {
     private experimentDataMap: Map<string, ExperimentTimeRangeData>;
 
     constructor(props: ReactTimeRangeDataWidgetProps) {
@@ -38,7 +40,7 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
         this.state = {
             inputting: false,
             userInputSelectionStartIsValid: true,
-            userInputSelectionEndIsValid: true,
+            userInputSelectionEndIsValid: true
         };
         this.subscribeToEvents();
     }
@@ -64,7 +66,7 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
 
         const update = {
             UUID,
-            viewRange: timeRange,
+            viewRange: timeRange
         } as ExperimentTimeRangeData;
 
         this.updateExperimentTimeRangeData(update);
@@ -172,7 +174,6 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
             default:
                 throw Error('Input index is invalid!');
         }
-
     };
 
     private onSubmit = (event: React.FormEvent): void => {
@@ -188,8 +189,10 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
      * @param value2
      * @returns { start: string, end: string }
      */
-    private getStartAndEnd = (v1: bigint | string | undefined, v2: bigint | string | undefined): { start: string, end: string } => {
-
+    private getStartAndEnd = (
+        v1: bigint | string | undefined,
+        v2: bigint | string | undefined
+    ): { start: string; end: string } => {
         if (v1 === undefined || v2 === undefined) {
             return { start: '', end: '' };
         }
@@ -211,12 +214,12 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
     };
 
     private verifyUserInput = (): void => {
-
         let { activeData, userInputSelectionStart, userInputSelectionEnd } = this.state;
 
         // We need at least one value to change: start or end.
-        const noUserInput = typeof userInputSelectionStart === 'undefined' && typeof userInputSelectionEnd === 'undefined';
-        if (!activeData || noUserInput ) {
+        const noUserInput =
+            typeof userInputSelectionStart === 'undefined' && typeof userInputSelectionEnd === 'undefined';
+        if (!activeData || noUserInput) {
             this.reset();
             return;
         }
@@ -235,40 +238,43 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
         }
 
         // If there is no user input for start or end, set that value to the current selectionRange value.
-        const { start: currentStart, end: currentEnd } = this.getStartAndEnd(selectionRange?.start, selectionRange?.end);
-        userInputSelectionStart = typeof userInputSelectionStart === 'bigint' ? userInputSelectionStart : BigInt(currentStart);
+        const { start: currentStart, end: currentEnd } = this.getStartAndEnd(
+            selectionRange?.start,
+            selectionRange?.end
+        );
+        userInputSelectionStart =
+            typeof userInputSelectionStart === 'bigint' ? userInputSelectionStart : BigInt(currentStart);
         userInputSelectionEnd = typeof userInputSelectionEnd === 'bigint' ? userInputSelectionEnd : BigInt(currentEnd);
 
         // Now we can validate
-        const isValid = (n: bigint): boolean => (n >= offset) && (n <= traceEndTime);
+        const isValid = (n: bigint): boolean => n >= offset && n <= traceEndTime;
         const startValid = isValid(userInputSelectionStart);
         const endValid = isValid(userInputSelectionEnd);
 
         if (startValid && endValid) {
             this.reset();
-            const  start = userInputSelectionStart - offset;
+            const start = userInputSelectionStart - offset;
             const end = userInputSelectionEnd - offset;
             signalManager().fireRequestSelectionRangeChange({
                 experimentUUID: activeData.UUID,
-                timeRange: new TimeRange(start, end),
+                timeRange: new TimeRange(start, end)
             });
         } else {
             this.setState({
                 userInputSelectionStartIsValid: startValid,
-                userInputSelectionEndIsValid: endValid,
+                userInputSelectionEndIsValid: endValid
             });
         }
     };
 
     public render(): React.ReactNode {
-
         const {
             activeData,
             inputting,
             userInputSelectionStartIsValid,
             userInputSelectionEndIsValid,
             userInputSelectionStart,
-            userInputSelectionEnd,
+            userInputSelectionEnd
         } = this.state;
 
         const viewRange = activeData?.viewRange;
@@ -278,37 +284,46 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
         const errorClassName = `${sectionClassName} invalid-input`;
 
         const { start: viewRangeStart, end: viewRangeEnd } = this.getStartAndEnd(viewRange?.start, viewRange?.end);
-        const { start: selectionRangeStart, end: selectionRangeEnd } = this.getStartAndEnd(selectionRange?.start, selectionRange?.end);
+        const { start: selectionRangeStart, end: selectionRangeEnd } = this.getStartAndEnd(
+            selectionRange?.start,
+            selectionRange?.end
+        );
 
         const startValid = inputting ? userInputSelectionStartIsValid : true;
         const endValid = inputting ? userInputSelectionEndIsValid : true;
 
         return (
-            <div className='trace-explorer-item-properties'>
-                <div className='trace-explorer-panel-content'>
+            <div className="trace-explorer-item-properties">
+                <div className="trace-explorer-panel-content">
                     <form onSubmit={this.onSubmit}>
                         {(!startValid || !endValid) && (
                             <div className={errorClassName}>
                                 <label htmlFor="errorMessage">
-                                    <h4 className='outputs-element-name'><i>Invalid Values</i></h4>
+                                    <h4 className="outputs-element-name">
+                                        <i>Invalid Values</i>
+                                    </h4>
                                 </label>
                             </div>
                         )}
                         <div className={sectionClassName}>
                             <label htmlFor="viewRangeStart">
-                                <h4 className='outputs-element-name'>View Range Start:</h4>
+                                <h4 className="outputs-element-name">View Range Start:</h4>
                                 {viewRangeStart}
                             </label>
                         </div>
                         <div className={sectionClassName}>
                             <label htmlFor="viewRangeEnd">
-                                <h4 className='outputs-element-name'>View Range End:</h4>
+                                <h4 className="outputs-element-name">View Range End:</h4>
                                 {viewRangeEnd}
                             </label>
                         </div>
                         <div className={startValid ? sectionClassName : errorClassName}>
                             <label htmlFor="selectionRangeStart">
-                                <h4 className='outputs-element-name'>{userInputSelectionStartIsValid ? 'Selection Range Start:' : '* Selection Range Start:'}</h4>
+                                <h4 className="outputs-element-name">
+                                    {userInputSelectionStartIsValid
+                                        ? 'Selection Range Start:'
+                                        : '* Selection Range Start:'}
+                                </h4>
                             </label>
                             <input
                                 type="number"
@@ -318,7 +333,9 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
                         </div>
                         <div className={endValid ? sectionClassName : errorClassName}>
                             <label htmlFor="selectionRangeEnd">
-                                <h4 className='outputs-element-name'>{endValid ? 'Selection Range End:' : '* Selection Range End:'}</h4>
+                                <h4 className="outputs-element-name">
+                                    {endValid ? 'Selection Range End:' : '* Selection Range End:'}
+                                </h4>
                             </label>
                             <input
                                 type="number"
@@ -326,10 +343,12 @@ export class ReactTimeRangeDataWidget extends React.Component<ReactTimeRangeData
                                 onChange={e => this.onChange(e, 1)}
                             />
                         </div>
-                        {inputting && (<div className={sectionClassName}>
-                            <input className="input-button" type="submit" value="Submit"/>
-                            <input className="input-button" type="button" onClick={this.reset} value="Cancel"/>
-                        </div>)}
+                        {inputting && (
+                            <div className={sectionClassName}>
+                                <input className="input-button" type="submit" value="Submit" />
+                                <input className="input-button" type="button" onClick={this.reset} value="Cancel" />
+                            </div>
+                        )}
                     </form>
                 </div>
             </div>

--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -8,14 +8,14 @@ import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { AvailableViewsComponent } from '../components/utils/available-views-component';
 
 export interface ReactAvailableViewsProps {
-    id: string,
-    title: string,
-    tspClientProvider: ITspClientProvider,
-    contextMenuRenderer?: (event: React.MouseEvent<HTMLDivElement>, output: OutputDescriptor) => void,
+    id: string;
+    title: string;
+    tspClientProvider: ITspClientProvider;
+    contextMenuRenderer?: (event: React.MouseEvent<HTMLDivElement>, output: OutputDescriptor) => void;
 }
 
 export interface ReactAvailableViewsState {
-    availableOutputDescriptors: OutputDescriptor[]
+    availableOutputDescriptors: OutputDescriptor[];
 }
 
 export class ReactAvailableViewsWidget extends React.Component<ReactAvailableViewsProps, ReactAvailableViewsState> {
@@ -33,7 +33,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         });
         signalManager().on(Signals.EXPERIMENT_SELECTED, this._onExperimentSelected);
         signalManager().on(Signals.EXPERIMENT_CLOSED, this._onExperimentClosed);
-        this.state = { availableOutputDescriptors: []};
+        this.state = { availableOutputDescriptors: [] };
     }
 
     componentWillUnmount(): void {
@@ -43,7 +43,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
 
     render(): React.ReactNode {
         return (
-            <div className='trace-explorer-views'>
+            <div className="trace-explorer-views">
                 <AvailableViewsComponent
                     traceID={this._selectedExperiment?.UUID}
                     outputDescriptors={this.state.availableOutputDescriptors}
@@ -55,16 +55,25 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         );
     }
 
-    protected handleOutputClicked = (outputDescriptor: OutputDescriptor): void => this.doHandleOutputClicked(outputDescriptor);
-    protected handleContextMenuEvent = (e: React.MouseEvent<HTMLDivElement>, output: OutputDescriptor | undefined): void => this.doHandleContextMenuEvent(e, output);
+    protected handleOutputClicked = (outputDescriptor: OutputDescriptor): void =>
+        this.doHandleOutputClicked(outputDescriptor);
+    protected handleContextMenuEvent = (
+        e: React.MouseEvent<HTMLDivElement>,
+        output: OutputDescriptor | undefined
+    ): void => this.doHandleContextMenuEvent(e, output);
 
     private doHandleOutputClicked(selectedOutput: OutputDescriptor) {
         if (selectedOutput && this._selectedExperiment) {
-            signalManager().fireOutputAddedSignal(new OutputAddedSignalPayload(selectedOutput, this._selectedExperiment));
+            signalManager().fireOutputAddedSignal(
+                new OutputAddedSignalPayload(selectedOutput, this._selectedExperiment)
+            );
         }
     }
 
-    protected doHandleContextMenuEvent(event: React.MouseEvent<HTMLDivElement>, output: OutputDescriptor | undefined): void {
+    protected doHandleContextMenuEvent(
+        event: React.MouseEvent<HTMLDivElement>,
+        output: OutputDescriptor | undefined
+    ): void {
         if (this.props.contextMenuRenderer && output) {
             this.props.contextMenuRenderer(event, output);
         }
@@ -73,16 +82,16 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
     }
 
     protected doHandleExperimentSelectedSignal(experiment: Experiment | undefined): void {
-        if ((this._selectedExperiment?.UUID !== experiment?.UUID) || this.state.availableOutputDescriptors.length === 0) {
+        if (this._selectedExperiment?.UUID !== experiment?.UUID || this.state.availableOutputDescriptors.length === 0) {
             this._selectedExperiment = experiment;
-            this.setState({ availableOutputDescriptors: []});
+            this.setState({ availableOutputDescriptors: [] });
             this.updateAvailableViews();
         }
     }
 
     protected doHandleExperimentClosedSignal(experiment: Experiment | undefined): void {
         if (this._selectedExperiment?.UUID === experiment?.UUID) {
-            this.setState({availableOutputDescriptors: []});
+            this.setState({ availableOutputDescriptors: [] });
         }
     }
 

--- a/theia-extensions/viewer-prototype/package.json
+++ b/theia-extensions/viewer-prototype/package.json
@@ -38,7 +38,9 @@
     "clean": "rimraf lib *.tsbuildinfo",
     "lint": "eslint .",
     "test": "echo 'test'",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "format:write": "prettier --write ./src",
+    "format:check": "prettier --check ./src"
   },
   "theiaExtensions": [
     {

--- a/theia-extensions/viewer-prototype/src/browser/theia-message-manager.ts
+++ b/theia-extensions/viewer-prototype/src/browser/theia-message-manager.ts
@@ -6,21 +6,20 @@ import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser';
 
 @injectable()
 export class TheiaMessageManager implements Messages.MessageManager {
+    constructor(@inject(StatusBar) protected readonly statusBar: StatusBar) {}
 
-    constructor(
-        @inject(StatusBar) protected readonly statusBar: StatusBar,
-    ) {
-
-    }
-
-    addStatusMessage(messageKey: string, {text,
-        category = Messages.MessageCategory.SERVER_MESSAGE,
-        severity = Messages.MessageSeverity.INFO }: Messages.StatusMessage): void {
-        this.statusBar.setElement(messageKey, {text: text, alignment: StatusBarAlignment.RIGHT});
+    addStatusMessage(
+        messageKey: string,
+        {
+            text,
+            category = Messages.MessageCategory.SERVER_MESSAGE,
+            severity = Messages.MessageSeverity.INFO
+        }: Messages.StatusMessage
+    ): void {
+        this.statusBar.setElement(messageKey, { text: text, alignment: StatusBarAlignment.RIGHT });
     }
 
     removeStatusMessage(messageKey: string): void {
         this.statusBar.removeElement(messageKey);
     }
-
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
@@ -5,7 +5,7 @@ export namespace TraceExplorerMenus {
 }
 export namespace TraceExplorerCommands {
     export const OPEN_TRACE: Command = {
-        id: 'trace-explorer:open-trace',
+        id: 'trace-explorer:open-trace'
     };
 
     export const CLOSE_TRACE: Command = {

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
@@ -1,12 +1,15 @@
 import { injectable } from 'inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
-import { TraceExplorerWidget, } from './trace-explorer-widget';
+import { TraceExplorerWidget } from './trace-explorer-widget';
 import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
 import { MenuModelRegistry, CommandRegistry } from '@theia/core';
 import { TraceExplorerCommands, TraceExplorerMenus } from './trace-explorer-commands';
 
 @injectable()
-export class TraceExplorerContribution extends AbstractViewContribution<TraceExplorerWidget> implements FrontendApplicationContribution {
+export class TraceExplorerContribution
+    extends AbstractViewContribution<TraceExplorerWidget>
+    implements FrontendApplicationContribution
+{
     constructor() {
         super({
             widgetId: TraceExplorerWidget.ID,

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget.tsx
@@ -5,11 +5,11 @@ import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { CommandService } from '@theia/core';
 import { TspClientProvider } from '../../tsp-client-provider-impl';
-import { signalManager} from 'traceviewer-base/lib/signals/signal-manager';
+import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 import { TraceExplorerItemPropertiesWidget } from './theia-trace-explorer-properties-widget';
 import { ContextMenuRenderer } from '@theia/core/lib/browser';
 import { TraceViewerCommand } from '../../trace-viewer/trace-viewer-commands';
-import { ReactOpenTracesWidget} from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-opened-traces-widget';
+import { ReactOpenTracesWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-opened-traces-widget';
 import { TraceExplorerMenus } from '../trace-explorer-commands';
 import { TraceViewerWidget } from '../../trace-viewer/trace-viewer';
 
@@ -21,7 +21,8 @@ export class TraceExplorerOpenedTracesWidget extends ReactWidget {
     static LINE_HEIGHT = 16;
 
     @inject(TspClientProvider) protected readonly tspClientProvider!: TspClientProvider;
-    @inject(TraceExplorerItemPropertiesWidget) protected readonly itemPropertiesWidget!: TraceExplorerItemPropertiesWidget;
+    @inject(TraceExplorerItemPropertiesWidget)
+    protected readonly itemPropertiesWidget!: TraceExplorerItemPropertiesWidget;
     @inject(ContextMenuRenderer) protected readonly contextMenuRenderer!: ContextMenuRenderer;
     @inject(CommandService) protected readonly commandService!: CommandService;
     @inject(WidgetManager) protected readonly widgetManager!: WidgetManager;
@@ -70,15 +71,17 @@ export class TraceExplorerOpenedTracesWidget extends ReactWidget {
     }
 
     render(): React.ReactNode {
-        return <div>
-            <ReactOpenTracesWidget
-                id={this.id}
-                title={this.title.label}
-                tspClientProvider={this.tspClientProvider}
-                contextMenuRenderer={(event, experiment) => this.doHandleContextMenuEvent(event, experiment) }
-                onClick={(event, experiment) => this.doHandleClickEvent(event, experiment) }
-            ></ReactOpenTracesWidget>
-        </div>;
+        return (
+            <div>
+                <ReactOpenTracesWidget
+                    id={this.id}
+                    title={this.title.label}
+                    tspClientProvider={this.tspClientProvider}
+                    contextMenuRenderer={(event, experiment) => this.doHandleContextMenuEvent(event, experiment)}
+                    onClick={(event, experiment) => this.doHandleClickEvent(event, experiment)}
+                ></ReactOpenTracesWidget>
+            </div>
+        );
     }
 
     protected onResize(msg: Widget.ResizeMessage): void {

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-placeholder-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-placeholder-widget.tsx
@@ -3,7 +3,7 @@ import { ReactWidget } from '@theia/core/lib/browser';
 import * as React from 'react';
 import { CommandService } from '@theia/core';
 import { OpenTraceCommand } from '../../trace-viewer/trace-viewer-commands';
-import {ReactExplorerPlaceholderWidget} from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-placeholder-widget';
+import { ReactExplorerPlaceholderWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-placeholder-widget';
 
 @injectable()
 export class TraceExplorerPlaceholderWidget extends ReactWidget {

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-properties-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-properties-widget.tsx
@@ -3,7 +3,7 @@ import { Message, ReactWidget, Widget } from '@theia/core/lib/browser';
 import * as React from 'react';
 import { EditorOpenerOptions, EditorManager } from '@theia/editor/lib/browser';
 import URI from '@theia/core/lib/common/uri';
-import { ReactItemPropertiesWidget} from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-properties-widget';
+import { ReactItemPropertiesWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-properties-widget';
 
 @injectable()
 export class TraceExplorerItemPropertiesWidget extends ReactWidget {
@@ -26,11 +26,11 @@ export class TraceExplorerItemPropertiesWidget extends ReactWidget {
     render(): React.ReactNode {
         return (
             <div>
-               <ReactItemPropertiesWidget
-               id={this.id}
-               title={this.title.label}
-               handleSourcecodeLookup={this.handleSourcecodeLookup}
-               ></ReactItemPropertiesWidget>
+                <ReactItemPropertiesWidget
+                    id={this.id}
+                    title={this.title.label}
+                    handleSourcecodeLookup={this.handleSourcecodeLookup}
+                ></ReactItemPropertiesWidget>
             </div>
         );
     }
@@ -45,10 +45,13 @@ export class TraceExplorerItemPropertiesWidget extends ReactWidget {
         this.update();
     }
 
-    protected handleSourcecodeLookup = (e: React.MouseEvent<HTMLParagraphElement>): void => this.doHandleSourcecodeLookup(e);
+    protected handleSourcecodeLookup = (e: React.MouseEvent<HTMLParagraphElement>): void =>
+        this.doHandleSourcecodeLookup(e);
 
     private doHandleSourcecodeLookup(e: React.MouseEvent<HTMLParagraphElement>) {
-        const { fileLocation, line }: { fileLocation: string, line: string } = JSON.parse(`${e.currentTarget.getAttribute('data-id')}`);
+        const { fileLocation, line }: { fileLocation: string; line: string } = JSON.parse(
+            `${e.currentTarget.getAttribute('data-id')}`
+        );
         if (fileLocation) {
             const modeOpt: EditorOpenerOptions = {
                 mode: 'open'

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-time-range-data-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-time-range-data-widget.tsx
@@ -18,12 +18,11 @@ export class TraceExplorerTimeRangeDataWidget extends ReactWidget {
     }
 
     render(): React.ReactNode {
-        return <div>
-            <ReactTimeRangeDataWidget
-                id={this.id}
-                title={this.title.label}
-            />
-        </div>;
+        return (
+            <div>
+                <ReactTimeRangeDataWidget id={this.id} title={this.title.label} />
+            </div>
+        );
     }
 
     protected onResize(msg: Widget.ResizeMessage): void {

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
@@ -2,7 +2,7 @@ import { inject, injectable, postConstruct } from 'inversify';
 import { ReactWidget, Widget, Message, WidgetManager } from '@theia/core/lib/browser';
 import { TspClientProvider } from '../../tsp-client-provider-impl';
 import * as React from 'react';
-import { ReactAvailableViewsWidget} from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-views-widget';
+import { ReactAvailableViewsWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-views-widget';
 
 @injectable()
 export class TraceExplorerViewsWidget extends ReactWidget {
@@ -20,13 +20,15 @@ export class TraceExplorerViewsWidget extends ReactWidget {
     }
 
     render(): React.ReactNode {
-        return <div>
-            <ReactAvailableViewsWidget
-                id={this.id}
-                title={this.title.label}
-                tspClientProvider={this.tspClientProvider}
-            ></ReactAvailableViewsWidget>
-        </div>;
+        return (
+            <div>
+                <ReactAvailableViewsWidget
+                    id={this.id}
+                    title={this.title.label}
+                    tspClientProvider={this.tspClientProvider}
+                ></ReactAvailableViewsWidget>
+            </div>
+        );
     }
 
     protected onResize(msg: Widget.ResizeMessage): void {

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component.tsx
@@ -10,15 +10,11 @@ import { EventsTableShortcutsTable } from './events-table-shortcuts-table';
 import { SelectShortcutsTable } from './select-shortcuts-table';
 
 @injectable()
-export class ChartShortcutsDialogProps extends DialogProps {
-}
+export class ChartShortcutsDialogProps extends DialogProps {}
 
 @injectable()
 export class ChartShortcutsDialog extends ReactDialog<undefined> {
-
-    constructor(
-        @inject(ChartShortcutsDialogProps) protected readonly props: ChartShortcutsDialogProps
-    ) {
+    constructor(@inject(ChartShortcutsDialogProps) protected readonly props: ChartShortcutsDialogProps) {
         super(props);
         this.appendAcceptButton();
     }
@@ -40,5 +36,7 @@ export class ChartShortcutsDialog extends ReactDialog<undefined> {
         this.update();
     }
 
-    get value(): undefined { return undefined; }
+    get value(): undefined {
+        return undefined;
+    }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/essential-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/essential-shortcuts-table.tsx
@@ -1,28 +1,31 @@
 import * as React from 'react';
 
 export class EssentialShortcutsTable extends React.Component {
-
     render(): React.ReactNode {
-        return <React.Fragment>
-            <span className='shortcuts-table-header'>ESSENTIAL</span>
-            <div className='shortcuts-table-row'>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td><i className='fa fa-question-circle fa-lg' /> Display This Menu</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>CTRL / command</span>
-                                    <span className='monaco-keybinding-key'>F1</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+        return (
+            <React.Fragment>
+                <span className="shortcuts-table-header">ESSENTIAL</span>
+                <div className="shortcuts-table-row">
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <i className="fa fa-question-circle fa-lg" /> Display This Menu
+                                    </td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">CTRL / command</span>
+                                        <span className="monaco-keybinding-key">F1</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div className="shortcuts-table-column">
+                        <table></table>
+                    </div>
                 </div>
-                <div className='shortcuts-table-column'>
-                    <table></table>
-                </div>
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/events-table-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/events-table-shortcuts-table.tsx
@@ -1,84 +1,97 @@
 import * as React from 'react';
 
 export class EventsTableShortcutsTable extends React.Component {
-
     render(): React.ReactNode {
-        return <React.Fragment>
-            <span className='shortcuts-table-header'>TABLE NAVIGATION</span>
-            <div className='shortcuts-table-row'>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>Cell Navigation</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-up' /></span>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-down' /></span>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-left' /></span>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-right' /></span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Page Up</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Page Up</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Page Down</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Page Down</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Multi-select</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Shift</span>
-                                    <span className='monaco-keybinding-key'>Click</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>Shift</span>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-up' /></span>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-down' /></span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+        return (
+            <React.Fragment>
+                <span className="shortcuts-table-header">TABLE NAVIGATION</span>
+                <div className="shortcuts-table-row">
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>Cell Navigation</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-up" />
+                                        </span>
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-down" />
+                                        </span>
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-left" />
+                                        </span>
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-right" />
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Page Up</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Page Up</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Page Down</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Page Down</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Multi-select</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Shift</span>
+                                        <span className="monaco-keybinding-key">Click</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">Shift</span>
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-up" />
+                                        </span>
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-down" />
+                                        </span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>Deselect row(s)</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Ctrl</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">meta</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Go to first row</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Home</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Go to last row</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">End</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Select current row</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Click</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">Space</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>Deselect row(s)</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Ctrl</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>meta</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Go to first row</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Home</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Go to last row</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>End</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Select current row</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Click</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>Space</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/select-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/select-shortcuts-table.tsx
@@ -1,53 +1,58 @@
 import * as React from 'react';
 
 export class SelectShortcutsTable extends React.Component {
-
     render(): React.ReactNode {
-        return <React.Fragment>
-            <span className='shortcuts-table-header'>SELECT</span>
-            <div className='shortcuts-table-row'>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>Select element</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span>Click element</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Select point in time</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span>Click anywhere in chart</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+        return (
+            <React.Fragment>
+                <span className="shortcuts-table-header">SELECT</span>
+                <div className="shortcuts-table-row">
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>Select element</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span>Click element</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Select point in time</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span>Click anywhere in chart</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>Extend time range</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Shift</span>
+                                        <span className="monaco-keybinding-key">Click</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">Shift</span>
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-left" />
+                                        </span>
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-right" />
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Select time range</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Drag</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>Extend time range</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Shift</span>
-                                    <span className='monaco-keybinding-key'>Click</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>Shift</span>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-left' /></span>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-right' /></span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Select time range</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Drag</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
@@ -1,72 +1,81 @@
 import * as React from 'react';
 
 export class TimeGraphShortcutsTable extends React.Component {
-
     render(): React.ReactNode {
-        return <React.Fragment>
-            <span className='shortcuts-table-header'>TIME-GRAPH NAVIGATION</span>
-            <div className='shortcuts-table-row'>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>Next state</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-right' /></span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Previous state</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-left' /></span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Next Marker</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>.</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Previous Marker</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>,</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+        return (
+            <React.Fragment>
+                <span className="shortcuts-table-header">TIME-GRAPH NAVIGATION</span>
+                <div className="shortcuts-table-row">
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>Next state</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-right" />
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Previous state</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-left" />
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Next Marker</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">.</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Previous Marker</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">,</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>Move up a row</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-up" />
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Move down a row</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">
+                                            <i className="fa fa-arrow-down" />
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Zoom to selected</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Z</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Zoom to state&apos;s range</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span>Double-click state</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>Move up a row</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-up' /></span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Move down a row</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-down' /></span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Zoom to selected</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Z</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Zoom to state&apos;s range</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span>Double-click state</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/zoom-pan-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/zoom-pan-shortcuts-table.tsx
@@ -1,93 +1,103 @@
 import * as React from 'react';
 
 export class ZoomPanShortcutsTable extends React.Component {
-
     render(): React.ReactNode {
-        return <React.Fragment>
-            <span className='shortcuts-table-header'>ZOOM AND PAN</span>
-            <div className='shortcuts-table-row'>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td><i className='fa fa-plus-square-o fa-lg' /> Zoom in</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>W</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>I</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>CTRL</span>
-                                    <span className='monaco-keybinding-key'>Scroll</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>+</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><i className='fa fa-minus-square-o fa-lg' /> Zoom out</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>S</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>K</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>CTRL</span>
-                                    <span className='monaco-keybinding-key'>Scroll</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>-</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><i className='fa fa-hand-paper-o fa-lg' /> Pan</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>A</span>
-                                    <span className='monaco-keybinding-seperator'>&</span>
-                                    <span className='monaco-keybinding-key'>D</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>J</span>
-                                    <span className='monaco-keybinding-seperator'>&</span>
-                                    <span className='monaco-keybinding-key'>L</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>CTRL</span>
-                                    <span className='monaco-keybinding-key'>Drag</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>Middle-Drag</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+        return (
+            <React.Fragment>
+                <span className="shortcuts-table-header">ZOOM AND PAN</span>
+                <div className="shortcuts-table-row">
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <i className="fa fa-plus-square-o fa-lg" /> Zoom in
+                                    </td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">W</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">I</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">CTRL</span>
+                                        <span className="monaco-keybinding-key">Scroll</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">+</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <i className="fa fa-minus-square-o fa-lg" /> Zoom out
+                                    </td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">S</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">K</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">CTRL</span>
+                                        <span className="monaco-keybinding-key">Scroll</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">-</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <i className="fa fa-hand-paper-o fa-lg" /> Pan
+                                    </td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">A</span>
+                                        <span className="monaco-keybinding-seperator">&</span>
+                                        <span className="monaco-keybinding-key">D</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">J</span>
+                                        <span className="monaco-keybinding-seperator">&</span>
+                                        <span className="monaco-keybinding-key">L</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">CTRL</span>
+                                        <span className="monaco-keybinding-key">Drag</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">Middle-Drag</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div className="shortcuts-table-column">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <i className="fa fa-undo fa-lg" /> Undo
+                                    </td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">CTRL</span>
+                                        <span className="monaco-keybinding-key">Z</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <i className="fa fa-repeat fa-lg" /> Redo
+                                    </td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">CTRL</span>
+                                        <span className="monaco-keybinding-key">SHIFT</span>
+                                        <span className="monaco-keybinding-key">Z</span>
+                                        <span className="monaco-keybinding-seperator">or</span>
+                                        <span className="monaco-keybinding-key">CTRL</span>
+                                        <span className="monaco-keybinding-key">Y</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Zoom to selected range</td>
+                                    <td className="monaco-keybinding shortcuts-table-keybinding">
+                                        <span className="monaco-keybinding-key">Right-Click</span>
+                                        <span className="monaco-keybinding-key">Drag</span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-                <div className='shortcuts-table-column'>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td><i className='fa fa-undo fa-lg' /> Undo</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>CTRL</span>
-                                    <span className='monaco-keybinding-key'>Z</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><i className='fa fa-repeat fa-lg' /> Redo</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>CTRL</span>
-                                    <span className='monaco-keybinding-key'>SHIFT</span>
-                                    <span className='monaco-keybinding-key'>Z</span>
-                                    <span className='monaco-keybinding-seperator'>or</span>
-                                    <span className='monaco-keybinding-key'>CTRL</span>
-                                    <span className='monaco-keybinding-key'>Y</span>
-
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Zoom to selected range</td>
-                                <td className='monaco-keybinding shortcuts-table-keybinding'>
-                                    <span className='monaco-keybinding-key'>Right-Click</span>
-                                    <span className='monaco-keybinding-key'>Drag</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
@@ -5,7 +5,6 @@ import { CommandService } from '@theia/core';
 
 @injectable()
 export class TraceExplorerServerStatusWidget extends ReactWidget {
-
     static ID = 'trace-explorer-server-status-widget';
     static LABEL = 'Trace Explorer Server Status Widget';
 
@@ -23,9 +22,16 @@ export class TraceExplorerServerStatusWidget extends ReactWidget {
     }
 
     render(): React.ReactNode {
-        return <div className='server-status-header'>
-            <span className='theia-header'>Server Status </span>
-            <i id='server-status-id' className='fa fa-times-circle-o fa-lg' title='Trace Viewer Critical Error: Trace Server Offline' style={{color: 'red', marginLeft: '5px'}}/>
-        </div>;
+        return (
+            <div className="server-status-header">
+                <span className="theia-header">Server Status </span>
+                <i
+                    id="server-status-id"
+                    className="fa fa-times-circle-o fa-lg"
+                    title="Trace Viewer Critical Error: Trace Server Offline"
+                    style={{ color: 'red', marginLeft: '5px' }}
+                />
+            </div>
+        );
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -18,12 +18,14 @@ export class TraceExplorerWidget extends BaseWidget {
     private _numberOfOpenedTraces = 0;
     @inject(TraceExplorerViewsWidget) protected readonly viewsWidget!: TraceExplorerViewsWidget;
     @inject(TraceExplorerOpenedTracesWidget) protected readonly openedTracesWidget!: TraceExplorerOpenedTracesWidget;
-    @inject(TraceExplorerItemPropertiesWidget) protected readonly itemPropertiesWidget!: TraceExplorerItemPropertiesWidget;
+    @inject(TraceExplorerItemPropertiesWidget)
+    protected readonly itemPropertiesWidget!: TraceExplorerItemPropertiesWidget;
     @inject(TraceExplorerPlaceholderWidget) protected readonly placeholderWidget!: TraceExplorerPlaceholderWidget;
     @inject(TraceExplorerServerStatusWidget) protected readonly serverStatusWidget!: TraceExplorerServerStatusWidget;
     @inject(TraceExplorerTimeRangeDataWidget) protected readonly timeRangeDataWidget!: TraceExplorerTimeRangeDataWidget;
     @inject(ViewContainer.Factory) protected readonly viewContainerFactory!: ViewContainer.Factory;
-    @inject(TraceServerConnectionStatusService) protected readonly connectionStatusService: TraceServerConnectionStatusService;
+    @inject(TraceServerConnectionStatusService)
+    protected readonly connectionStatusService: TraceServerConnectionStatusService;
 
     openExperiment(traceUUID: string): void {
         return this.openedTracesWidget.openExperiment(traceUUID);
@@ -69,7 +71,7 @@ export class TraceExplorerWidget extends BaseWidget {
         this.traceViewsContainer.addWidget(this.itemPropertiesWidget);
         this.traceViewsContainer.addWidget(this.timeRangeDataWidget);
         this.toDispose.push(this.traceViewsContainer);
-        const layout = this.layout = new PanelLayout();
+        const layout = (this.layout = new PanelLayout());
         layout.addWidget(this.serverStatusWidget);
         layout.addWidget(this.placeholderWidget);
         layout.addWidget(this.traceViewsContainer);
@@ -83,7 +85,8 @@ export class TraceExplorerWidget extends BaseWidget {
         signalManager().off(Signals.OPENED_TRACES_UPDATED, this.onUpdateSignal);
     }
 
-    protected onUpdateSignal = (payload: OpenedTracesUpdatedSignalPayload): void => this.doHandleOpenedTracesChanged(payload);
+    protected onUpdateSignal = (payload: OpenedTracesUpdatedSignalPayload): void =>
+        this.doHandleOpenedTracesChanged(payload);
     protected doHandleOpenedTracesChanged(payload: OpenedTracesUpdatedSignalPayload): void {
         this._numberOfOpenedTraces = payload.getNumberOfOpenedTraces();
         this.update();
@@ -112,5 +115,4 @@ export class TraceExplorerWidget extends BaseWidget {
     protected onAfterHide(): void {
         this.connectionStatusService.removeConnectionStatusListener();
     }
-
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-overview-binding.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-overview-binding.ts
@@ -3,11 +3,13 @@ import { PreferenceService, createPreferenceProxy, PreferenceContribution } from
 import { OverviewPreferences, OverviewSchema } from './trace-overview-preference';
 
 export function bindTraceOverviewPreferences(bind: interfaces.Bind): void {
-    bind(OverviewPreferences).toDynamicValue(ctx => {
-        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createPreferenceProxy(preferences, OverviewSchema);
-    }).inSingletonScope();
+    bind(OverviewPreferences)
+        .toDynamicValue(ctx => {
+            const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+            return createPreferenceProxy(preferences, OverviewSchema);
+        })
+        .inSingletonScope();
     bind(PreferenceContribution).toConstantValue({
-        schema: OverviewSchema,
+        schema: OverviewSchema
     });
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-overview-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-overview-preference.ts
@@ -4,10 +4,12 @@ export const TRACE_OVERVIEW_DEFAULT_VIEW_KEY = 'trace Viewer.trace Overview.defa
 export const DEFAULT_OVERVIEW_OUTPUT_NAME = 'Histogram';
 
 export function getSwitchToDefaultViewErrorMessage(preferredName: string, defaultName: string): string {
-    return `The ${preferredName} view cannot be opened as the trace overview. ` +
-    `Opening ${defaultName} instead. ` +
-    'Please set the Default View preference (Ctrl + ,) of the Trace Overview to an XY view, ' +
-    'or make sure the name is spelled correctly.';
+    return (
+        `The ${preferredName} view cannot be opened as the trace overview. ` +
+        `Opening ${defaultName} instead. ` +
+        'Please set the Default View preference (Ctrl + ,) of the Trace Overview to an XY view, ' +
+        'or make sure the name is spelled correctly.'
+    );
 }
 
 export function getOpenTraceOverviewFailErrorMessage(): string {
@@ -21,14 +23,15 @@ export const OverviewSchema: PreferenceSchema = {
         [TRACE_OVERVIEW_DEFAULT_VIEW_KEY]: {
             type: 'string',
             default: DEFAULT_OVERVIEW_OUTPUT_NAME,
-            description: 'Specify the name of the view that will be used as the default view for the Trace Overview. ' +
-            'Use the same name displayed in the Available Views list. E.g: For the Histogram view, enter Histogram.'
+            description:
+                'Specify the name of the view that will be used as the default view for the Trace Overview. ' +
+                'Use the same name displayed in the Available Views list. E.g: For the Histogram view, enter Histogram.'
         }
-    },
+    }
 };
 
 interface OverviewContribution {
-    [TRACE_OVERVIEW_DEFAULT_VIEW_KEY]: string
+    [TRACE_OVERVIEW_DEFAULT_VIEW_KEY]: string;
 }
 
 export const OverviewPreferences = Symbol('OverviewPreferences');

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-bindings.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-bindings.ts
@@ -3,12 +3,13 @@ import { PreferenceService, createPreferenceProxy, PreferenceContribution } from
 import { TracePreferences, ServerSchema } from './trace-server-preference';
 
 export function bindTraceServerPreferences(bind: interfaces.Bind): void {
-    bind(TracePreferences).toDynamicValue(ctx => {
-        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createPreferenceProxy(preferences, ServerSchema);
-    }).inSingletonScope();
+    bind(TracePreferences)
+        .toDynamicValue(ctx => {
+            const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+            return createPreferenceProxy(preferences, ServerSchema);
+        })
+        .inSingletonScope();
     bind(PreferenceContribution).toConstantValue({
-        schema: ServerSchema,
+        schema: ServerSchema
     });
-
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
@@ -11,26 +11,28 @@ export const ServerSchema: PreferenceSchema = {
     properties: {
         [TRACE_PATH]: {
             type: 'string',
-            description: 'The path to trace-server executable, e.g.: /usr/bin/tracecompass-server',
+            description: 'The path to trace-server executable, e.g.: /usr/bin/tracecompass-server'
         },
         [TRACE_PORT]: {
             type: 'integer',
             default: TRACE_VIEWER_DEFAULT_PORT,
-            description: 'Specify the port the Trace Viewer would use to connect to the trace server',
+            description: 'Specify the port the Trace Viewer would use to connect to the trace server'
         },
         [TRACE_ARGS]: {
             type: 'string',
             default: '',
-            description: 'Specify trace-server command line arguments. This change will take effect the next time the trace server starts.'+'\n'+
-            'E.g. for Trace Compass server: -data /home/user/server-workspace -vmargs -Dtraceserver.port=8080',
+            description:
+                'Specify trace-server command line arguments. This change will take effect the next time the trace server starts.' +
+                '\n' +
+                'E.g. for Trace Compass server: -data /home/user/server-workspace -vmargs -Dtraceserver.port=8080'
         }
-    },
+    }
 };
 
 interface TracePreferenceContribution {
-    [TRACE_PATH]?: string
-    [TRACE_PORT]: number
-    [TRACE_ARGS]: string
+    [TRACE_PATH]?: string;
+    [TRACE_PORT]: number;
+    [TRACE_ARGS]: string;
 }
 
 export const TracePreferences = Symbol('TracePreferences');

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-status.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-status.ts
@@ -4,13 +4,12 @@ import { RestClient, ConnectionStatusListener } from 'tsp-typescript-client/lib/
 
 @injectable()
 export class TraceServerConnectionStatusService {
-
     private connectionStatusListener: ConnectionStatusListener;
 
     private constructor() {
-        this.connectionStatusListener = ((status: boolean) => {
+        this.connectionStatusListener = (status: boolean) => {
             TraceServerConnectionStatusService.renderStatus(status);
-        });
+        };
     }
 
     public addConnectionStatusListener(): void {
@@ -23,9 +22,12 @@ export class TraceServerConnectionStatusService {
 
     static renderStatus(status: boolean): void {
         if (document.getElementById('server-status-id')) {
-            document.getElementById('server-status-id')!.className = status ? 'fa fa-check-circle-o fa-lg' : 'fa fa-times-circle-o fa-lg';
-            document.getElementById('server-status-id')!.title = status ?
-                'Server health and latency are good. No known issues' : 'Trace Viewer Critical Error: Trace Server Offline';
+            document.getElementById('server-status-id')!.className = status
+                ? 'fa fa-check-circle-o fa-lg'
+                : 'fa fa-times-circle-o fa-lg';
+            document.getElementById('server-status-id')!.title = status
+                ? 'Server health and latency are good. No known issues'
+                : 'Trace Viewer Critical Error: Trace Server Offline';
             document.getElementById('server-status-id')!.style.color = status ? 'green' : 'red';
         }
     }

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-url-provider-frontend-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-url-provider-frontend-impl.ts
@@ -8,7 +8,6 @@ import { TracePreferences, TRACE_PORT } from './trace-server-preference';
 
 @injectable()
 export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, FrontendApplicationContribution {
-
     /**
      * The Trace Server URL resolved from a URL template and a port number.
      * Updated each time the port is changed from the preferences.
@@ -50,7 +49,7 @@ export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, Front
         @inject(EnvVariablesServer) protected environment: EnvVariablesServer,
         @inject(TracePreferences) protected tracePreferences: TracePreferences,
         @inject(TraceServerConfigService) protected traceServerConfigService: TraceServerConfigService,
-        @inject(MessageService) protected messageService: MessageService,
+        @inject(MessageService) protected messageService: MessageService
     ) {
         this._traceServerUrlPromise = new Promise(resolve => {
             const self = this.onDidChangeTraceServerUrl(url => {
@@ -61,9 +60,7 @@ export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, Front
         // Get the URL template from the remote environment.
         this.environment.getValue('TRACE_SERVER_URL').then(variable => {
             const url = variable?.value;
-            this._traceServerUrlTemplate = url
-                ? this.normalizeUrl(url)
-                : TRACE_SERVER_DEFAULT_URL;
+            this._traceServerUrlTemplate = url ? this.normalizeUrl(url) : TRACE_SERVER_DEFAULT_URL;
             this.updateTraceServerUrl();
         });
         // Get the configurable port from Theia's preferences.

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -1,18 +1,23 @@
 import { injectable, inject } from 'inversify';
 import { CommandRegistry, CommandContribution, MessageService } from '@theia/core';
-import { WidgetOpenerOptions, WidgetOpenHandler, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
+import {
+    WidgetOpenerOptions,
+    WidgetOpenHandler,
+    KeybindingContribution,
+    KeybindingRegistry
+} from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import {
-  OpenTraceCommand,
-  StartServerCommand,
-  StopServerCommand,
-  TraceViewerCommand,
-  KeyboardShortcutsCommand,
-  OpenTraceWithRootPathCommand,
-  OpenTraceWithPathCommand,
+    OpenTraceCommand,
+    StartServerCommand,
+    StopServerCommand,
+    TraceViewerCommand,
+    KeyboardShortcutsCommand,
+    OpenTraceWithRootPathCommand,
+    OpenTraceWithPathCommand
 } from './trace-viewer-commands';
 import { PortBusy, TraceServerConfigService } from '../../common/trace-server-config';
 import { TracePreferences, TRACE_PATH, TRACE_ARGS } from '../trace-server-preference';
@@ -28,16 +33,16 @@ interface TraceViewerWidgetOpenerOptions extends WidgetOpenerOptions {
 }
 
 @injectable()
-export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget> implements CommandContribution, KeybindingContribution {
-
+export class TraceViewerContribution
+    extends WidgetOpenHandler<TraceViewerWidget>
+    implements CommandContribution, KeybindingContribution
+{
     private tspClient: TspClient;
 
-    private constructor(
-        @inject(TspClientProvider) private tspClientProvider: TspClientProvider
-    ) {
+    private constructor(@inject(TspClientProvider) private tspClientProvider: TspClientProvider) {
         super();
         this.tspClient = this.tspClientProvider.getTspClient();
-        this.tspClientProvider.addTspClientChangeListener(tspClient => this.tspClient = tspClient);
+        this.tspClientProvider.addTspClientChangeListener(tspClient => (this.tspClient = tspClient));
     }
 
     @inject(FileDialogService) protected readonly fileDialogService: FileDialogService;
@@ -81,7 +86,10 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                 const resolve = await this.traceServerConfigService.startTraceServer({ path, args });
                 if (resolve === 'success') {
                     if (this.args && this.args.length > 0) {
-                        progress.report({ message: `Trace server started using the following arguments:  ${this.args}.`, work: { done: 100, total: 100 } });
+                        progress.report({
+                            message: `Trace server started using the following arguments:  ${this.args}.`,
+                            work: { done: 100, total: 100 }
+                        });
                     } else {
                         progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                     }
@@ -93,7 +101,8 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                 if (PortBusy.is(err as any)) {
                     if (this.args && this.args.length > 0) {
                         this.messageService.error(
-                            `Error starting the server (port busy) using the following arguments: ${this.args}`);
+                            `Error starting the server (port busy) using the following arguments: ${this.args}`
+                        );
                     } else {
                         this.messageService.error('Error starting the server (port busy)');
                     }
@@ -145,7 +154,10 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                     if (resolve === 'success') {
                         await this.waitForTraceServer(10_000);
                         if (this.args && this.args.length > 0) {
-                            progress.report({ message: `Trace server started using the following arguments:  ${args}.`, work: { done: 100, total: 100 } });
+                            progress.report({
+                                message: `Trace server started using the following arguments:  ${args}.`,
+                                work: { done: 100, total: 100 }
+                            });
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
@@ -157,7 +169,8 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                     if (PortBusy.is(err as any)) {
                         if (this.args && this.args.length > 0) {
                             this.messageService.error(
-                                `Error starting the server (port busy) using the following arguments: ${this.args}`);
+                                `Error starting the server (port busy) using the following arguments: ${this.args}`
+                            );
                         } else {
                             this.messageService.error('Error starting the server (port busy)');
                         }
@@ -177,7 +190,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             keybinding: 'ctrlcmd+f1',
-            command: KeyboardShortcutsCommand.id,
+            command: KeyboardShortcutsCommand.id
         });
     }
 
@@ -187,7 +200,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
         });
         registry.registerCommand(OpenTraceWithPathCommand, {
             isVisible: () => false,
-            execute: (path: string) => path && this.open(new URI(path)),
+            execute: (path: string) => path && this.open(new URI(path))
         });
         registry.registerCommand(OpenTraceWithRootPathCommand, {
             isVisible: () => false,
@@ -206,7 +219,10 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                     if (resolve === 'success') {
                         await this.waitForTraceServer(10000);
                         if (this.args && this.args.length > 0) {
-                            progress.report({ message: `Trace server started using the following arguments:  ${args}.`, work: { done: 100, total: 100 } });
+                            progress.report({
+                                message: `Trace server started using the following arguments:  ${args}.`,
+                                work: { done: 100, total: 100 }
+                            });
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
@@ -220,7 +236,8 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                     if (PortBusy.is(error as any)) {
                         if (this.args && this.args.length > 0) {
                             this.messageService.error(
-                                `Error starting the server (port busy) using the following arguments: ${this.args}`);
+                                `Error starting the server (port busy) using the following arguments: ${this.args}`
+                            );
                         } else {
                             this.messageService.error('Error starting the server (port busy)');
                         }
@@ -248,7 +265,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
         });
         registry.registerCommand(KeyboardShortcutsCommand, {
             execute: async () => {
-                await new ChartShortcutsDialog({title: 'Trace Viewer Keyboard and Mouse Shortcuts'}).open();
+                await new ChartShortcutsDialog({ title: 'Trace Viewer Keyboard and Mouse Shortcuts' }).open();
             }
         });
     }
@@ -259,7 +276,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
 
     protected async waitForTraceServer(timeoutMs: number): Promise<void> {
         let timeout = false;
-        const timeoutHandle = setTimeout(() => timeout = true, timeoutMs);
+        const timeoutHandle = setTimeout(() => (timeout = true), timeoutMs);
         // Try fetching the Trace Server health, repeat on error only.
         // If we get a response of some sort, it means the HTTP server is up somehow.
         while (true) {
@@ -270,7 +287,12 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                     clearTimeout(timeoutHandle);
                     return;
                 }
-                error = new Error('Unsuccessful health check: ' + healthResponse.getStatusMessage() + ' status: ' + healthResponse.getModel()?.status);
+                error = new Error(
+                    'Unsuccessful health check: ' +
+                        healthResponse.getStatusMessage() +
+                        ' status: ' +
+                        healthResponse.getModel()?.status
+                );
             } catch (err) {
                 error = err;
             }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -1,5 +1,12 @@
 import { ContainerModule, Container } from 'inversify';
-import { WidgetFactory, OpenHandler, FrontendApplicationContribution, bindViewContribution, WebSocketConnectionProvider, KeybindingContribution } from '@theia/core/lib/browser';
+import {
+    WidgetFactory,
+    OpenHandler,
+    FrontendApplicationContribution,
+    bindViewContribution,
+    WebSocketConnectionProvider,
+    KeybindingContribution
+} from '@theia/core/lib/browser';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { TraceViewerContribution } from './trace-viewer-contribution';
 import { TraceServerUrlProvider } from '../../common/trace-server-url-provider';
@@ -39,38 +46,46 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusService);
 
     bind(TraceViewerWidget).toSelf();
-    bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({
-        id: TraceViewerWidget.ID,
-        async createWidget(options: TraceViewerWidgetOptions): Promise<TraceViewerWidget> {
-            const child = new Container({ defaultScope: 'Singleton' });
-            child.parent = context.container;
-            child.bind(TraceViewerWidgetOptions).toConstantValue(options);
-            return child.get(TraceViewerWidget);
-        }
-    })).inSingletonScope();
+    bind<WidgetFactory>(WidgetFactory)
+        .toDynamicValue(context => ({
+            id: TraceViewerWidget.ID,
+            async createWidget(options: TraceViewerWidgetOptions): Promise<TraceViewerWidget> {
+                const child = new Container({ defaultScope: 'Singleton' });
+                child.parent = context.container;
+                child.bind(TraceViewerWidgetOptions).toConstantValue(options);
+                return child.get(TraceViewerWidget);
+            }
+        }))
+        .inSingletonScope();
 
     bind(TraceViewerContribution).toSelf().inSingletonScope();
-    [CommandContribution, OpenHandler, FrontendApplicationContribution, KeybindingContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toService(TraceViewerContribution)
+    [CommandContribution, OpenHandler, FrontendApplicationContribution, KeybindingContribution].forEach(
+        serviceIdentifier => bind(serviceIdentifier).toService(TraceViewerContribution)
     );
 
     bindViewContribution(bind, TraceExplorerContribution);
     bind(FrontendApplicationContribution).toService(TraceExplorerContribution);
-    bind(WidgetFactory).toDynamicValue(context => ({
-        id: TraceExplorerWidget.ID,
-        createWidget: () => TraceExplorerWidget.createWidget(context.container)
-    })).inSingletonScope();
+    bind(WidgetFactory)
+        .toDynamicValue(context => ({
+            id: TraceExplorerWidget.ID,
+            createWidget: () => TraceExplorerWidget.createWidget(context.container)
+        }))
+        .inSingletonScope();
 
-    bind(TraceServerConfigService).toDynamicValue(ctx => {
-        const connection = ctx.container.get(WebSocketConnectionProvider);
-        return connection.createProxy<TraceServerConfigService>(traceServerPath);
-    }).inSingletonScope();
+    bind(TraceServerConfigService)
+        .toDynamicValue(ctx => {
+            const connection = ctx.container.get(WebSocketConnectionProvider);
+            return connection.createProxy<TraceServerConfigService>(traceServerPath);
+        })
+        .inSingletonScope();
     bindTraceServerPreferences(bind);
 
     bindTraceOverviewPreferences(bind);
 
-    bind(BackendFileService).toDynamicValue(ctx => {
-        const connection = ctx.container.get(WebSocketConnectionProvider);
-        return connection.createProxy<BackendFileService>(backendFileServicePath);
-    }).inSingletonScope();
+    bind(BackendFileService)
+        .toDynamicValue(ctx => {
+            const connection = ctx.container.get(WebSocketConnectionProvider);
+            return connection.createProxy<BackendFileService>(backendFileServicePath);
+        })
+        .inSingletonScope();
 });

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
@@ -4,60 +4,60 @@ export namespace TraceViewerToolbarCommands {
     export const ZOOM_IN: Command = {
         id: 'trace.viewer.zoomin',
         label: 'Zoom In',
-        iconClass: 'fa fa-plus-square-o fa-lg',
+        iconClass: 'fa fa-plus-square-o fa-lg'
     };
 
     export const ZOOM_OUT: Command = {
         id: 'trace.viewer.toolbar.zoomout',
         label: 'Zoom Out',
-        iconClass: 'fa fa-minus-square-o fa-lg',
+        iconClass: 'fa fa-minus-square-o fa-lg'
     };
 
     export const UNDO: Command = {
         id: 'trace.viewer.toolbar.undo',
         label: 'Undo',
-        iconClass: 'fa fa-undo fa-lg',
+        iconClass: 'fa fa-undo fa-lg'
     };
 
     export const REDO: Command = {
         id: 'trace.viewer.toolbar.redo',
         label: 'Redo',
-        iconClass: 'fa fa-repeat fa-lg',
+        iconClass: 'fa fa-repeat fa-lg'
     };
 
     export const RESET: Command = {
         id: 'trace.viewer.toolbar.reset',
         label: 'Reset',
-        iconClass: 'fa fa-home fa-lg',
+        iconClass: 'fa fa-home fa-lg'
     };
 
     export const FILTER: Command = {
         id: 'trace.viewer.toolbar.filter',
         label: 'Trace Viewer Toolbar Filter',
-        iconClass: 'fa fa-filter fa-lg',
+        iconClass: 'fa fa-filter fa-lg'
     };
 
     export const MARKER_SETS: Command = {
         id: 'trace.viewer.toolbar.markersets',
         label: 'Markers',
-        iconClass: 'fa fa-bars fa-lg',
+        iconClass: 'fa fa-bars fa-lg'
     };
     export const OPEN_TRACE: Command = {
         id: 'trace.viewer.openTrace',
         label: 'Open Trace',
-        iconClass: 'codicon codicon-new-folder',
+        iconClass: 'codicon codicon-new-folder'
     };
 
     export const CHARTS_CHEATSHEET: Command = {
         id: 'trace.viewer.toolbar.cheatsheet',
         label: 'Keyboard Shortcuts (CTRL / command + F1)',
-        iconClass: 'fa fa-info-circle fa-lg',
+        iconClass: 'fa fa-info-circle fa-lg'
     };
 
     export const OPEN_OVERVIEW_OUTPUT: Command = {
         id: 'trace.viewer.traceOverview',
         label: 'Show trace overview',
-        iconClass: 'codicon codicon-graph-line',
+        iconClass: 'codicon codicon-graph-line'
     };
 }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -42,9 +42,8 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
     }
 
     registerCommands(registry: CommandRegistry): void {
-        registry.registerCommand(
-            TraceViewerToolbarCommands.OPEN_OVERVIEW_OUTPUT, {
-            isVisible:(widget: Widget) => {
+        registry.registerCommand(TraceViewerToolbarCommands.OPEN_OVERVIEW_OUTPUT, {
+            isVisible: (widget: Widget) => {
                 if (widget instanceof TraceViewerWidget) {
                     return true;
                 }
@@ -57,8 +56,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             }
         });
 
-        registry.registerCommand(
-            TraceViewerToolbarCommands.ZOOM_IN, {
+        registry.registerCommand(TraceViewerToolbarCommands.ZOOM_IN, {
             isVisible: (widget: Widget) => {
                 if (widget instanceof TraceViewerWidget) {
                     return widget.isTimeRelatedChartOpened() || widget.isTraceOverviewOpened();
@@ -69,8 +67,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
                 signalManager().fireUpdateZoomSignal(true);
             }
         });
-        registry.registerCommand(
-            TraceViewerToolbarCommands.ZOOM_OUT, {
+        registry.registerCommand(TraceViewerToolbarCommands.ZOOM_OUT, {
             isVisible: (w: Widget) => {
                 if (w instanceof TraceViewerWidget) {
                     const traceWidget = w as TraceViewerWidget;
@@ -82,8 +79,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
                 signalManager().fireUpdateZoomSignal(false);
             }
         });
-        registry.registerCommand(
-            TraceViewerToolbarCommands.UNDO, {
+        registry.registerCommand(TraceViewerToolbarCommands.UNDO, {
             isVisible: (widget: Widget) => {
                 if (widget instanceof TraceViewerWidget) {
                     return widget.isTimeRelatedChartOpened() || widget.isTraceOverviewOpened();
@@ -94,8 +90,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
                 signalManager().fireUndoSignal();
             }
         });
-        registry.registerCommand(
-            TraceViewerToolbarCommands.REDO, {
+        registry.registerCommand(TraceViewerToolbarCommands.REDO, {
             isVisible: (widget: Widget) => {
                 if (widget instanceof TraceViewerWidget) {
                     return widget.isTimeRelatedChartOpened() || widget.isTraceOverviewOpened();
@@ -106,8 +101,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
                 signalManager().fireRedoSignal();
             }
         });
-        registry.registerCommand(
-            TraceViewerToolbarCommands.RESET, {
+        registry.registerCommand(TraceViewerToolbarCommands.RESET, {
             isVisible: (widget: Widget) => {
                 if (widget instanceof TraceViewerWidget) {
                     return widget.isTimeRelatedChartOpened() || widget.isTraceOverviewOpened();
@@ -118,30 +112,32 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
                 signalManager().fireResetZoomSignal();
             }
         });
-        registry.registerCommand(
-            TraceViewerToolbarCommands.OPEN_TRACE, {
-                isVisible: (w: Widget) => {
-                    if (w instanceof TraceExplorerOpenedTracesWidget) {
-                        return true;
-                    }
-                    return false;
-                },
-                execute: async () => {
-                    await registry.executeCommand(OpenTraceCommand.id);
-                }
-            });
-
-        registry.registerCommand(
-            TraceViewerToolbarCommands.CHARTS_CHEATSHEET, {
+        registry.registerCommand(TraceViewerToolbarCommands.OPEN_TRACE, {
             isVisible: (w: Widget) => {
-                if (w instanceof TraceViewerWidget) {
-                    const traceWidget = w as TraceViewerWidget;
-                    return traceWidget.isTimeRelatedChartOpened() || traceWidget.isTraceOverviewOpened() || traceWidget.isTableRelatedChartOpened();
+                if (w instanceof TraceExplorerOpenedTracesWidget) {
+                    return true;
                 }
                 return false;
             },
             execute: async () => {
-                await new ChartShortcutsDialog({title: 'Trace Viewer Keyboard and Mouse Shortcuts'}).open();
+                await registry.executeCommand(OpenTraceCommand.id);
+            }
+        });
+
+        registry.registerCommand(TraceViewerToolbarCommands.CHARTS_CHEATSHEET, {
+            isVisible: (w: Widget) => {
+                if (w instanceof TraceViewerWidget) {
+                    const traceWidget = w as TraceViewerWidget;
+                    return (
+                        traceWidget.isTimeRelatedChartOpened() ||
+                        traceWidget.isTraceOverviewOpened() ||
+                        traceWidget.isTableRelatedChartOpened()
+                    );
+                }
+                return false;
+            },
+            execute: async () => {
+                await new ChartShortcutsDialog({ title: 'Trace Viewer Keyboard and Mouse Shortcuts' }).open();
             }
         });
     }
@@ -151,31 +147,31 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             id: TraceViewerToolbarCommands.UNDO.id,
             command: TraceViewerToolbarCommands.UNDO.id,
             tooltip: TraceViewerToolbarCommands.UNDO.label,
-            priority: 1,
+            priority: 1
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.REDO.id,
             command: TraceViewerToolbarCommands.REDO.id,
             tooltip: TraceViewerToolbarCommands.REDO.label,
-            priority: 2,
+            priority: 2
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.ZOOM_IN.id,
             command: TraceViewerToolbarCommands.ZOOM_IN.id,
             tooltip: TraceViewerToolbarCommands.ZOOM_IN.label,
-            priority: 3,
+            priority: 3
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.ZOOM_OUT.id,
             command: TraceViewerToolbarCommands.ZOOM_OUT.id,
             tooltip: TraceViewerToolbarCommands.ZOOM_OUT.label,
-            priority: 4,
+            priority: 4
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.RESET.id,
             command: TraceViewerToolbarCommands.RESET.id,
             tooltip: TraceViewerToolbarCommands.RESET.label,
-            priority: 5,
+            priority: 5
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.FILTER.id,
@@ -189,65 +185,86 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             },
             // render() here is not a react component and hence need to disable the react display-name rule
             // eslint-disable-next-line react/display-name
-            render: (widget: Widget) => <div className="item enabled">
-                <div id="trace.viewer.toolbar.filter" className="fa fa-filter" title="Markers filter" onClick={async (event: React.MouseEvent) => {
-                    const toDisposeOnHide = new DisposableCollection();
-                    const menuPath = TraceViewerToolbarMenus.MARKER_CATEGORIES_MENU;
-                    let index = 1;
-                    const traceViewerWidget = widget as TraceViewerWidget;
-                    const markerCategories = traceViewerWidget.getMarkerCategories();
-                    let selectAll = true;
-                    markerCategories.forEach((categoryInfo, categoryName) => {
-                        const toggleInd = categoryInfo.toggleInd;
+            render: (widget: Widget) => (
+                <div className="item enabled">
+                    <div
+                        id="trace.viewer.toolbar.filter"
+                        className="fa fa-filter"
+                        title="Markers filter"
+                        onClick={async (event: React.MouseEvent) => {
+                            const toDisposeOnHide = new DisposableCollection();
+                            const menuPath = TraceViewerToolbarMenus.MARKER_CATEGORIES_MENU;
+                            let index = 1;
+                            const traceViewerWidget = widget as TraceViewerWidget;
+                            const markerCategories = traceViewerWidget.getMarkerCategories();
+                            let selectAll = true;
+                            markerCategories.forEach((categoryInfo, categoryName) => {
+                                const toggleInd = categoryInfo.toggleInd;
 
-                        if (!toggleInd) {
-                            selectAll = false;
-                        }
+                                if (!toggleInd) {
+                                    selectAll = false;
+                                }
 
-                        index += 1;
-                        toDisposeOnHide.push(this.menus.registerMenuAction(menuPath, {
-                            label: categoryName,
-                            commandId: categoryName.toString() + index.toString(),
-                            order: index.toString(),
-                        }));
-                        toDisposeOnHide.push(this.commands.registerCommand({
-                            id: categoryName.toString() + index.toString(),
-                            label: categoryName
-                        }, {
-                            execute: () => {
-                                traceViewerWidget.updateMarkerCategoryState(categoryName);
-                            },
-                            isToggled: () => toggleInd,
-                        }));
-                    });
+                                index += 1;
+                                toDisposeOnHide.push(
+                                    this.menus.registerMenuAction(menuPath, {
+                                        label: categoryName,
+                                        commandId: categoryName.toString() + index.toString(),
+                                        order: index.toString()
+                                    })
+                                );
+                                toDisposeOnHide.push(
+                                    this.commands.registerCommand(
+                                        {
+                                            id: categoryName.toString() + index.toString(),
+                                            label: categoryName
+                                        },
+                                        {
+                                            execute: () => {
+                                                traceViewerWidget.updateMarkerCategoryState(categoryName);
+                                            },
+                                            isToggled: () => toggleInd
+                                        }
+                                    )
+                                );
+                            });
 
-                    toDisposeOnHide.push(this.menus.registerMenuAction(menuPath, {
-                        label: 'Select all',
-                        commandId: 'Select all' + index.toString(),
-                        order: '0',
-                    }));
-                    toDisposeOnHide.push(this.commands.registerCommand({
-                        id: 'Select all' + index.toString(),
-                        label: 'Select all'
-                    }, {
-                        execute: () => {
-                            traceViewerWidget.updateAllMarkerCategoryState(!selectAll);
-                            return;
-                        },
-                        isToggled: () => selectAll,
-                    }));
+                            toDisposeOnHide.push(
+                                this.menus.registerMenuAction(menuPath, {
+                                    label: 'Select all',
+                                    commandId: 'Select all' + index.toString(),
+                                    order: '0'
+                                })
+                            );
+                            toDisposeOnHide.push(
+                                this.commands.registerCommand(
+                                    {
+                                        id: 'Select all' + index.toString(),
+                                        label: 'Select all'
+                                    },
+                                    {
+                                        execute: () => {
+                                            traceViewerWidget.updateAllMarkerCategoryState(!selectAll);
+                                            return;
+                                        },
+                                        isToggled: () => selectAll
+                                    }
+                                )
+                            );
 
-                    return this.contextMenuRenderer.render({
-                        menuPath,
-                        args: [],
-                        anchor: { x: event.clientX, y: event.clientY },
-                        onHide: () => setTimeout(() => toDisposeOnHide.dispose())
-                    });
-                }}></div>
-            </div>,
+                            return this.contextMenuRenderer.render({
+                                menuPath,
+                                args: [],
+                                anchor: { x: event.clientX, y: event.clientY },
+                                onHide: () => setTimeout(() => toDisposeOnHide.dispose())
+                            });
+                        }}
+                    ></div>
+                </div>
+            ),
             priority: 6,
             group: 'navigation',
-            onDidChange: this.onMarkerCategoriesChangedEvent,
+            onDidChange: this.onMarkerCategoriesChangedEvent
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.MARKER_SETS.id,
@@ -259,61 +276,77 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             },
             // render() here is not a react component and hence need to disable the react display-name rule
             // eslint-disable-next-line react/display-name
-            render: (widget: TraceViewerWidget) => <div className="item enabled">
-                <div id="trace.viewer.toolbar.markersets" className="fa fa-bars" title="Marker Sets" onClick={async (event: React.MouseEvent) => {
-                    const toDisposeOnHide = new DisposableCollection();
-                    const menuPath = TraceViewerToolbarMenus.MARKER_SETS_MENU;
-                    let index = 0;
-                    const traceViewerWidget = widget as TraceViewerWidget;
-                    const markerSetsMap = traceViewerWidget.getMarkerSets();
-                    const sortedMarkerSets = Array.from(markerSetsMap.keys()).sort((a, b) => a.id < b.id ? -1 : 1);
-                    sortedMarkerSets.forEach(markerSet => {
-                        index += 1;
-                        toDisposeOnHide.push(this.menus.registerMenuAction(menuPath, {
-                            label: markerSet.name,
-                            commandId: markerSet.name.toString() + index.toString(),
-                            order: String.fromCharCode(index),
-                        }));
+            render: (widget: TraceViewerWidget) => (
+                <div className="item enabled">
+                    <div
+                        id="trace.viewer.toolbar.markersets"
+                        className="fa fa-bars"
+                        title="Marker Sets"
+                        onClick={async (event: React.MouseEvent) => {
+                            const toDisposeOnHide = new DisposableCollection();
+                            const menuPath = TraceViewerToolbarMenus.MARKER_SETS_MENU;
+                            let index = 0;
+                            const traceViewerWidget = widget as TraceViewerWidget;
+                            const markerSetsMap = traceViewerWidget.getMarkerSets();
+                            const sortedMarkerSets = Array.from(markerSetsMap.keys()).sort((a, b) =>
+                                a.id < b.id ? -1 : 1
+                            );
+                            sortedMarkerSets.forEach(markerSet => {
+                                index += 1;
+                                toDisposeOnHide.push(
+                                    this.menus.registerMenuAction(menuPath, {
+                                        label: markerSet.name,
+                                        commandId: markerSet.name.toString() + index.toString(),
+                                        order: String.fromCharCode(index)
+                                    })
+                                );
 
-                        toDisposeOnHide.push(this.commands.registerCommand({
-                            id: markerSet.name.toString() + index.toString(),
-                            label: markerSet.name
-                        }, {
-                            execute: () => {
-                                traceViewerWidget.updateMarkerSetState(markerSet);
-                            },
-                            isToggled: () => !!markerSetsMap.get(markerSet)
-                        }));
-                    });
-                    return this.contextMenuRenderer.render({
-                        menuPath,
-                        args: [],
-                        anchor: { x: event.clientX, y: event.clientY },
-                        onHide: () => setTimeout(() => toDisposeOnHide.dispose())
-                    });
-                }}></div>
-            </div>,
+                                toDisposeOnHide.push(
+                                    this.commands.registerCommand(
+                                        {
+                                            id: markerSet.name.toString() + index.toString(),
+                                            label: markerSet.name
+                                        },
+                                        {
+                                            execute: () => {
+                                                traceViewerWidget.updateMarkerSetState(markerSet);
+                                            },
+                                            isToggled: () => !!markerSetsMap.get(markerSet)
+                                        }
+                                    )
+                                );
+                            });
+                            return this.contextMenuRenderer.render({
+                                menuPath,
+                                args: [],
+                                anchor: { x: event.clientX, y: event.clientY },
+                                onHide: () => setTimeout(() => toDisposeOnHide.dispose())
+                            });
+                        }}
+                    ></div>
+                </div>
+            ),
             priority: 7,
             group: 'navigation',
-            onDidChange: this.onMakerSetsChangedEvent,
+            onDidChange: this.onMakerSetsChangedEvent
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.OPEN_TRACE.id,
             command: TraceViewerToolbarCommands.OPEN_TRACE.id,
             tooltip: TraceViewerToolbarCommands.OPEN_TRACE.label,
-            priority: 8,
+            priority: 8
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.OPEN_OVERVIEW_OUTPUT.id,
             command: TraceViewerToolbarCommands.OPEN_OVERVIEW_OUTPUT.id,
             tooltip: TraceViewerToolbarCommands.OPEN_OVERVIEW_OUTPUT.label,
-            priority: 9,
+            priority: 9
         });
         registry.registerItem({
             id: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.id,
             command: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.id,
             tooltip: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.label,
-            priority: 10,
+            priority: 10
         });
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -8,7 +8,10 @@ import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
-import { TraceContextComponent, PersistedState } from 'traceviewer-react-components/lib/components/trace-context-component';
+import {
+    TraceContextComponent,
+    PersistedState
+} from 'traceviewer-react-components/lib/components/trace-context-component';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { TheiaMessageManager } from '../theia-message-manager';
 import { ThemeService } from '@theia/core/lib/browser/theming';
@@ -22,8 +25,13 @@ import { CancellationTokenSource } from '@theia/core';
 import { FileDialogService, SaveFileDialogProps } from '@theia/filesystem/lib/browser';
 import * as React from 'react';
 import 'animate.css';
-import { DEFAULT_OVERVIEW_OUTPUT_NAME, TRACE_OVERVIEW_DEFAULT_VIEW_KEY,
-    getOpenTraceOverviewFailErrorMessage, getSwitchToDefaultViewErrorMessage, OverviewPreferences } from '../trace-overview-preference';
+import {
+    DEFAULT_OVERVIEW_OUTPUT_NAME,
+    TRACE_OVERVIEW_DEFAULT_VIEW_KEY,
+    getOpenTraceOverviewFailErrorMessage,
+    getSwitchToDefaultViewErrorMessage,
+    OverviewPreferences
+} from '../trace-overview-preference';
 
 export const TraceViewerWidgetOptions = Symbol('TraceViewerWidgetOptions');
 export interface TraceViewerWidgetOptions {
@@ -60,18 +68,25 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     protected explorerWidget: TraceExplorerWidget;
 
     private markerCategoriesMap: Map<string, string[]> = new Map<string, string[]>();
-    private toolbarMarkerCategoriesMap: Map<string, { categoryCount: number, toggleInd: boolean }> = new Map();
+    private toolbarMarkerCategoriesMap: Map<string, { categoryCount: number; toggleInd: boolean }> = new Map();
     private selectedMarkerCategoriesMap: Map<string, string[]> = new Map<string, string[]>();
     private markerSetsMap: Map<MarkerSet, boolean> = new Map<MarkerSet, boolean>();
     private selectedMarkerSetId = '';
 
-    private onOutputAdded = (payload: OutputAddedSignalPayload): Promise<void> => this.doHandleOutputAddedSignal(payload);
+    private onOutputAdded = (payload: OutputAddedSignalPayload): Promise<void> =>
+        this.doHandleOutputAddedSignal(payload);
     private onTraceOverviewOpened = (traceId: string): Promise<void> => this.doHandleTraceOverviewOpenedSignal(traceId);
-    private onTraceOverviewOutputSelected = (payload: {traceId: string, outputDescriptor: OutputDescriptor}): Promise<void> => this.doHandleTraceOverviewOutputSelected(payload);
-    private onExperimentSelected = (experiment: Experiment): Promise<void> => this.doHandleExperimentSelectedSignal(experiment);
+    private onTraceOverviewOutputSelected = (payload: {
+        traceId: string;
+        outputDescriptor: OutputDescriptor;
+    }): Promise<void> => this.doHandleTraceOverviewOutputSelected(payload);
+    private onExperimentSelected = (experiment: Experiment): Promise<void> =>
+        this.doHandleExperimentSelectedSignal(experiment);
     private onCloseExperiment = (UUID: string): void => this.doHandleCloseExperimentSignal(UUID);
-    private onMarkerCategoryClosedSignal = (payload: { traceViewerId: string, markerCategory: string }) => this.doHandleMarkerCategoryClosedSignal(payload);
-    private onSaveAsCSV= (payload: {traceId: string, data: string}): Promise<void> => this.doHandleSaveAsCSVSignal(payload);
+    private onMarkerCategoryClosedSignal = (payload: { traceViewerId: string; markerCategory: string }) =>
+        this.doHandleMarkerCategoryClosedSignal(payload);
+    private onSaveAsCSV = (payload: { traceId: string; data: string }): Promise<void> =>
+        this.doHandleSaveAsCSVSignal(payload);
 
     private overviewOutputDescriptor: OutputDescriptor | undefined;
     private prevOverviewOutputDescriptor: OutputDescriptor | undefined;
@@ -105,13 +120,15 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         this.tspClient = this.tspClientProvider.getTspClient();
         this.traceManager = this.tspClientProvider.getTraceManager();
         this.experimentManager = this.tspClientProvider.getExperimentManager();
-        this.toDispose.push(Disposable.create(() => {
-            this.tspClientProvider.addTspClientChangeListener(tspClient => {
-                this.tspClient = tspClient;
-                this.traceManager = this.tspClientProvider.getTraceManager();
-                this.experimentManager = this.tspClientProvider.getExperimentManager();
-            });
-        }));
+        this.toDispose.push(
+            Disposable.create(() => {
+                this.tspClientProvider.addTspClientChangeListener(tspClient => {
+                    this.tspClient = tspClient;
+                    this.traceManager = this.tspClientProvider.getTraceManager();
+                    this.experimentManager = this.tspClientProvider.getExperimentManager();
+                });
+            })
+        );
 
         if (this.options.traceUUID) {
             const experiment = await this.experimentManager.updateExperiment(this.options.traceUUID);
@@ -134,7 +151,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         this.node.tabIndex = 0;
 
         // Load the trace overview by default
-        if (this.loadTraceOverview){
+        if (this.loadTraceOverview) {
             this.doHandleTraceOverviewOpenedSignal(this.openedExperiment?.UUID);
         }
     }
@@ -171,19 +188,25 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         const cancellation = new CancellationTokenSource();
 
         // This will show a progress dialog with "Cancel" option
-        this.messageService.showProgress({
-                text: `Opening "${this.uri.name}"`,
-                options: {
-                    cancelable: true
+        this.messageService
+            .showProgress(
+                {
+                    text: `Opening "${this.uri.name}"`,
+                    options: {
+                        cancelable: true
+                    }
+                },
+                () => {
+                    cancellation.cancel();
                 }
-            },
-            () => {
-                cancellation.cancel();
-            })
+            )
             .then(async progress => {
                 try {
                     progress.report({ message: 'Finding traces ', work: { done: 10, total: 100 } });
-                    const tracesArray = await this.backendFileService.findTraces(this.uri.toString(), cancellation.token);
+                    const tracesArray = await this.backendFileService.findTraces(
+                        this.uri.toString(),
+                        cancellation.token
+                    );
 
                     if (cancellation.token.isCancellationRequested) {
                         progress.report({ message: 'Complete', work: { done: 100, total: 100 } });
@@ -234,7 +257,10 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
                         this.messageService.error('Invalid trace(s): ' + invalidTraces.toString());
                         this.dispose();
                     } else {
-                        const experiment = await this.experimentManager.openExperiment(this.uri.name + this.uri.ext, traces);
+                        const experiment = await this.experimentManager.openExperiment(
+                            this.uri.name + this.uri.ext,
+                            traces
+                        );
                         if (experiment) {
                             const widgets = this.widgetManager.getWidgets(TraceViewerWidget.ID);
                             const widget = widgets.find(w => w.id === experiment.UUID);
@@ -296,7 +322,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
                 this.outputDescriptors = persistedState.outputs;
             }
 
-            if (persistedState.storedOverviewOutput){
+            if (persistedState.storedOverviewOutput) {
                 this.overviewOutputDescriptor = persistedState.storedOverviewOutput;
             }
         }
@@ -340,30 +366,44 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         this.onOutputRemoved = this.onOutputRemoved.bind(this);
         this.onOverviewRemoved = this.onOverviewRemoved.bind(this);
 
-        return <div className='trace-viewer-container'>
-            {this.openedExperiment ? <TraceContextComponent experiment={this.openedExperiment}
-                ref={this.traceContextComponent}
-                tspClient={this.tspClient}
-                outputs={this.outputDescriptors}
-                overviewDescriptor={this.overviewOutputDescriptor}
-                markerCategoriesMap={this.selectedMarkerCategoriesMap}
-                markerSetId={this.selectedMarkerSetId}
-                onOutputRemove={this.onOutputRemoved}
-                onOverviewRemove={this.onOverviewRemoved}
-                addResizeHandler={this.addResizeHandler}
-                removeResizeHandler={this.removeResizeHandler}
-                backgroundTheme={this.backgroundTheme}
-                persistedState={this.persistedState}
-                messageManager={this._signalHandler} /> : 'Trace is loading...'}
-        </div>;
+        return (
+            <div className="trace-viewer-container">
+                {this.openedExperiment ? (
+                    <TraceContextComponent
+                        experiment={this.openedExperiment}
+                        ref={this.traceContextComponent}
+                        tspClient={this.tspClient}
+                        outputs={this.outputDescriptors}
+                        overviewDescriptor={this.overviewOutputDescriptor}
+                        markerCategoriesMap={this.selectedMarkerCategoriesMap}
+                        markerSetId={this.selectedMarkerSetId}
+                        onOutputRemove={this.onOutputRemoved}
+                        onOverviewRemove={this.onOverviewRemoved}
+                        addResizeHandler={this.addResizeHandler}
+                        removeResizeHandler={this.removeResizeHandler}
+                        backgroundTheme={this.backgroundTheme}
+                        persistedState={this.persistedState}
+                        messageManager={this._signalHandler}
+                    />
+                ) : (
+                    'Trace is loading...'
+                )}
+            </div>
+        );
     }
 
     private async fetchAnnotationCategories(output: OutputDescriptor) {
         if (this.openedExperiment) {
-            const annotationCategories = await this.tspClient.fetchAnnotationsCategories(this.openedExperiment.UUID, output.id, this.selectedMarkerSetId);
+            const annotationCategories = await this.tspClient.fetchAnnotationsCategories(
+                this.openedExperiment.UUID,
+                output.id,
+                this.selectedMarkerSetId
+            );
             const annotationCategoriesResponse = annotationCategories.getModel();
             if (annotationCategories.isOk() && annotationCategoriesResponse) {
-                const markerCategories = annotationCategoriesResponse.model ? annotationCategoriesResponse.model.annotationCategories : [];
+                const markerCategories = annotationCategoriesResponse.model
+                    ? annotationCategoriesResponse.model.annotationCategories
+                    : [];
                 this.addMarkerCategories(output.id, markerCategories);
             }
         }
@@ -374,7 +414,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
             const exist = this.outputDescriptors.find(output => output.id === payload.getOutputDescriptor().id);
             if (!exist) {
                 const output = payload.getOutputDescriptor();
-                this.outputDescriptors =  this.outputDescriptors.concat(output);
+                this.outputDescriptors = this.outputDescriptors.concat(output);
                 await this.fetchAnnotationCategories(output);
                 this.update();
             } else {
@@ -388,11 +428,15 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
                 await new Promise(resolve => {
                     const titleHandle = document.getElementById(traceId + exist.id + 'handle');
                     titleHandle?.classList.add('animate__animated', 'animate__pulse');
-                    titleHandle?.addEventListener('animationend', event => {
-                        event.stopPropagation();
-                        titleHandle?.classList.remove('animate__animated', 'animate__pulse');
-                        resolve('Animation ended');
-                    }, {once: true});
+                    titleHandle?.addEventListener(
+                        'animationend',
+                        event => {
+                            event.stopPropagation();
+                            titleHandle?.classList.remove('animate__animated', 'animate__pulse');
+                            resolve('Animation ended');
+                        },
+                        { once: true }
+                    );
                 });
             }
         }
@@ -414,7 +458,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     protected async doHandleExperimentSelectedSignal(experiment: Experiment): Promise<void> {
         if (this.openedExperiment && this.openedExperiment.UUID === experiment.UUID) {
             // Update the trace UUID so that the overview can be opened
-            if (this.loadTraceOverview){
+            if (this.loadTraceOverview) {
                 const defaultOutputDescriptor = await this.getDefaultTraceOverviewOutputDescriptor();
                 this.updateOverviewOutputDescriptor(defaultOutputDescriptor);
             }
@@ -423,10 +467,10 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         }
     }
 
-    private async doHandleSaveAsCSVSignal(payload: {traceId: string, data: string}) {
+    private async doHandleSaveAsCSVSignal(payload: { traceId: string; data: string }) {
         if (this.openedExperiment && payload && payload.traceId === this.openedExperiment.UUID) {
             const props: SaveFileDialogProps = {
-                inputValue: (this.openedExperiment !== undefined ? (this.openedExperiment.name) : 'trace') + '.csv',
+                inputValue: (this.openedExperiment !== undefined ? this.openedExperiment.name : 'trace') + '.csv',
                 filters: {
                     'CSV Files': ['csv']
                 },
@@ -444,7 +488,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         }
     }
 
-    private doHandleMarkerCategoryClosedSignal(payload: { traceViewerId: string, markerCategory: string }) {
+    private doHandleMarkerCategoryClosedSignal(payload: { traceViewerId: string; markerCategory: string }) {
         const traceViewerId = payload.traceViewerId;
         const markerCategory = payload.markerCategory;
         if (traceViewerId === this.id) {
@@ -453,16 +497,24 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     }
 
     private async doHandleTraceOverviewOpenedSignal(traceId: string | undefined): Promise<void> {
-        if (this.openedExperiment && this.openedExperiment.UUID === traceId){
+        if (this.openedExperiment && this.openedExperiment.UUID === traceId) {
             this.loadOverviewOutputDescriptor();
             this.shell.activateWidget(this.openedExperiment.UUID);
         }
     }
 
-    private async doHandleTraceOverviewOutputSelected(payload: {traceId: string, outputDescriptor: OutputDescriptor}): Promise<void> {
-        if (this.openedExperiment && payload && payload.traceId === this.openedExperiment.UUID && payload.outputDescriptor){
-                await this.updateOverviewOutputDescriptor(payload.outputDescriptor);
-                this.shell.activateWidget(this.openedExperiment.UUID);
+    private async doHandleTraceOverviewOutputSelected(payload: {
+        traceId: string;
+        outputDescriptor: OutputDescriptor;
+    }): Promise<void> {
+        if (
+            this.openedExperiment &&
+            payload &&
+            payload.traceId === this.openedExperiment.UUID &&
+            payload.outputDescriptor
+        ) {
+            await this.updateOverviewOutputDescriptor(payload.outputDescriptor);
+            this.shell.activateWidget(this.openedExperiment.UUID);
         }
     }
 
@@ -527,7 +579,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         return this.markerSetsMap;
     }
 
-    getMarkerCategories(): Map<string, { categoryCount: number, toggleInd: boolean }> {
+    getMarkerCategories(): Map<string, { categoryCount: number; toggleInd: boolean }> {
         return this.toolbarMarkerCategoriesMap;
     }
 
@@ -567,7 +619,9 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
             return;
         }
         this.selectedMarkerSetId = markerSet.id;
-        const prevSelectedMarkerSet = Array.from(this.markerSetsMap.keys()).find(markerSetItem => this.markerSetsMap.get(markerSetItem) === true);
+        const prevSelectedMarkerSet = Array.from(this.markerSetsMap.keys()).find(
+            markerSetItem => this.markerSetsMap.get(markerSetItem) === true
+        );
         if (prevSelectedMarkerSet) {
             this.markerSetsMap.set(prevSelectedMarkerSet, false);
         }
@@ -578,7 +632,9 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     }
 
     isTimeRelatedChartOpened(): boolean {
-        const timeRelatedOutputs = this.outputDescriptors.filter(output => output.type === 'TIME_GRAPH' || output.type === 'TREE_TIME_XY');
+        const timeRelatedOutputs = this.outputDescriptors.filter(
+            output => output.type === 'TIME_GRAPH' || output.type === 'TREE_TIME_XY'
+        );
         return timeRelatedOutputs.length > 0;
     }
 
@@ -588,7 +644,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     }
 
     isTraceOverviewOpened(): boolean {
-        if (this.overviewOutputDescriptor){
+        if (this.overviewOutputDescriptor) {
             return true;
         }
 
@@ -620,12 +676,16 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
 
         // First, check if there is a preferred view
         const preferredViewName: string | undefined = this.overviewPreferences[TRACE_OVERVIEW_DEFAULT_VIEW_KEY];
-        let descriptor: OutputDescriptor | undefined = availableDescriptors?.find(output => output.name.toLowerCase() === preferredViewName?.toLowerCase());
+        let descriptor: OutputDescriptor | undefined = availableDescriptors?.find(
+            output => output.name.toLowerCase() === preferredViewName?.toLowerCase()
+        );
 
         // Failed to find an output that matches the user preference, fallback to default
         if (!descriptor) {
             const defaultViewName = DEFAULT_OVERVIEW_OUTPUT_NAME;
-            descriptor = availableDescriptors?.find(output => output.name.toLowerCase() === defaultViewName?.toLowerCase());
+            descriptor = availableDescriptors?.find(
+                output => output.name.toLowerCase() === defaultViewName?.toLowerCase()
+            );
 
             if (descriptor && preferredViewName) {
                 this.messageService.error(getSwitchToDefaultViewErrorMessage(preferredViewName, descriptor.name));
@@ -644,7 +704,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
      * Get the output descriptor for the trace over view
      */
     protected async getAvailableTraceOverviewOutputDescriptor(): Promise<OutputDescriptor[] | undefined> {
-        if (this.openedExperiment){
+        if (this.openedExperiment) {
             const descriptors = await this.experimentManager.getAvailableOutputs(this.openedExperiment.UUID);
             const overviewOutputDescriptors = descriptors?.filter(output => output.type === 'TREE_TIME_XY');
             return overviewOutputDescriptors;

--- a/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
@@ -8,7 +8,6 @@ import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
 
 @injectable()
 export class TspClientProvider implements ITspClientProvider {
-
     private _tspClient: TspClient;
     private _traceManager: TraceManager;
     private _experimentManager: ExperimentManager;
@@ -16,7 +15,7 @@ export class TspClientProvider implements ITspClientProvider {
 
     constructor(
         @inject(TraceServerUrlProvider) private tspUrlProvider: TraceServerUrlProvider,
-        @inject(LazyTspClientFactory) private lazyTspClientFactory: LazyTspClientFactory,
+        @inject(LazyTspClientFactory) private lazyTspClientFactory: LazyTspClientFactory
     ) {
         const traceServerUrlPromise = this.tspUrlProvider.getTraceServerUrlPromise();
         this._tspClient = this.lazyTspClientFactory(traceServerUrlPromise);

--- a/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
@@ -7,13 +7,12 @@ export const PortBusy = ApplicationError.declare(-32650, code => ({
 }));
 
 export interface StartTraceServerOptions {
-    path?: string
-    args?: string
+    path?: string;
+    args?: string;
 }
 
 export const TraceServerConfigService = Symbol('TraceServerConfigService');
 export interface TraceServerConfigService {
-
     /**
      * Spawn the trace server from a given path
      */

--- a/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
@@ -3,7 +3,6 @@ export const TRACE_VIEWER_DEFAULT_PORT = 8080;
 
 export const TraceServerUrlProvider = Symbol('TraceServerUrlProvider');
 export interface TraceServerUrlProvider {
-
     /**
      * Get a promise that resolves once the Trace Server URL is initialized.
      * @returns a new promise each time `.onDidChangeTraceServerUrl` fires.

--- a/theia-extensions/viewer-prototype/src/electron-node/trace-server/electron-trace-server-service.ts
+++ b/theia-extensions/viewer-prototype/src/electron-node/trace-server/electron-trace-server-service.ts
@@ -4,11 +4,13 @@ import { TraceServerServiceImpl } from '../../node/trace-server/trace-server-ser
 
 const APPLICATION_ROOT = resolve(dirname(process.argv0));
 
-export const BUNDLED_TRACE_SERVER_PATH = resolve(APPLICATION_ROOT, 'resources/trace-compass-server/tracecompass-server');
+export const BUNDLED_TRACE_SERVER_PATH = resolve(
+    APPLICATION_ROOT,
+    'resources/trace-compass-server/tracecompass-server'
+);
 
 @injectable()
 export class ElectronTraceServerServiceImpl extends TraceServerServiceImpl {
-
     protected async findTraceServerPath(): Promise<string | undefined> {
         return (await super.findTraceServerPath()) ?? this.getBundledTraceServerPath();
     }

--- a/theia-extensions/viewer-prototype/src/node/backend-file-service-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/backend-file-service-impl.ts
@@ -8,22 +8,21 @@ import { FileUri } from '@theia/core/lib/node';
 
 @injectable()
 export class BackendFileServiceImpl implements BackendFileService {
-
     async writeToFile(uri: URI, data: string): Promise<string> {
         fs.writeFile(uri.path.fsPath(), data, err => {
             if (err) {
                 throw new Error(err.message);
             }
-          });
+        });
         return 'success';
     }
 
     async findTraces(path: string, cancellationToken: CancellationToken): Promise<string[]> {
         /*
-        * On Windows, Theia returns a path that starts with "/" (e.g "/c:/"), causing fsPromise.stat
-        * to fail. FileUri.fsPath returns the platform specific path of the orginal Theia path
-        * that fixes this issue.
-        */
+         * On Windows, Theia returns a path that starts with "/" (e.g "/c:/"), causing fsPromise.stat
+         * to fail. FileUri.fsPath returns the platform specific path of the orginal Theia path
+         * that fixes this issue.
+         */
         const cleanedPath = FileUri.fsPath(path);
 
         const traces: string[] = [];

--- a/theia-extensions/viewer-prototype/src/node/trace-server/trace-server-service.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server/trace-server-service.ts
@@ -10,12 +10,11 @@ import treeKill = require('tree-kill');
 const SUCCESS = 'success';
 
 export interface ChildProcessWithPid extends ChildProcess {
-    pid: number
+    pid: number;
 }
 
 @injectable()
 export class TraceServerServiceImpl implements TraceServerConfigService {
-
     protected server?: ChildProcess;
     private cliArgs?: string;
 
@@ -29,10 +28,10 @@ export class TraceServerServiceImpl implements TraceServerConfigService {
                 throw new Error('the Trace Server is already running on a different port');
             }
         }
-        path = path?.trim() || await this.findTraceServerPath();
+        path = path?.trim() || (await this.findTraceServerPath());
         if (!path) {
             throw new Error('no Trace Server path found');
-        } else if (!await this.validateTraceServerPath(path)) {
+        } else if (!(await this.validateTraceServerPath(path))) {
             throw new Error(`could not find the Trace Server file at the specified path: ${path}`);
         }
         const argsArray: Array<string> | undefined = args?.split(' ');
@@ -94,7 +93,9 @@ export class TraceServerServiceImpl implements TraceServerConfigService {
 
     protected async findTraceServerPath(): Promise<string | undefined> {
         const traceServerPath = process.env.TRACE_SERVER_PATH?.trim();
-        if (traceServerPath) { return traceServerPath; }
+        if (traceServerPath) {
+            return traceServerPath;
+        }
     }
 
     protected async validateTraceServerPath(traceServerPath: string): Promise<boolean> {

--- a/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
+++ b/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
@@ -7,12 +7,20 @@ import { BackendFileServiceImpl } from './backend-file-service-impl';
 
 export default new ContainerModule(bind => {
     bind(BackendFileService).to(BackendFileServiceImpl).inSingletonScope();
-    bind(ConnectionHandler).toDynamicValue(ctx => new JsonRpcConnectionHandler<TraceServerConfigService>(
-        traceServerPath,
-        () => ctx.container.get<TraceServerConfigService>(TraceServerConfigService),
-    )).inSingletonScope();
-    bind(ConnectionHandler).toDynamicValue(ctx => new JsonRpcConnectionHandler(
-        backendFileServicePath,
-        () => ctx.container.get<BackendFileService>(BackendFileService)
-    )).inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler<TraceServerConfigService>(traceServerPath, () =>
+                    ctx.container.get<TraceServerConfigService>(TraceServerConfigService)
+                )
+        )
+        .inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler(backendFileServicePath, () =>
+                    ctx.container.get<BackendFileService>(BackendFileService)
+                )
+        )
+        .inSingletonScope();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11941,6 +11941,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 pretty-format@^27.0.2:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"


### PR DESCRIPTION
This commit adds Prettier to enforce code style for the trace extension.

Contributors can run `yarn format` to automatically run Prettier to format the source code of the  three packages `traceviewer-base`, `traceviewer-react-components`, and `theia-traceviewer`. Alternatively, they can run Prettier on a single file using the command  `yarn prettier --write <file-name>`. 

This commit also configures CI to run `yarn prettier --check` to ensure that any new code follows the pre-defined code style rules.

However, we need to merge the changes that is done by running `yarn format:write` first, else CI will always fail.

Replaces #968 and resolves #861.