### PR TITLE
Fix SHA in git-blame-ignore-revs to commit of prettier format change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Run code through Prettier
-f194f10b3b3ed4b0cdd2bf28786a9c6f28248c94
+6e3116b0461fad2671928678cced579e4d4c88fb


### PR DESCRIPTION
Prettier was introduced with PR #973, but SHA in .git-blame-ignore-revs was not updated after it was merged.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>