### PR TITLE
docker: fix and improve docker example

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,18 +1,38 @@
-FROM node:16-alpine
+FROM node:16.20.2-bookworm-slim as build
 
-RUN mkdir /home/app
-WORKDIR /home/app
-
-RUN apk add --no-cache bash git python3 make pkgconfig libsecret-dev g++
-# Use "bash" as replacement for "sh"
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN apt-get update && apt-get install -y \
+    git \
+    python3 \
+    make \
+    pkg-config \
+    libsecret-1-dev \
+    g++ \
+    libx11-dev \
+    libxkbfile-dev
 
 # Build the browser theia-trace-extension application
-COPY example-package.json /home/app/package.json
-RUN npx yarn
+COPY example-package.json /app/tte/package.json
+WORKDIR /app/tte/
+RUN yarn && \
+    npx theia build --app-target=\"browser\" --mode development && \
+    yarn autoclean --init && \
+    echo *.ts >> .yarnclean && \
+    echo *.ts.map >> .yarnclean && \
+    echo *.spec.* >> .yarnclean && \
+    yarn cache clean
 
-COPY startup.sh /home/app
-RUN ["chmod", "+x", "/home/app/startup.sh"]
+FROM node:16.20.2-bookworm-slim
 
-# Start the service
-ENTRYPOINT ["/home/app/startup.sh"]
+COPY --from=build /app/tte /app/tte
+
+RUN apt-get update && apt-get install -y \
+    libx11-6 \
+    libxkbfile1 \
+    libsecret-1-0 \
+    && rm -rf /var/lib/apt/lists/*
+ENV NODE_ENV production
+
+WORKDIR /app/tte
+COPY docker-entrypoint.sh /usr/local/bin
+EXPOSE 4000
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -9,8 +9,8 @@ Notes:
   If you want to run a complete application, you will need a service
   running the trace-server (not included here);
 
-- the image will be built using the latest [npm package] of the
-  theia-trace-extension, and not the code in this repo;
+- the image will be built using a specific [npm package] of the
+  theia-trace-extension, and not the latest code in this repo;
 
 - the *example-package.json* file is not named *package.json* because
   at the time this change was proposed building the theia-trace-extension
@@ -20,7 +20,8 @@ Notes:
 
 ## How to build and run
 
-Build the image and name it *tte*:
+Build the image and name it *tte*. Try adding `--network host` in case
+of build failures related to debian packages retrieval:
 
 ```bash
 docker build -t tte .

--- a/examples/docker/docker-entrypoint.sh
+++ b/examples/docker/docker-entrypoint.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+yarn start --hostname 0.0.0.0 --port 4000

--- a/examples/docker/example-package.json
+++ b/examples/docker/example-package.json
@@ -15,6 +15,9 @@
     }
   },
   "dependencies": {
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
+    "@mui/material": "^5.10.14",
     "@theia/core": "1.43.1",
     "@theia/editor": "1.43.1",
     "@theia/filesystem": "1.43.1",
@@ -27,9 +30,8 @@
     "@theia/preferences": "1.43.1",
     "@theia/process": "1.43.1",
     "@theia/terminal": "1.43.1",
-    "@theia/vsx-registry": "1.43.1",
     "@theia/workspace": "1.43.1",
-    "theia-traceviewer": "next"
+    "theia-traceviewer": "0.2.0-next.20231206220005.ff0943f.0"
   },
   "devDependencies": {
     "@theia/cli": "1.43.1"
@@ -42,6 +44,5 @@
   "engines": {
     "yarn": "1.0.x || >=1.2.1",
     "node": ">=12.14.1 <17"
-  },
-  "theiaPluginsDir": "../plugins"
+  }
 }

--- a/examples/docker/startup.sh
+++ b/examples/docker/startup.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd /home/app
-npx yarn start --hostname 0.0.0.0 --port 4000


### PR DESCRIPTION
Before this commit the docker example was not properly building. The issue was introduced when moving from Theia 1.3x to 1.4x, where an extra step in the build process was introduced (i.e. running "yarn" was not enough, an extra "theia" command was needed).

After this commit:
- the docker example is building again
- the docker image generated is stable and reproducible, not based on "next"
- the docker image is much smaller thanks to a multistage build