### PR TITLE
Fix toggle columns missing in title bar menu

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -11,7 +11,13 @@ import { TooltipComponent } from './tooltip-component';
 import { TooltipXYComponent } from './tooltip-xy-component';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import { DropDownComponent, OptionState } from './drop-down-component';
+import {
+    DropDownComponent,
+    DropDownSubSection,
+    OptionCheckBoxState,
+    OptionState,
+    OptionType
+} from './drop-down-component';
 
 export interface AbstractOutputProps {
     tspClient: TspClient;
@@ -70,6 +76,8 @@ export abstract class AbstractOutputComponent<
     public readonly PIN_VIEW_LABEL = 'Pin View';
 
     public readonly UNPIN_VIEW_LABEL = 'Unpin View';
+
+    public readonly TOGGLE_COLUMN_LABEL = 'Toggle Columns';
 
     private dropDownOptions: OptionState[] = [];
 
@@ -251,13 +259,15 @@ export abstract class AbstractOutputComponent<
         label: string,
         onClick?: (arg?: unknown) => void,
         arg?: unknown,
-        condition?: () => boolean
+        condition?: () => boolean,
+        subSection?: DropDownSubSection
     ): void {
         const newOption = {
             label: label,
             onClick: onClick,
             arg: arg,
-            condition: condition
+            condition: condition,
+            subSection: subSection
         } as OptionState;
         if (this.dropDownOptions.includes(newOption)) {
             return;

--- a/packages/react-components/src/components/drop-down-component.tsx
+++ b/packages/react-components/src/components/drop-down-component.tsx
@@ -7,19 +7,39 @@
 import React from 'react';
 import { AbstractOutputProps } from './abstract-output-component';
 
+export enum OptionType {
+    DEFAULT,
+    CHECKBOX
+}
+
 export interface OptionState {
+    type: OptionType;
     label: string;
     condition?: () => boolean;
     onClick?: (arg?: unknown) => void;
     arg?: () => unknown;
+    subSection?: DropDownSubSection; // Contains a list of options for a subsection
+}
+
+export interface DropDownSubSection {
+    options: OptionState[]; // Contains a list of options for a subsection
+    condition: () => boolean;
+    height?: number;
 }
 
 type OptionProps = AbstractOutputProps & OptionState;
 
-export class DropDownOption extends React.Component<OptionProps, OptionState> {
+abstract class AbstractDropDownOption<P extends OptionProps, S extends OptionState> extends React.Component<P, S> {
+    constructor(props: P) {
+        super(props);
+    }
+}
+
+export class DropDownOption extends AbstractDropDownOption<OptionProps, OptionState> {
     constructor(props: OptionProps) {
         super(props);
         this.state = {
+            type: OptionType.DEFAULT,
             label: props.label,
             onClick: props.onClick ?? undefined,
             arg: props.arg ?? undefined,
@@ -33,6 +53,41 @@ export class DropDownOption extends React.Component<OptionProps, OptionState> {
                 {this.state.condition?.() && (
                     <li className="drop-down-list-item" onClick={() => this.state.onClick?.(this.state.arg?.())}>
                         <div className="drop-down-list-item-text">{this.state.label}</div>
+                    </li>
+                )}
+            </React.Fragment>
+        );
+    }
+}
+
+export type OptionCheckBoxState = OptionState & {
+    checked: () => boolean;
+};
+
+type OptionCheckBoxProps = OptionProps & OptionCheckBoxState;
+
+export class DropDownOptionCheckBox extends AbstractDropDownOption<OptionCheckBoxProps, OptionCheckBoxState> {
+    constructor(props: OptionCheckBoxProps) {
+        super(props);
+        this.state = {
+            type: OptionType.CHECKBOX,
+            label: props.label,
+            checked: props.checked,
+            onClick: props.onClick ?? undefined,
+            arg: props.arg ?? undefined,
+            condition: props.condition ?? (() => true)
+        };
+    }
+
+    render(): JSX.Element {
+        return (
+            <React.Fragment>
+                {this.state.condition?.() && (
+                    <li className="drop-down-list-item" onClick={() => this.state.onClick?.(this.state.arg?.())}>
+                        <div className="drop-down-list-item-checkbox">
+                            <input type="checkbox" checked={this.state.checked()} />
+                        </div>
+                        <div className="drop-down-list-item-checkbox-label">{this.state.label}</div>
                     </li>
                 )}
             </React.Fragment>
@@ -58,14 +113,55 @@ export class DropDownComponent extends React.Component<DropDownProps> {
             <React.Fragment>
                 {this.props.dropDownOpen && (
                     <div className="options-menu-drop-down" ref={this.optionsMenuRef}>
-                        <ul>
-                            {this.props.dropDownOptions?.map((option, index) => (
-                                <DropDownOption {...this.props} key={index} {...option} />
-                            ))}
-                        </ul>
+                        <ul>{this.props.dropDownOptions?.map((option, index) => this.renderSection(option, index))}</ul>
                     </div>
                 )}
             </React.Fragment>
         );
+    }
+
+    renderSection(option: OptionState, index: number): React.ReactNode {
+        if (option.subSection && option.subSection.options.length > 0) {
+            return (
+                <React.Fragment>
+                    {
+                        // Rendering the upper level option label
+                        this.renderOption(option, index)
+                    }
+                    {option.subSection.condition?.() && (
+                        <ul
+                            className="drop-down-sub-section"
+                            style={{ height: option.subSection.height ? option.subSection.height + 'px' : 'auto' }}
+                        >
+                            {
+                                // Rendering the sub section
+                                option.subSection.options.map((subOption, subOptionIndex) =>
+                                    this.renderOption(subOption, subOptionIndex)
+                                )
+                            }
+                        </ul>
+                    )}
+                </React.Fragment>
+            );
+        } else {
+            return this.renderOption(option, index);
+        }
+    }
+
+    renderOption(option: OptionState, index: number): React.ReactNode {
+        if (option.type === OptionType.CHECKBOX) {
+            const checkboxOptions = option as OptionCheckBoxState;
+            return (
+                <React.Fragment>
+                    <DropDownOptionCheckBox {...this.props} key={index} {...checkboxOptions} />
+                </React.Fragment>
+            );
+        } else {
+            return (
+                <React.Fragment>
+                    <DropDownOption {...this.props} key={index} {...option} />
+                </React.Fragment>
+            );
+        }
     }
 }

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -352,7 +352,6 @@ canvas {
     max-height: var(--trace-viewer-private-menu-item-height);
     padding: 0px;
     line-height: var(--trace-viewer-private-menu-item-height);
-    display: table-row;
 }
 .drop-down-list-item:hover {
     background: var(--trace-viewer-menu-selectionBackground);
@@ -363,8 +362,20 @@ canvas {
 .drop-down-list-item-text {
     padding-left: 18%;
 }
-.toggle-columns-table {
-    height: 150px;
+
+.drop-down-list-item-checkbox {
+    display: inline-block;
+    padding-left: 3%;
+}
+
+.drop-down-list-item-checkbox-label {
+    display: inline-block;
+    padding-left: 3%;
+}
+
+.drop-down-sub-section {
+    list-style-type: none;
+    padding: 0px;
     overflow: scroll;
     z-index: 999 !important;
     background: var(--trace-viewer-menu-background);


### PR DESCRIPTION
The toggle columns menu item in the title bar menu was removed due to the refactor done in commit 35df458. This commit uses the addOption method that was introduced in commit 35df458 to bring back the toggle columns options.

Fixes #981.