### PR TITLE
Color String Whitespace hotfix

### DIFF
--- a/packages/base/src/utils/convert-color-string-to-hex.ts
+++ b/packages/base/src/utils/convert-color-string-to-hex.ts
@@ -5,6 +5,7 @@
  */
 export function convertColorStringToHexNumber(rgb: string): number {
     let string = '0';
+    rgb.trim();
     if (rgb[0] === '#') {
         // We are working with hex string.
         string = '0x' + rgb.slice(1);


### PR DESCRIPTION
Trims the whitespace off of the input string.  This fixes an issue that is occurring in the CodeOSS migration: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/issues/116.

Signed-off-by: Will Yang <william.yang@ericsson.com>