### PR TITLE
releng: Define publishing latest semantic versions

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -1,0 +1,30 @@
+name: NPM package (latest)
+on:
+  push:
+    branches: [ master ]
+jobs:
+  build:
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository == 'eclipse-cdt-cloud/theia-trace-extension' && "contains(github.event.head_commit.message, '[latest]:')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # For github-tag-action below
+    steps:
+    - uses: actions/checkout@v2
+    # Setup .npmrc file to publish to npm
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+        # Defaults to the user or organization that owns the workflow file
+        scope: '@theia-ide'
+    - run: yarn
+    - run: yarn publish:latest
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    - name: Push new (bumped) tag based on HEAD commit message
+      uses: anothrNick/github-tag-action@1.67.0
+      env:
+        DEFAULT_BUMP: none # commit message includes #major|minor|patch
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -2,11 +2,9 @@ name: NPM package (next)
 on:
   push:
     branches: [ master ]
-#  release:
-#    types: [created]
 jobs:
   build:
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository == 'eclipse-cdt-cloud/theia-trace-extension' 
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository == 'eclipse-cdt-cloud/theia-trace-extension' && "!contains(github.event.head_commit.message, '[latest]:')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -16,7 +14,7 @@ jobs:
         node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
         # Defaults to the user or organization that owns the workflow file
-        scope: '@theia-ide' 
+        scope: '@theia-ide'
     - run: yarn
     - run: yarn publish:next
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 # LC_COLLATE=C sort .gitignore
-!examples/*/electron-builder.yml
-!examples/*/package.json
-!examples/*/resources/
-!examples/*/scripts/
 *.log
 *.tsbuildinfo
 .browser_modules/
@@ -12,7 +8,11 @@
 /packages/react-components/lib/
 TraceCompassTutorialTraces
 TraceCompassTutorialTraces.tgz
-examples/*
+examples/*/gen-webpack.config.js
+examples/*/lib/
+examples/*/src-gen/
+examples/electron/dist/
+examples/plugins/
 node_modules/
 theia-extensions/viewer-prototype/lib/
 trace-compass-server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,54 @@ file. Adding the SHA-1 of a commit to this file will make `git-blame` ignore tha
 * For GitHub, this file is automatically detected and will ignore all the commits that are included in the file.
 * With Git CLI, run `git blame --ignore-revs-file=.git-blame-ignore-revs <pathToSomeFile>` to ignore the commits.
 
