### PR TITLE
Use 'traceviewer-base/lib' instead of 'traceviewer-base/src'

### DIFF
--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -13,7 +13,7 @@ import { EntryTree } from './utils/filter-tree/entry-tree';
 import { XyEntry, XYSeries } from 'tsp-typescript-client/lib/models/xy';
 import * as React from 'react';
 import { flushSync } from 'react-dom';
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { BIMath } from 'timeline-chart/lib/bigint-utils';
 import {
     XYChartFactoryParams,

--- a/packages/react-components/src/components/utils/xy-output-component-utils.tsx
+++ b/packages/react-components/src/components/utils/xy-output-component-utils.tsx
@@ -1,4 +1,4 @@
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { AbstractOutputProps } from '../abstract-output-component';
 
 export interface XYChartFactoryParams {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -14,7 +14,7 @@ import {
     FLAG_ZOOM_OUT,
     MouseButton
 } from './abstract-xy-output-component';
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { validateNumArray } from './utils/filter-tree/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';

--- a/packages/react-components/src/components/xy-output-overview-component.tsx
+++ b/packages/react-components/src/components/xy-output-overview-component.tsx
@@ -2,7 +2,7 @@ import { AbstractOutputProps } from './abstract-output-component';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import * as React from 'react';
 import { drawSelection } from './utils/xy-output-component-utils';
-import { TimeRange } from 'traceviewer-base/src/utils/time-range';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { AbstractXYOutputState, MouseButton } from './abstract-xy-output-component';
 import {
     AbstractXYOutputComponent,


### PR DESCRIPTION
Some traceviewer-base imports still use the src directory instead of lib. This commit fixes this.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>