### PR TITLE
Refresh open traces view on start during open

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -94,6 +94,8 @@ export class TraceViewerContribution
                         progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                     }
                     progress.cancel();
+                    TraceServerConnectionStatusService.renderStatus(true);
+                    signalManager().fireTraceServerStartedSignal();
                     this.openDialog(rootPath);
                 }
             } catch (err) {
@@ -161,6 +163,8 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
+                        TraceServerConnectionStatusService.renderStatus(true);
+                        signalManager().fireTraceServerStartedSignal();
                         return super.open(traceURI, options);
                     }
                     throw new Error('Could not start trace server: ' + resolve);


### PR DESCRIPTION
When triggering an open command, a trace server will be started if necessary. With this PR, upon successful start of trace server, the status indication and the opened trace view will be refreshed.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>