### PR TITLE
Make --trace-extension-list-line-height a mappable CSS variable

### DIFF
--- a/packages/react-components/style/trace-explorer.css
+++ b/packages/react-components/style/trace-explorer.css
@@ -1,5 +1,5 @@
 :root {
-    --trace-extension-list-line-height: 16px;
+    --trace-extension-list-line-height: var(--trace-viewer-trace-extension-list-line-height);
 }
 
 #trace-explorer-views-widget,

--- a/theia-extensions/viewer-prototype/style/trace-viewer.css
+++ b/theia-extensions/viewer-prototype/style/trace-viewer.css
@@ -44,4 +44,5 @@
     --trace-viewer-sideBarSectionHeader-background: var(--theia-sideBarSectionHeader-background);
     --trace-viewer-view-container-title-height: var(--theia-view-container-title-height);
     --trace-viewer-sideBarSectionHeader-foreground: var(--theia-sideBarSectionHeader-foreground);
+    --trace-viewer-trace-extension-list-line-height: 16px;
 }


### PR DESCRIPTION
The CSS variable --trace-extension-list-line-height is used in both the vscode and theia trace extension. This commit maps this CSS variable to --trace-viewer-trace-extension-list-line-height so each extension can declare its own style.