### PR TITLE
Added indicator for empty column search

### DIFF
--- a/packages/react-components/src/components/__tests__/__snapshots__/table-renderer-components.test.tsx.snap
+++ b/packages/react-components/src/components/__tests__/__snapshots__/table-renderer-components.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`<TableOutputComponent /> Empty search filter renderer 1`] = `
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  title="Enter a regular expression"
 >
   <svg
     aria-hidden="true"

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -770,7 +770,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             } else if (direction === Direction.PREVIOUS) {
                 // no backward search if there is no selection
                 this.gridMatched = false;
-                return;
+                return false;
             }
 
             let rowNodes: RowNode[] = [];
@@ -829,7 +829,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             if (isFound) {
                 // Match found in cache
                 this.gridMatched = false;
-                return;
+                return isFound;
             }
             // find match outside the cache
             let syncData = undefined;
@@ -843,6 +843,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                         this.startTimestamp = this.endTimestamp = BigInt(data.row[this.timestampCol]);
                         syncData = data.row;
                     }
+                    isFound = true;
                 }
             }
 
@@ -860,6 +861,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             }
             this.gridMatched = false;
         }
+        return isFound;
     }
 
     private isValidRowSelection(rowNode: RowNode): boolean {


### PR DESCRIPTION
Added a check to see if any row elements match search. The color of search text updates to red if no results, and is unassigned (reverts to theme) if there are none.

This makes it more clear that a search does not have any results.

Signed-off-by: Dylan leclair dleclair@blackberry.com