### PR TITLE
Added output data changed signal

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -30,6 +30,7 @@ export declare interface SignalManager {
     fireTraceServerStartedSignal(): void;
     fireUndoSignal(): void;
     fireRedoSignal(): void;
+    fireOutputDataChanged(outputs: OutputDescriptor[]): void;
     fireOpenOverviewOutputSignal(traceId: string): void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     firePinView(output: OutputDescriptor, payload?: any): void;
@@ -73,7 +74,8 @@ export const Signals = {
     SAVE_AS_CSV: 'save as csv',
     VIEW_RANGE_UPDATED: 'view range updated',
     SELECTION_RANGE_UPDATED: 'selection range updated',
-    REQUEST_SELECTION_RANGE_CHANGE: 'change selection range'
+    REQUEST_SELECTION_RANGE_CHANGE: 'change selection range',
+    OUTPUT_DATA_CHANGED: 'output data changed'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -142,6 +144,9 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireRedoSignal(): void {
         this.emit(Signals.REDO);
+    }
+    fireOutputDataChanged(outputs: OutputDescriptor[]): void {
+        this.emit(Signals.OUTPUT_DATA_CHANGED, outputs);
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     firePinView(output: OutputDescriptor, payload?: any): void {

--- a/packages/react-components/src/components/utils/timegraph-container-component.tsx
+++ b/packages/react-components/src/components/utils/timegraph-container-component.tsx
@@ -33,11 +33,14 @@ export class ReactTimeGraphContainer extends React.Component<ReactTimeGraphConta
     }
 
     componentWillUnmount(): void {
-        if (this.container) {
-            this.container.destroy();
-        }
         if (this._resizeHandler) {
             this.props.removeWidgetResizeHandler(this._resizeHandler);
+        }
+    }
+
+    destroyContainer(): void {
+        if (this.container) {
+            this.container.destroy();
         }
     }
 


### PR DESCRIPTION
Introduced a new signal to indicate that the data on the server has been updated and therefore the components should refetch the data and rerender the components. This PR handles the signal in table-output-component and timegraph-output-component. We have a use case where data is modified on the server, and we want the components to rerender with the new data. Currently, the user would have to close the active trace panel and reopen it to see the changes.