### PR TITLE
Move MaterialUI to proper package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@mui/material": "^5.10.14",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6"
   }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.17 <1.3.0",
     "@fortawesome/free-solid-svg-icons": "^5.8.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
+    "@mui/material": "^5.10.14",
     "@vscode/codicons": "^0.0.29",
     "ag-grid-community": "^28.2.0",
     "ag-grid-react": "^28.2.0",


### PR DESCRIPTION
MaterialUI was installed in the top-level node_modules.  It's moved to the correct one in /packages/react-components/ where it's used.

This may fix eclipse-cdt-cloud/vscode-trace-extension/issues/175 according to this [stackoverflow thread](https://stackoverflow.com/questions/72413194/uncaught-typeerror-cannot-read-properties-of-null-reading-usecontext).

Signed-off-by: Will Yang <william.yang@ericsson.com>