### PR TITLE
Upgrade tsp-typescript-client to 0.4.0-next.20231003144311.a5128df.0

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
+++ b/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
@@ -15,6 +15,8 @@ import { EntryModel } from 'tsp-typescript-client/lib/models/entry';
 import { OutputStyleModel } from 'tsp-typescript-client/lib/models/styles';
 import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
 import { DataTreeEntry } from 'tsp-typescript-client/lib/models/data-tree';
+import { ConfigurationSourceType } from 'tsp-typescript-client/lib/models/configuration-source';
+import { Configuration } from 'tsp-typescript-client/lib/models/configuration';
 
 export const TspClientProxy = Symbol('TspClientProxy') as symbol & interfaces.Abstract<TspClientProxy>;
 export type TspClientProxy = ITspClient;
@@ -367,5 +369,82 @@ export class TheiaRpcTspProxy implements ITspClient {
      */
     public async checkHealth(): Promise<TspClientResponse<HealthStatus>> {
         return this.toTspClientResponse<HealthStatus>(await this.tspClient.checkHealth());
+    }
+
+    /**
+     * Fetch all configuration source types
+     * @returns Generic response with the model
+     */
+    public async fetchConfigurationSourceTypes(): Promise<TspClientResponse<ConfigurationSourceType[]>> {
+        return this.toTspClientResponse<ConfigurationSourceType[]>(
+            await this.tspClient.fetchConfigurationSourceTypes()
+        );
+    }
+
+    /**
+     * Fetch configuration source type for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @returns Generic response with the model
+     */
+    public async fetchConfigurationSourceType(typeId: string): Promise<TspClientResponse<ConfigurationSourceType>> {
+        return this.toTspClientResponse<ConfigurationSourceType>(
+            await this.tspClient.fetchConfigurationSourceType(typeId)
+        );
+    }
+
+    /**
+     * Fetch all configurations for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @returns Generic response with the model
+     */
+    public async fetchConfigurations(typeId: string): Promise<TspClientResponse<Configuration[]>> {
+        return this.toTspClientResponse<Configuration[]>(await this.tspClient.fetchConfigurations(typeId));
+    }
+
+    /**
+     * Fetch a configuration by ID for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @returns Generic response with the model
+     */
+    public async fetchConfiguration(typeId: string, configId: string): Promise<TspClientResponse<Configuration>> {
+        return this.toTspClientResponse<Configuration>(await this.tspClient.fetchConfiguration(typeId, configId));
+    }
+
+    /**
+     * Create a configuration for a given type ID and parameters
+     * @param typeId the ID of the configuration source type
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async createConfiguration(typeId: string, parameters: Query): Promise<TspClientResponse<Configuration>> {
+        return this.toTspClientResponse<Configuration>(await this.tspClient.createConfiguration(typeId, parameters));
+    }
+
+    /**
+     * Update a configuration for a given type ID, config ID and parameters
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    public async updateConfiguration(
+        typeId: string,
+        configId: string,
+        parameters: Query
+    ): Promise<TspClientResponse<Configuration>> {
+        return this.toTspClientResponse<Configuration>(
+            await this.tspClient.updateConfiguration(typeId, configId, parameters)
+        );
+    }
+
+    /**
+     * Delete a configuration for a given type ID and config ID
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @returns Generic response with the model
+     */
+    public async deleteConfiguration(typeId: string, configId: string): Promise<TspClientResponse<Configuration>> {
+        return this.toTspClientResponse<Configuration>(await this.tspClient.deleteConfiguration(typeId, configId));
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13765,9 +13765,9 @@ tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsp-typescript-client@next:
-  version "0.4.0-next.20230814204256.d8f8dcc.0"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.20230814204256.d8f8dcc.0.tgz#e50283e12188d9a78fb68d100dcf706a7d400005"
-  integrity sha512-lzfZIPHiHHiEoNM7luYArQ0+lpDAZPtyyN3WjmSXFwd648o+FNu2+sdvGu37ZBnvWn+Yt9vexq/f+vZwIhSU9A==
+  version "0.4.0-next.20231003144311.a5128df.0"
+  resolved "https://registry.npmjs.org/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.20231003144311.a5128df.0.tgz#6048ed21c3d22d501c372a8968b6779ddc7727f2"
+  integrity sha512-ymRdsIYvOahHCieNuaGIQ925tvNbwB5bYG8ZbhN6ECaWH197Hzwb8rzmwMfTxxNkywtcsOnLLOKIExaLaDUPyw==
   dependencies:
     json-bigint sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473
     node-fetch "^2.5.0"


### PR DESCRIPTION
This includes the new configuration end-points. Add implementations of the new methods to theia-rpc-tsp-proxy.ts.

See also:
- https://github.com/eclipse-cdt-cloud/tsp-typescript-client/pull/87
- https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/92
- https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/93

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>