### PR TITLE
Refactor server communication to JSON-RPC

### DIFF
--- a/doc/adr/0002/graphql-server-prototype/index.js
+++ b/doc/adr/0002/graphql-server-prototype/index.js
@@ -2,7 +2,7 @@
 // [1] https://www.apollographql.com/docs/apollo-server/getting-started/#step-3-define-your-graphql-schema
 
 const { ApolloServer, gql } = require('apollo-server');
-const { TspClient } = require('tsp-typescript-client/lib/protocol/tsp-client');
+const { HttpTspClient } = require('tsp-typescript-client/lib/protocol/http-tsp-client');
 
 // A schema is a collection of type definitions (hence "typeDefs").
 const typeDefs = gql`
@@ -21,7 +21,7 @@ const baseUrl = "http://localhost:8080/tsp/api";
 const resolvers = {
   Query: {
     async status() {
-      const tspClient = new TspClient(baseUrl);
+      const tspClient = new HttpTspClient(baseUrl);
       try {
         const response = await tspClient.checkHealth();
         if (response.isOk()) {
@@ -37,7 +37,7 @@ const resolvers = {
     },
     async traces() {
       // Same simple approach as above. Returns how many traces only.
-      const tspClient = new TspClient(baseUrl);
+      const tspClient = new HttpTspClient(baseUrl);
       try {
         const response = await tspClient.fetchTraces();
         if (response.isOk()) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "prepare": "yarn -s tsref && yarn -s tsbuild && yarn -s download:plugins && yarn -s prepare:examples",
+    "prepare": "yarn -s clean && yarn -s tsref && yarn -s tsbuild && yarn -s download:plugins && yarn -s prepare:examples",
     "tsref": "node scripts/typescript-references.js",
     "tsbuild": "tsc -b",
     "tswatch": "tsc -b -w",

--- a/packages/base/src/experiment-manager.ts
+++ b/packages/base/src/experiment-manager.ts
@@ -1,5 +1,5 @@
 import { Trace } from 'tsp-typescript-client/lib/models/trace';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { Query } from 'tsp-typescript-client/lib/models/query/query';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
@@ -9,10 +9,10 @@ import { signalManager, Signals } from './signals/signal-manager';
 
 export class ExperimentManager {
     private fOpenExperiments: Map<string, Experiment> = new Map();
-    private fTspClient: TspClient;
+    private fTspClient: ITspClient;
     private fTraceManager: TraceManager;
 
-    constructor(tspClient: TspClient, traceManager: TraceManager) {
+    constructor(tspClient: ITspClient, traceManager: TraceManager) {
         this.fTspClient = tspClient;
         this.fTraceManager = traceManager;
         signalManager().on(Signals.EXPERIMENT_DELETED, (experiment: Experiment) =>
@@ -79,7 +79,10 @@ export class ExperimentManager {
             traceURIs.push(traces[i].UUID);
         }
 
-        const tryCreate = async function (tspClient: TspClient, retry: number): Promise<TspClientResponse<Experiment>> {
+        const tryCreate = async function (
+            tspClient: ITspClient,
+            retry: number
+        ): Promise<TspClientResponse<Experiment>> {
             return tspClient.createExperiment(
                 new Query({
                     name: retry === 0 ? name : name + '(' + retry + ')',

--- a/packages/base/src/lazy-tsp-client.ts
+++ b/packages/base/src/lazy-tsp-client.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { TspClient } from 'tsp-typescript-client';
+import { ITspClient } from 'tsp-typescript-client';
+import { HttpTspClient } from 'tsp-typescript-client/lib/protocol/http-tsp-client';
 
 /**
  * Hack!
@@ -8,17 +9,17 @@ import { TspClient } from 'tsp-typescript-client';
  * Only keep methods, discard properties.
  */
 export type LazyTspClient = {
-    [K in keyof TspClient]: TspClient[K] extends (...args: infer A) => infer R | Promise<infer R>
+    [K in keyof ITspClient]: ITspClient[K] extends (...args: infer A) => infer R | Promise<infer R>
         ? (...args: A) => Promise<R>
         : never; // Discard property.
 };
 
 export type LazyTspClientFactory = typeof LazyTspClientFactory;
-export function LazyTspClientFactory(url: Promise<string>): TspClient {
-    // All methods from the `TspClient` are asynchronous. The `LazyTspClient`
+export function LazyTspClientFactory(url: Promise<string>): ITspClient {
+    // All methods from the `HttpTspClient` are asynchronous. The `LazyTspClient`
     // will just delay each call to its methods by first awaiting for the
-    // asynchronous `baseUrl` resolution to then get a valid `TspClient`.
-    const tspClientPromise = url.then(baseUrl => new TspClient(baseUrl));
+    // asynchronous `baseUrl` resolution to then get a valid `HttpTspClient`.
+    const tspClientPromise = url.then(baseUrl => new HttpTspClient(baseUrl));
     // eslint-disable-next-line no-null/no-null
     return new Proxy(Object.create(null), {
         get(target, property, _receiver) {
@@ -31,5 +32,5 @@ export function LazyTspClientFactory(url: Promise<string>): TspClient {
             }
             return method;
         }
-    }) as LazyTspClient as TspClient;
+    }) as LazyTspClient as ITspClient;
 }

--- a/packages/base/src/trace-manager.ts
+++ b/packages/base/src/trace-manager.ts
@@ -1,5 +1,5 @@
 import { Trace } from 'tsp-typescript-client/lib/models/trace';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { Query } from 'tsp-typescript-client/lib/models/query/query';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
@@ -7,9 +7,9 @@ import { signalManager } from './signals/signal-manager';
 
 export class TraceManager {
     private fOpenTraces: Map<string, Trace> = new Map();
-    private fTspClient: TspClient;
+    private fTspClient: ITspClient;
 
-    constructor(tspClient: TspClient) {
+    constructor(tspClient: ITspClient) {
         this.fTspClient = tspClient;
     }
 
@@ -69,7 +69,7 @@ export class TraceManager {
     async openTrace(traceURI: string, traceName?: string): Promise<Trace | undefined> {
         const name = traceName ? traceName : traceURI.replace(/\/$/, '').replace(/(.*\/)?/, '');
 
-        const tryOpen = async function (tspClient: TspClient, retry: number): Promise<TspClientResponse<Trace>> {
+        const tryOpen = async function (tspClient: ITspClient, retry: number): Promise<TspClientResponse<Trace>> {
             return tspClient.openTrace(
                 new Query({
                     name: retry === 0 ? name : name + '(' + retry + ')',
@@ -103,7 +103,7 @@ export class TraceManager {
         if (currentTrace) {
             const traceResponse = await this.fTspClient.fetchTrace(currentTrace.UUID);
             const trace = traceResponse.getModel();
-            if (trace && traceResponse.isOk) {
+            if (trace && traceResponse.isOk()) {
                 this.fOpenTraces.set(traceUUID, trace);
                 return trace;
             }

--- a/packages/base/src/tsp-client-provider.ts
+++ b/packages/base/src/tsp-client-provider.ts
@@ -1,9 +1,9 @@
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { ExperimentManager } from './experiment-manager';
 import { TraceManager } from './trace-manager';
 
 export interface ITspClientProvider {
-    getTspClient(): TspClient;
+    getTspClient(): ITspClient;
     getTraceManager(): TraceManager;
     getExperimentManager(): ExperimentManager;
     /**
@@ -11,5 +11,5 @@ export interface ITspClientProvider {
      * @param listener The listener function to be called when the url is
      * changed
      */
-    addTspClientChangeListener(listener: (tspClient: TspClient) => void): void;
+    addTspClientChangeListener(listener: (tspClient: ITspClient) => void): void;
 }

--- a/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
+++ b/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
@@ -6,7 +6,7 @@ import { CellRenderer, LoadingRenderer, SearchFilterRenderer } from '../table-re
 import { AbstractOutputProps } from '../abstract-output-component';
 import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
 import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { HttpTspClient } from 'tsp-typescript-client/lib/protocol/http-tsp-client';
 import { ColDef, Column, ColumnApi, GridApi, IRowModel, RowNode } from 'ag-grid-community';
 
 describe('<TableOutputComponent />', () => {
@@ -38,7 +38,7 @@ describe('<TableOutputComponent />', () => {
                 componentLeft: 0,
                 chartOffset: 0
             },
-            tspClient: new TspClient('testURL'),
+            tspClient: new HttpTspClient('testURL'),
             traceId: '0',
             outputDescriptor: {
                 id: '0',

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars, faSpinner, faThumbtack, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
@@ -11,16 +11,10 @@ import { TooltipComponent } from './tooltip-component';
 import { TooltipXYComponent } from './tooltip-xy-component';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import {
-    DropDownComponent,
-    DropDownSubSection,
-    OptionCheckBoxState,
-    OptionState,
-    OptionType
-} from './drop-down-component';
+import { DropDownComponent, DropDownSubSection, OptionState } from './drop-down-component';
 
 export interface AbstractOutputProps {
-    tspClient: TspClient;
+    tspClient: ITspClient;
     tooltipComponent: TooltipComponent | null;
     tooltipXYComponent: TooltipXYComponent | null;
     traceId: string;

--- a/packages/react-components/src/components/data-providers/style-provider.ts
+++ b/packages/react-components/src/components/data-providers/style-provider.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper';
 import { OutputStyleModel, OutputElementStyle } from 'tsp-typescript-client/lib/models/styles';
 import { StyleProperties } from './style-properties';
 
 export class StyleProvider {
-    private tspClient: TspClient;
+    private tspClient: ITspClient;
     private traceId: string;
     private outputId: string;
 
@@ -13,7 +13,7 @@ export class StyleProvider {
 
     private styleModel: OutputStyleModel | undefined;
 
-    constructor(outputId: string, traceId: string, tspClient: TspClient) {
+    constructor(outputId: string, traceId: string, tspClient: ITspClient) {
         this.outputId = outputId;
         this.tspClient = tspClient;
         this.traceId = traceId;

--- a/packages/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/packages/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import {
     TimeGraphArrow,
     TimeGraphEntry,
@@ -21,7 +21,7 @@ enum ElementType {
 }
 
 export class TspDataProvider {
-    private client: TspClient;
+    private client: ITspClient;
     private outputId: string;
     private traceUUID: string;
     private timeGraphEntries: TimeGraphEntry[];
@@ -29,7 +29,7 @@ export class TspDataProvider {
 
     public totalRange: bigint;
 
-    constructor(client: TspClient, traceUUID: string, outputId: string) {
+    constructor(client: ITspClient, traceUUID: string, outputId: string) {
         this.timeGraphEntries = [];
         this.timeGraphRows = [];
         this.client = client;

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -9,7 +9,7 @@ import { TimelineChart } from 'timeline-chart/lib/time-graph-model';
 import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TimeRange, TimeRangeString } from 'traceviewer-base/lib/utils/time-range';
 import { TableOutputComponent } from './table-output-component';
 import { TimegraphOutputComponent } from './timegraph-output-component';
@@ -34,7 +34,7 @@ import { TimeRangeUpdatePayload } from 'traceviewer-base/lib/signals/time-range-
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
 export interface TraceContextProps {
-    tspClient: TspClient;
+    tspClient: ITspClient;
     experiment: Experiment;
     outputs: OutputDescriptor[];
     overviewDescriptor?: OutputDescriptor; // The default output descriptor for the overview

--- a/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
+++ b/packages/react-components/src/components/trace-overview-selection-dialog-component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { OutputDescriptor, TspClient } from 'tsp-typescript-client';
+import { OutputDescriptor, ITspClient } from 'tsp-typescript-client';
 import { AbstractDialogComponent, DialogComponentProps } from './abstract-dialog-component';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 import { AvailableViewsComponent } from './utils/available-views-component';
 
 export interface TraceOverviewSelectionComponentProps extends DialogComponentProps {
-    tspClient: TspClient;
+    tspClient: ITspClient;
     traceID: string;
 }
 

--- a/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
@@ -1,0 +1,23 @@
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from 'inversify';
+import { PortPreferenceProxy } from '../common/trace-server-url-provider';
+import { TracePreferences, TRACE_PORT } from './trace-server-preference';
+
+@injectable()
+export class PreferencesFrontendContribution implements FrontendApplicationContribution {
+    constructor(
+        @inject(TracePreferences) protected tracePreferences: TracePreferences,
+        @inject(PortPreferenceProxy) protected portPreferenceProxy: PortPreferenceProxy
+    ) {}
+
+    async initialize(): Promise<void> {
+        this.tracePreferences.ready.then(() => {
+            this.portPreferenceProxy.onPortPreferenceChanged(this.tracePreferences[TRACE_PORT]);
+            this.tracePreferences.onPreferenceChanged(async event => {
+                const newValue = typeof event.newValue === 'string' ? parseInt(event.newValue) : event.newValue;
+                const oldValue = typeof event.oldValue === 'string' ? parseInt(event.oldValue) : event.oldValue;
+                this.portPreferenceProxy.onPortPreferenceChanged(newValue, oldValue, true);
+            });
+        });
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
@@ -14,9 +14,11 @@ export class PreferencesFrontendContribution implements FrontendApplicationContr
         this.tracePreferences.ready.then(() => {
             this.portPreferenceProxy.onPortPreferenceChanged(this.tracePreferences[TRACE_PORT]);
             this.tracePreferences.onPreferenceChanged(async event => {
-                const newValue = typeof event.newValue === 'string' ? parseInt(event.newValue) : event.newValue;
-                const oldValue = typeof event.oldValue === 'string' ? parseInt(event.oldValue) : event.oldValue;
-                this.portPreferenceProxy.onPortPreferenceChanged(newValue, oldValue, true);
+                if (event.preferenceName === TRACE_PORT) {
+                    const newValue = typeof event.newValue === 'string' ? parseInt(event.newValue) : event.newValue;
+                    const oldValue = typeof event.oldValue === 'string' ? parseInt(event.oldValue) : event.oldValue;
+                    this.portPreferenceProxy.onPortPreferenceChanged(newValue, oldValue, true);
+                }
             });
         });
     }

--- a/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
+++ b/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
@@ -1,0 +1,371 @@
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
+import { Trace } from 'tsp-typescript-client/lib/models/trace';
+import { Query } from 'tsp-typescript-client/lib/models/query/query';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+import { GenericResponse } from 'tsp-typescript-client/lib/models/response/responses';
+import { HealthStatus } from 'tsp-typescript-client/lib/models/health';
+import { XyEntry, XYModel } from 'tsp-typescript-client/lib/models/xy';
+import { TimeGraphEntry, TimeGraphArrow, TimeGraphModel } from 'tsp-typescript-client/lib/models/timegraph';
+import { AnnotationCategoriesModel, AnnotationModel } from 'tsp-typescript-client/lib/models/annotation';
+import { TableModel, ColumnHeaderEntry } from 'tsp-typescript-client/lib/models/table';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { EntryModel } from 'tsp-typescript-client/lib/models/entry';
+import { OutputStyleModel } from 'tsp-typescript-client/lib/models/styles';
+import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
+import { DataTreeEntry } from 'tsp-typescript-client/lib/models/data-tree';
+
+export const TspClientProxy = Symbol('TspClientProxy') as symbol & interfaces.Abstract<TspClientProxy>;
+export type TspClientProxy = ITspClient;
+
+@injectable()
+export class TheiaRpcTspProxy implements ITspClient {
+    public constructor(@inject(TspClientProxy) protected tspClient: ITspClient) {}
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    protected toTspClientResponse<T>(result: any): TspClientResponse<T> {
+        const tspClientResponse: TspClientResponse<T> = new TspClientResponse(
+            result.text,
+            result.statusCode,
+            result.statusMessage,
+            result.responseModel
+        );
+        return tspClientResponse;
+    }
+
+    /**
+     * Fetch all available traces on the server
+     * @returns List of Trace
+     */
+    public async fetchTraces(): Promise<TspClientResponse<Trace[]>> {
+        return this.toTspClientResponse<Trace[]>(await this.tspClient.fetchTraces());
+    }
+
+    /**
+     * Fetch a specific trace information
+     * @param traceUUID Trace UUID to fetch
+     */
+    public async fetchTrace(traceUUID: string): Promise<TspClientResponse<Trace>> {
+        return this.toTspClientResponse<Trace>(await this.tspClient.fetchTrace(traceUUID));
+    }
+
+    /**
+     * Open a trace on the server
+     * @param parameters Query object
+     * @returns The opened trace
+     */
+    public async openTrace(parameters: Query): Promise<TspClientResponse<Trace>> {
+        return this.toTspClientResponse<Trace>(await this.tspClient.openTrace(parameters));
+    }
+
+    /**
+     * Delete a trace on the server
+     * @param traceUUID Trace UUID to delete
+     * @param deleteTrace Also delete the trace from disk
+     * @param removeCache Remove all cache for this trace
+     * @returns The deleted trace
+     */
+    public async deleteTrace(
+        traceUUID: string,
+        deleteTrace?: boolean,
+        removeCache?: boolean
+    ): Promise<TspClientResponse<Trace>> {
+        return this.toTspClientResponse<Trace>(await this.tspClient.deleteTrace(traceUUID, deleteTrace, removeCache));
+    }
+
+    /**
+     * Fetch all available experiments on the server
+     * @returns List of Experiment
+     */
+    public async fetchExperiments(): Promise<TspClientResponse<Experiment[]>> {
+        return this.toTspClientResponse<Experiment[]>(await this.tspClient.fetchExperiments());
+    }
+
+    /**
+     * Fetch a specific experiment information
+     * @param expUUID Experiment UUID to fetch
+     * @returns The experiment
+     */
+    public async fetchExperiment(expUUID: string): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.fetchExperiment(expUUID));
+    }
+
+    /**
+     * Create an experiment on the server
+     * @param parameters Query object
+     * @returns The created experiment
+     */
+    public async createExperiment(parameters: Query): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.createExperiment(parameters));
+    }
+
+    /**
+     * Update an experiment
+     * @param expUUID Experiment UUID to update
+     * @param parameters Query object
+     * @returns The updated experiment
+     */
+    public async updateExperiment(expUUID: string, parameters: Query): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.updateExperiment(expUUID, parameters));
+    }
+
+    /**
+     * Delete an experiment on the server
+     * @param expUUID Experiment UUID to delete
+     * @returns The deleted experiment
+     */
+    public async deleteExperiment(expUUID: string): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.deleteExperiment(expUUID));
+    }
+
+    /**
+     * List all the outputs associated to this experiment
+     * @param expUUID Experiment UUID
+     * @returns List of OutputDescriptor
+     */
+    public async experimentOutputs(expUUID: string): Promise<TspClientResponse<OutputDescriptor[]>> {
+        return this.toTspClientResponse<OutputDescriptor[]>(await this.tspClient.experimentOutputs(expUUID));
+    }
+
+    /**
+     * Fetch Data tree
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with entries
+     */
+    public async fetchDataTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<DataTreeEntry>>>> {
+        return this.toTspClientResponse<GenericResponse<EntryModel<DataTreeEntry>>>(
+            await this.tspClient.fetchDataTree(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch XY tree
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with entries
+     */
+    public async fetchXYTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<XyEntry>>>> {
+        return this.toTspClientResponse<GenericResponse<EntryModel<XyEntry>>>(
+            await this.tspClient.fetchXYTree(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch XY. model extends XYModel
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns XY model response with the model
+     */
+    public async fetchXY(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<XYModel>>> {
+        return this.toTspClientResponse<GenericResponse<XYModel>>(
+            await this.tspClient.fetchXY(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch XY tooltip
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param xValue X value
+     * @param yValue Optional Y value
+     * @param seriesID Optional series ID
+     * @returns Map of key=name of the property and value=string value associated
+     */
+    public async fetchXYToolTip(
+        expUUID: string,
+        outputID: string,
+        xValue: number,
+        yValue?: number,
+        seriesID?: string
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: string }>>> {
+        return this.toTspClientResponse<GenericResponse<{ [key: string]: string }>>(
+            await this.tspClient.fetchXYToolTip(expUUID, outputID, xValue, yValue, seriesID)
+        );
+    }
+
+    /**
+     * Fetch Time Graph tree, Model extends TimeGraphEntry
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Time graph entry response with entries of type TimeGraphEntry
+     */
+    public async fetchTimeGraphTree(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<TimeGraphEntry>>>> {
+        return this.toTspClientResponse<GenericResponse<EntryModel<TimeGraphEntry>>>(
+            await this.tspClient.fetchTimeGraphTree(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Time Graph states. Model extends TimeGraphModel
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchTimeGraphStates(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TimeGraphModel>>> {
+        return this.toTspClientResponse<GenericResponse<TimeGraphModel>>(
+            await this.tspClient.fetchTimeGraphStates(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Time Graph arrows. Model extends TimeGraphArrow
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchTimeGraphArrows(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TimeGraphArrow[]>>> {
+        return this.toTspClientResponse<GenericResponse<TimeGraphArrow[]>>(
+            await this.tspClient.fetchTimeGraphArrows(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch marker sets.
+     * @returns Generic response with the model
+     */
+    public async fetchMarkerSets(expUUID: string): Promise<TspClientResponse<GenericResponse<MarkerSet[]>>> {
+        return this.toTspClientResponse<GenericResponse<MarkerSet[]>>(await this.tspClient.fetchMarkerSets(expUUID));
+    }
+
+    /**
+     * Fetch annotations categories.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param markerSetId Marker Set ID
+     * @returns Generic response with the model
+     */
+    public async fetchAnnotationsCategories(
+        expUUID: string,
+        outputID: string,
+        markerSetId?: string
+    ): Promise<TspClientResponse<GenericResponse<AnnotationCategoriesModel>>> {
+        return this.toTspClientResponse<GenericResponse<AnnotationCategoriesModel>>(
+            await this.tspClient.fetchAnnotationsCategories(expUUID, outputID, markerSetId)
+        );
+    }
+
+    /**
+     * Fetch annotations.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchAnnotations(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<AnnotationModel>>> {
+        return this.toTspClientResponse<GenericResponse<AnnotationModel>>(
+            await this.tspClient.fetchAnnotations(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch tooltip for a Time Graph element.
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Map of key=name of the property and value=string value associated
+     */
+    public async fetchTimeGraphTooltip(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: string }>>> {
+        return this.toTspClientResponse<GenericResponse<{ [key: string]: string }>>(
+            await this.tspClient.fetchTimeGraphTooltip(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Table columns
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic entry response with columns headers as model
+     */
+    public async fetchTableColumns(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<ColumnHeaderEntry[]>>> {
+        return this.toTspClientResponse<GenericResponse<ColumnHeaderEntry[]>>(
+            await this.tspClient.fetchTableColumns(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch Table lines
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchTableLines(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<TableModel>>> {
+        return this.toTspClientResponse<GenericResponse<TableModel>>(
+            await this.tspClient.fetchTableLines(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Fetch output styles
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async fetchStyles(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<OutputStyleModel>>> {
+        return this.toTspClientResponse<GenericResponse<OutputStyleModel>>(
+            await this.tspClient.fetchStyles(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
+     * Check the health status of the server
+     * @returns The Health Status
+     */
+    public async checkHealth(): Promise<TspClientResponse<HealthStatus>> {
+        return this.toTspClientResponse<HealthStatus>(await this.tspClient.checkHealth());
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -8,7 +8,7 @@ import { TraceExplorerServerStatusWidget } from './trace-explorer-sub-widgets/tr
 import { TraceExplorerTimeRangeDataWidget } from './trace-explorer-sub-widgets/theia-trace-explorer-time-range-data-widget';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { OpenedTracesUpdatedSignalPayload } from 'traceviewer-base/lib/signals/opened-traces-updated-signal-payload';
-import { TraceServerConnectionStatusService } from '../trace-server-status';
+import { TraceServerConnectionStatusClient } from '../../common/trace-server-connection-status';
 
 @injectable()
 export class TraceExplorerWidget extends BaseWidget {
@@ -24,8 +24,8 @@ export class TraceExplorerWidget extends BaseWidget {
     @inject(TraceExplorerServerStatusWidget) protected readonly serverStatusWidget!: TraceExplorerServerStatusWidget;
     @inject(TraceExplorerTimeRangeDataWidget) protected readonly timeRangeDataWidget!: TraceExplorerTimeRangeDataWidget;
     @inject(ViewContainer.Factory) protected readonly viewContainerFactory!: ViewContainer.Factory;
-    @inject(TraceServerConnectionStatusService)
-    protected readonly connectionStatusService: TraceServerConnectionStatusService;
+    @inject(TraceServerConnectionStatusClient)
+    protected readonly connectionStatusClient: TraceServerConnectionStatusClient;
 
     openExperiment(traceUUID: string): void {
         return this.openedTracesWidget.openExperiment(traceUUID);
@@ -109,10 +109,10 @@ export class TraceExplorerWidget extends BaseWidget {
     }
 
     protected onAfterShow(): void {
-        this.connectionStatusService.addConnectionStatusListener();
+        this.connectionStatusClient.addConnectionStatusListener();
     }
 
     protected onAfterHide(): void {
-        this.connectionStatusService.removeConnectionStatusListener();
+        this.connectionStatusClient.removeConnectionStatusListener();
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
@@ -1,23 +1,28 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { injectable } from '@theia/core/shared/inversify';
-import { RestClient, ConnectionStatusListener } from 'tsp-typescript-client/lib/protocol/rest-client';
+import { injectable } from 'inversify';
+import {
+    TraceServerConnectionStatusBackend,
+    TraceServerConnectionStatusClient
+} from '../common/trace-server-connection-status';
+import { inject } from '@theia/core/shared/inversify';
 
 @injectable()
-export class TraceServerConnectionStatusService {
-    private connectionStatusListener: ConnectionStatusListener;
+export class TraceServerConnectionStatusClientImpl implements TraceServerConnectionStatusClient {
+    constructor(
+        @inject(TraceServerConnectionStatusBackend)
+        protected traceServerConnectionStatusProxy: TraceServerConnectionStatusBackend
+    ) {}
 
-    constructor() {
-        this.connectionStatusListener = (status: boolean) => {
-            TraceServerConnectionStatusService.renderStatus(status);
-        };
+    updateStatus(status: boolean): void {
+        TraceServerConnectionStatusClientImpl.renderStatus(status);
     }
 
     public addConnectionStatusListener(): void {
-        RestClient.addConnectionStatusListener(this.connectionStatusListener);
+        this.traceServerConnectionStatusProxy.setClient(this);
     }
 
     public removeConnectionStatusListener(): void {
-        RestClient.removeConnectionStatusListener(this.connectionStatusListener);
+        this.traceServerConnectionStatusProxy.removeClient(this);
     }
 
     static renderStatus(status: boolean): void {

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
@@ -1,28 +1,23 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { injectable } from 'inversify';
-import {
-    TraceServerConnectionStatusBackend,
-    TraceServerConnectionStatusClient
-} from '../common/trace-server-connection-status';
-import { inject } from '@theia/core/shared/inversify';
+import { TraceServerConnectionStatusClient } from '../common/trace-server-connection-status';
 
 @injectable()
 export class TraceServerConnectionStatusClientImpl implements TraceServerConnectionStatusClient {
-    constructor(
-        @inject(TraceServerConnectionStatusBackend)
-        protected traceServerConnectionStatusProxy: TraceServerConnectionStatusBackend
-    ) {}
+    protected active = false;
 
     updateStatus(status: boolean): void {
-        TraceServerConnectionStatusClientImpl.renderStatus(status);
+        if (this.active) {
+            TraceServerConnectionStatusClientImpl.renderStatus(status);
+        }
     }
 
-    public addConnectionStatusListener(): void {
-        this.traceServerConnectionStatusProxy.setClient(this);
+    addConnectionStatusListener(): void {
+        this.active = true;
     }
 
-    public removeConnectionStatusListener(): void {
-        this.traceServerConnectionStatusProxy.removeClient(this);
+    removeConnectionStatusListener(): void {
+        this.active = false;
     }
 
     static renderStatus(status: boolean): void {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -21,12 +21,12 @@ import {
 } from './trace-viewer-commands';
 import { PortBusy, TraceServerConfigService } from '../../common/trace-server-config';
 import { TracePreferences, TRACE_PATH, TRACE_ARGS } from '../trace-server-preference';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { ChartShortcutsDialog } from '../trace-explorer/trace-explorer-sub-widgets/charts-cheatsheet-component';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import { TraceServerConnectionStatusService } from '../trace-server-status';
+import { TraceServerConnectionStatusClientImpl } from '../trace-server-connection-status-client-impl';
 import { FileStat } from '@theia/filesystem/lib/common/files';
+import { ITspClient } from 'tsp-typescript-client';
 
 interface TraceViewerWidgetOpenerOptions extends WidgetOpenerOptions {
     traceUUID: string;
@@ -37,7 +37,7 @@ export class TraceViewerContribution
     extends WidgetOpenHandler<TraceViewerWidget>
     implements CommandContribution, KeybindingContribution
 {
-    private tspClient: TspClient;
+    private tspClient: ITspClient;
 
     constructor(@inject(TspClientProvider) private tspClientProvider: TspClientProvider) {
         super();
@@ -94,7 +94,7 @@ export class TraceViewerContribution
                         progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                     }
                     progress.cancel();
-                    TraceServerConnectionStatusService.renderStatus(true);
+                    TraceServerConnectionStatusClientImpl.renderStatus(true);
                     signalManager().fireTraceServerStartedSignal();
                     this.openDialog(rootPath);
                 }
@@ -163,7 +163,7 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
-                        TraceServerConnectionStatusService.renderStatus(true);
+                        TraceServerConnectionStatusClientImpl.renderStatus(true);
                         signalManager().fireTraceServerStartedSignal();
                         return super.open(traceURI, options);
                     }
@@ -230,7 +230,7 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
-                        TraceServerConnectionStatusService.renderStatus(true);
+                        TraceServerConnectionStatusClientImpl.renderStatus(true);
                         signalManager().fireTraceServerStartedSignal();
                         return;
                     }
@@ -261,7 +261,7 @@ export class TraceViewerContribution
                 try {
                     await this.traceServerConfigService.stopTraceServer();
                     this.messageService.info('Trace server terminated successfully.');
-                    TraceServerConnectionStatusService.renderStatus(false);
+                    TraceServerConnectionStatusClientImpl.renderStatus(false);
                 } catch (err) {
                     this.messageService.error('Failed to stop the trace server.');
                 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -47,7 +47,6 @@ export default new ContainerModule(bind => {
     bind(TabBarToolbarContribution).toService(TraceViewerToolbarContribution);
     bind(CommandContribution).toService(TraceViewerToolbarContribution);
     bind(TraceServerConnectionStatusClient).to(TraceServerConnectionStatusClientImpl).inSingletonScope();
-    bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusClient);
 
     bind(TraceViewerWidget).toSelf();
     bind<WidgetFactory>(WidgetFactory)
@@ -110,7 +109,8 @@ export default new ContainerModule(bind => {
     bind(TraceServerConnectionStatusBackend)
         .toDynamicValue(ctx => {
             const connection = ctx.container.get(WebSocketConnectionProvider);
-            return connection.createProxy<TraceServerConnectionStatusBackend>(TRACE_SERVER_CONNECTION_STATUS);
+            const client = ctx.container.get<TraceServerConnectionStatusClient>(TraceServerConnectionStatusClient);
+            return connection.createProxy<TraceServerConnectionStatusBackend>(TRACE_SERVER_CONNECTION_STATUS, client);
         })
         .inSingletonScope();
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -4,7 +4,6 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Trace } from 'tsp-typescript-client/lib/models/trace';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
@@ -34,6 +33,7 @@ import {
     getSwitchToDefaultViewErrorMessage,
     OverviewPreferences
 } from '../trace-overview-preference';
+import { ITspClient } from 'tsp-typescript-client';
 
 export const TraceViewerWidgetOptions = Symbol('TraceViewerWidgetOptions');
 export interface TraceViewerWidgetOptions {
@@ -49,7 +49,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
     protected uri: Path;
     protected openedExperiment: Experiment | undefined;
     protected outputDescriptors: OutputDescriptor[] = [];
-    protected tspClient: TspClient;
+    protected tspClient: ITspClient;
     protected traceManager: TraceManager;
     protected experimentManager: ExperimentManager;
     protected backgroundTheme: string;

--- a/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
@@ -1,41 +1,25 @@
-import { injectable, inject } from '@theia/core/shared/inversify';
-import { TraceServerUrlProvider } from '../common/trace-server-url-provider';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { injectable, inject } from 'inversify';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
-import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
+import { ITspClient } from 'tsp-typescript-client';
+import { TheiaRpcTspProxy } from './theia-rpc-tsp-proxy';
 
 @injectable()
 export class TspClientProvider implements ITspClientProvider {
-    private _tspClient: TspClient;
+    private _tspClient: ITspClient;
     private _traceManager: TraceManager;
     private _experimentManager: ExperimentManager;
-    private _listeners: ((tspClient: TspClient) => void)[];
+    private _listeners: ((tspClient: ITspClient) => void)[];
 
-    constructor(
-        @inject(TraceServerUrlProvider) private tspUrlProvider: TraceServerUrlProvider,
-        @inject(LazyTspClientFactory) private lazyTspClientFactory: LazyTspClientFactory
-    ) {
-        const traceServerUrlPromise = this.tspUrlProvider.getTraceServerUrlPromise();
-        this._tspClient = this.lazyTspClientFactory(traceServerUrlPromise);
+    constructor(@inject(TheiaRpcTspProxy) protected client: ITspClient) {
+        this._tspClient = client;
         this._traceManager = new TraceManager(this._tspClient);
         this._experimentManager = new ExperimentManager(this._tspClient, this._traceManager);
         this._listeners = [];
-        // Skip the first event fired when the Trace Server URL gets initialized.
-        traceServerUrlPromise.then(() => {
-            tspUrlProvider.onDidChangeTraceServerUrl(url => {
-                this._tspClient = new TspClient(url);
-                this._traceManager = new TraceManager(this._tspClient);
-                this._experimentManager = new ExperimentManager(this._tspClient, this._traceManager);
-                for (const listener of this._listeners) {
-                    listener(this._tspClient);
-                }
-            });
-        });
     }
 
-    public getTspClient(): TspClient {
+    public getTspClient(): ITspClient {
         return this._tspClient;
     }
 
@@ -52,7 +36,7 @@ export class TspClientProvider implements ITspClientProvider {
      * @param listener The listener function to be called when the url is
      * changed
      */
-    addTspClientChangeListener(listener: (tspClient: TspClient) => void): void {
+    addTspClientChangeListener(listener: (tspClient: ITspClient) => void): void {
         this._listeners.push(listener);
     }
 }

--- a/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
@@ -1,6 +1,8 @@
 import { ApplicationError } from '@theia/core';
 
 export const traceServerPath = '/services/theia-trace-extension/trace-server-config';
+export const TRACE_SERVER_CLIENT = '/services/theia-trace-extension/trace-server-client';
+
 export const PortBusy = ApplicationError.declare(-32650, code => ({
     message: 'Port busy',
     data: { code }

--- a/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
@@ -1,0 +1,34 @@
+export const TraceServerConnectionStatusBackend = Symbol('TraceServerConnectionStatusBackend');
+
+export const TRACE_SERVER_CONNECTION_STATUS = '/services/theia-trace-extension/trace-server-connection-status';
+
+export interface TraceServerConnectionStatusBackend {
+    /**
+     * Set a new TraceServerConnectionStatusClient to be notified on status changes.
+     * @param client the client to be notified.
+     */
+    setClient(client: TraceServerConnectionStatusClient): void;
+    /**
+     * Remove a new TraceServerConnectionStatusClient so it won't no longer be notified on status changes.
+     * @param client the client to be removed.
+     */
+    removeClient(client: TraceServerConnectionStatusClient): void;
+}
+
+export const TraceServerConnectionStatusClient = Symbol('TraceServerConnectionStatusClient');
+
+export interface TraceServerConnectionStatusClient {
+    /**
+     * Update the status on the client.
+     * @param status the new value of the status.
+     */
+    updateStatus(status: boolean): void;
+    /**
+     * Subscribe this client to the connection status
+     */
+    addConnectionStatusListener(): void;
+    /**
+     * Unsubscribe this client from the connection status
+     */
+    removeConnectionStatusListener(): void;
+}

--- a/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
@@ -4,15 +4,20 @@ export const TRACE_SERVER_CONNECTION_STATUS = '/services/theia-trace-extension/t
 
 export interface TraceServerConnectionStatusBackend {
     /**
-     * Set a new TraceServerConnectionStatusClient to be notified on status changes.
+     * Add a new TraceServerConnectionStatusClient to be notified on status changes.
      * @param client the client to be notified.
      */
-    setClient(client: TraceServerConnectionStatusClient): void;
+    addClient(client: TraceServerConnectionStatusClient): void;
     /**
      * Remove a new TraceServerConnectionStatusClient so it won't no longer be notified on status changes.
      * @param client the client to be removed.
      */
     removeClient(client: TraceServerConnectionStatusClient): void;
+
+    /**
+     * Get the current status of the trace server
+     */
+    getStatus(): Promise<boolean>;
 }
 
 export const TraceServerConnectionStatusClient = Symbol('TraceServerConnectionStatusClient');

--- a/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
@@ -22,3 +22,16 @@ export interface TraceServerUrlProvider {
      */
     onDidChangeTraceServerUrl(listener: (url: string) => void): void;
 }
+
+export const TRACE_SERVER_PORT = '/services/theia-trace-extension/trace-server-port';
+
+export const PortPreferenceProxy = Symbol('PortPreferenceProxy');
+export interface PortPreferenceProxy {
+    /**
+     * Notify the backend about a change of the port preference.
+     * @param newPort the new value of the port preference.
+     * @param oldValue the old value of the port preference.
+     * @param preferenceChanged boolean that indicated whether the preference was changed or initialized.
+     */
+    onPortPreferenceChanged(newPort: number | undefined, oldValue?: number, preferenceChanged?: boolean): Promise<void>;
+}

--- a/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
@@ -1,0 +1,29 @@
+import { injectable } from 'inversify';
+import { RestClient } from 'tsp-typescript-client/lib/protocol/rest-client';
+import {
+    TraceServerConnectionStatusBackend,
+    TraceServerConnectionStatusClient
+} from '../common/trace-server-connection-status';
+
+@injectable()
+export class TraceServerConnectionStatusBackendImpl implements TraceServerConnectionStatusBackend {
+    protected clients: TraceServerConnectionStatusClient[] = [];
+
+    constructor() {
+        const listener = (status: boolean) => {
+            this.clients.forEach(client => client.updateStatus(status));
+        };
+        RestClient.addConnectionStatusListener(listener);
+    }
+
+    setClient(client: TraceServerConnectionStatusClient): void {
+        this.clients.push(client);
+    }
+
+    removeClient(client: TraceServerConnectionStatusClient): void {
+        const index = this.clients.indexOf(client);
+        if (index > -1) {
+            this.clients.splice(index, 1);
+        }
+    }
+}

--- a/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
@@ -8,15 +8,21 @@ import {
 @injectable()
 export class TraceServerConnectionStatusBackendImpl implements TraceServerConnectionStatusBackend {
     protected clients: TraceServerConnectionStatusClient[] = [];
+    protected lastStatus = false;
 
     constructor() {
         const listener = (status: boolean) => {
             this.clients.forEach(client => client.updateStatus(status));
+            this.lastStatus = status;
         };
         RestClient.addConnectionStatusListener(listener);
     }
 
-    setClient(client: TraceServerConnectionStatusClient): void {
+    getStatus(): Promise<boolean> {
+        return Promise.resolve(this.lastStatus);
+    }
+
+    addClient(client: TraceServerConnectionStatusClient): void {
         this.clients.push(client);
     }
 

--- a/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
+++ b/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
@@ -45,8 +45,7 @@ export default new ContainerModule(bind => {
                 new JsonRpcConnectionHandler(TRACE_SERVER_CLIENT, () => {
                     const provider = ctx.container.get<TraceServerUrlProvider>(TraceServerUrlProvider);
                     const lazyTspClientFactory = ctx.container.get<LazyTspClientFactory>(LazyTspClientFactory);
-                    const traceServerUrlPromise = provider.getTraceServerUrlPromise();
-                    return lazyTspClientFactory(traceServerUrlPromise);
+                    return lazyTspClientFactory(() => provider.getTraceServerUrlPromise());
                 })
         )
         .inSingletonScope();

--- a/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
+++ b/theia-extensions/viewer-prototype/src/node/viewer-prototype-backend-module.ts
@@ -1,12 +1,27 @@
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
-import { traceServerPath } from '../common/trace-server-config';
+import { TRACE_SERVER_CLIENT, traceServerPath } from '../common/trace-server-config';
 import { TraceServerConfigService } from '../common/trace-server-config';
 import { BackendFileService, backendFileServicePath } from '../common/backend-file-service';
 import { BackendFileServiceImpl } from './backend-file-service-impl';
+import { PortPreferenceProxy, TRACE_SERVER_PORT, TraceServerUrlProvider } from '../common/trace-server-url-provider';
+import { TraceServerUrlProviderImpl } from './trace-server-url-provider-impl';
+import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
+import { TraceServerConnectionStatusBackendImpl } from './trace-server-connection-status-backend-impl';
+import {
+    TRACE_SERVER_CONNECTION_STATUS,
+    TraceServerConnectionStatusBackend
+} from '../common/trace-server-connection-status';
 
 export default new ContainerModule(bind => {
+    bind(LazyTspClientFactory).toFunction(LazyTspClientFactory);
     bind(BackendFileService).to(BackendFileServiceImpl).inSingletonScope();
+    bind(TraceServerUrlProviderImpl).toSelf().inSingletonScope();
+    bind(TraceServerUrlProvider).to(TraceServerUrlProviderImpl).inSingletonScope();
+    bind(BackendApplicationContribution).toService(TraceServerUrlProvider);
+    bind(PortPreferenceProxy).toService(TraceServerUrlProvider);
+    bind(TraceServerConnectionStatusBackend).to(TraceServerConnectionStatusBackendImpl).inSingletonScope();
     bind(ConnectionHandler)
         .toDynamicValue(
             ctx =>
@@ -20,6 +35,33 @@ export default new ContainerModule(bind => {
             ctx =>
                 new JsonRpcConnectionHandler(backendFileServicePath, () =>
                     ctx.container.get<BackendFileService>(BackendFileService)
+                )
+        )
+        .inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler(TRACE_SERVER_CLIENT, () => {
+                    const provider = ctx.container.get<TraceServerUrlProvider>(TraceServerUrlProvider);
+                    const lazyTspClientFactory = ctx.container.get<LazyTspClientFactory>(LazyTspClientFactory);
+                    const traceServerUrlPromise = provider.getTraceServerUrlPromise();
+                    return lazyTspClientFactory(traceServerUrlPromise);
+                })
+        )
+        .inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler(TRACE_SERVER_PORT, () =>
+                    ctx.container.get<PortPreferenceProxy>(PortPreferenceProxy)
+                )
+        )
+        .inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ctx =>
+                new JsonRpcConnectionHandler(TRACE_SERVER_CONNECTION_STATUS, () =>
+                    ctx.container.get<TraceServerConnectionStatusBackend>(TraceServerConnectionStatusBackend)
                 )
         )
         .inSingletonScope();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10154,7 +10154,7 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
-json-bigint@sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473:
+"json-bigint@github:sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473":
   version "1.0.0"
   resolved "https://codeload.github.com/sidorares/json-bigint/tar.gz/2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10154,7 +10154,7 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
-"json-bigint@github:sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473":
+json-bigint@sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473:
   version "1.0.0"
   resolved "https://codeload.github.com/sidorares/json-bigint/tar.gz/2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
   dependencies:


### PR DESCRIPTION
**Update to newest tsp-typescript-client next version**

To consume the new types introduced with https://github.com/eclipse-cdt-cloud/tsp-typescript-client/pull/83.
Invoke the yarn clean script before running the prepare script.
Make sure all imports are from `lib` instead of `src`.

**Update types of base package and react-components**

Use the newly introduced types of tsp-typescript-client.
The type of TspClient becomes ITspClient.
The constructor for the base implementation becomes HttpTspClient.

**Refactor server communication to JSON-RPC**

TspClient Proxy:
Provide an implementation of the ITspClient called `TheiaRpcTspProxy`.
The implementation forwards all calls to a JSON RPC proxy called `TheiaClientProxy`.
Responses are then mapped to a `TspClientResponse`.
On the backend the `TheiaClientProxy` returns a lazyTspClient.
The lazyTspClient returns a `HttpTspClient` (default implementation).

Trace Server url provider:
The implementation of the provider was moved to the backend.
This way the env variable can be read out directly.
For the port preference a proxy mechanism was added.
Changes to the preference are sent via JSON RPC and handled by the url provider.

Trace Server connection status:
The implementation was moved to the backend.
Frontends can register themselves on the backend.
Each registered frontend will be pinged when the status has changed.

Misc:
Use `ITspClient` instead of `TspClient` for types, as `TspClient` is deprecated.

Fixes https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/976

Contributed on behalf of STMicroelectronics