### PR TITLE
Call TSP endpoint to close an experiment when closing it in the UI

### DIFF
--- a/packages/base/src/experiment-manager.ts
+++ b/packages/base/src/experiment-manager.ts
@@ -122,6 +122,17 @@ export class ExperimentManager {
     }
 
     /**
+     * Close the given experiment from the server
+     * @param experimentUUID experiment UUID
+     */
+    async closeExperiment(experimentUUID: string): Promise<void> {
+        const experimentToDelete = this.fOpenExperiments.get(experimentUUID);
+        if (experimentToDelete) {
+            await this.fTspClient.closeExperiment(experimentUUID);
+        }
+    }
+
+    /**
      * Delete the given experiment from the server
      * @param experimentUUID experiment UUID
      */

--- a/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
+++ b/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
@@ -113,6 +113,15 @@ export class TheiaRpcTspProxy implements ITspClient {
     }
 
     /**
+     * Close an experiment
+     * @param expUUID Experiment UUID to close
+     * @returns The closed experiment
+     */
+    public async closeExperiment(expUUID: string): Promise<TspClientResponse<Experiment>> {
+        return this.toTspClientResponse<Experiment>(await this.tspClient.closeExperiment(expUUID));
+    }
+
+    /**
      * Delete an experiment on the server
      * @param expUUID Experiment UUID to delete
      * @returns The deleted experiment

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget.tsx
@@ -67,11 +67,12 @@ export class TraceExplorerOpenedTracesWidget extends ReactWidget {
 
     public closeExperiment(traceUUID: string): void {
         signalManager().fireCloseTraceViewerTabSignal(traceUUID);
+        this._experimentManager.closeExperiment(traceUUID);
     }
 
     public deleteExperiment(traceUUID: string): void {
-        this._experimentManager.deleteExperiment(traceUUID);
         this.closeExperiment(traceUUID);
+        this._experimentManager.deleteExperiment(traceUUID);
     }
 
     render(): React.ReactNode {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -349,6 +349,7 @@ export class TraceViewerWidget extends ReactWidget implements StatefulWidget {
         super.onCloseRequest(msg);
         if (this.openedExperiment) {
             signalManager().fireExperimentClosedSignal(this.openedExperiment);
+            this.experimentManager.closeExperiment(this.openedExperiment.UUID);
         }
     }
 


### PR DESCRIPTION
With this it's possible to close an experiment on the server. Upon reception of the command the server can dispose allocated resources hence the client doesn't need them anymore.

This change follows the TSP update provided by:
https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/95

Fixes #1024

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>