+## Releasing a new version
+
+* Run either one of the below repository root commands, depending on the case at hand.
+* Below, `Z` means `z+1`, and the same notation is used for `x` and `y`.
+
+For a release bumping the version from `x.y.z` to `x.y.Z`:
+
+```bash
+yarn version:patch
+```
+
+For a release bumping the version from `x.y.z` to `x.Y.z`:
+
+```bash
+yarn version:minor
+```
+
+For a release bumping the version from `x.y.z` to `X.y.z`:
+
+```bash
+yarn version:major
+```
+
+Currently, [automatically adding][auto-signoff] a [Signed-off-by:][sign-off] footer to the
+resulting commit message fails for this `lerna` use with `yarn`. Should one be necessary,
+the commit needs to be amended accordingly, using `git commit --amend -s` or the like.
+
+Once pushed, reviewed then merged, the resulting commit triggers the GitHub workflow that
+publishes this new release to [the npm Registry][npm-registry]. That action shall also push
+the corresponding git tag. The locally created tag (internally by `lerna version`) should
+then be overridable by that remote one.
+
+Should there be an issue with that automated workflow, the said local tag can be manually
+pushed, once the commit is merged and [published as latest release][npm-registry]. If need
+be, the latter step can also be done manually by running this repository root command:
+
+```bash
+yarn && yarn publish:latest`
+```
+
+If needed, this is a command template to push the tag after publishing per above:
+
+```bash
+git push origin vX.Y.Z
+```
+
+Where either one of `X`, `Y` or `Z` was bumped depending on the chosen case further above.
+
 ## Contact
 
 For issues related to the Trace Viewer, please open a GitHub tracker for the [Theia Trace Extension][trace-viewer].
@@ -151,6 +199,7 @@ For issues related to the Trace Viewer, please open a GitHub tracker for the [Th
 For issues concerning `eclipse-cdt-cloud`, please refer to the contact options listed on the [CDT.Cloud website][cdt-cloud-website].
 
 [architecture]: https://github.com/theia-ide/theia-trace-extension#architecture
+[auto-signoff]: https://github.com/lerna/lerna/blob/main/libs/commands/version/README.md#--signoff-git-commit
 [cdt-cloud-website]: https://cdt-cloud.io/contact/
 [code-of-conduct]: https://github.com/eclipse/.github/blob/master/CODE_OF_CONDUCT.md
 [commit-message-example]: https://github.com/theia-ide/theia-trace-extension/commit/bc18fcd110d7b8433293692421f2e4fb49f89bd6
@@ -171,6 +220,7 @@ For issues concerning `eclipse-cdt-cloud`, please refer to the contact options l
 [issue-369]: https://github.com/theia-ide/theia-trace-extension/pull/369/files
 [issue-402]: https://github.com/theia-ide/theia-trace-extension/pull/402
 [new-contributors]: #new-contributors
+[npm-registry]: https://www.npmjs.com/
 [pr-guide]: #pull-request-guidelines
 [pull-requests]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pulls
 [sign-off]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
     "start-all:electron": "yarn start:server & yarn start:electron",
     "lint": "lerna run lint",
     "test": "lerna run test --",
-    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
+    "publish:latest": "lerna publish from-git --registry=https://registry.npmjs.org/ --exact --no-push --yes",
     "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes",
     "format:write": "lerna run format:write",
-    "format:check": "lerna run format:check"
+    "format:check": "lerna run format:check",
+    "version:major": "lerna version major --exact --no-push --yes -m \"[latest]: %s #major\n\nGitHub workflow shall publish and tag upon merge.\"",
+    "version:minor": "lerna version minor --exact --no-push --yes -m \"[latest]: %s #minor\n\nGitHub workflow shall publish and tag upon merge.\"",
+    "version:patch": "lerna version patch --exact --no-push --yes -m \"[latest]: %s #patch\n\nGitHub workflow shall publish and tag upon merge.\""
   },
   "keywords": [
     "theia-extension",


### PR DESCRIPTION
Add a `publish-latest` GitHub workflow similar to the existing `publish-next`.
- Make the former trigger on merging a commit that bumps the package versions depending on the chosen yarn script command.
- Hence, make the latter trigger only on the other kinds of commits.
- Align `publish-next` (with `publish-latest`) also so its previous trivial nits don't show as differences, upon comparing the two files for review purposes or so.

Beside the usual goal of publishing onto the npm Registry, use the `github-tag-action` in `publish-latest`, to push the corresponding tag after that publishing.
- Make the hereby generated commit (message) automatically convey how to name that bumped tag.
- For that purpose, `github-tag-action` uses a message token such as `#major`, `#minor` or `#patch`.
- Here, `publish-latest` expects `GITHUB_TOKEN` to be set, similarly to the already used `NPM_AUTH_TOKEN`.

Add the related yarn scripts and document how to use them (commands) in the `CONTRIBUTING` markdown.
- Document also how the aforementioned workflow is expected to automate the process that includes these commands.
- And, mention how to work-around any potential workflow issue manually; if any until that can be fixed.
- This adds the benefit of documenting how that automation proceeds, step-wise.

Fix `.gitignore`'s `examples`-related lines so they work also upon using the hereby added yarn commands.

Once confirmed, this approach can be ported to [1] and [2] in turn.
- With this approach, introducing a Jenkins job [3] wouldn't be necessary.

[1] https://github.com/eclipse-cdt-cloud/timeline-chart
[2] https://github.com/eclipse-cdt-cloud/tsp-typescript-client
[3] https://ci.eclipse.org/cdt-cloud/

Signed-off-by: Marco Miller <marco.miller@ericsson.com>