### PR TITLE
Check-in updated yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9795,10 +9795,9 @@ jsesc@~0.5.0:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
-"json-bigint@github:sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473":
+json-bigint@sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473:
   version "1.0.0"
-  resolved "git+ssh://git@github.com/sidorares/json-bigint.git#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
-  integrity sha512-gwIzA5y/ka8GA+JW4APGVAE/AU/txxYgwZ9c+b+rnBA/NH9E9bfJB4HbyqP3Imk99R6ZFGME4X1JGcdGIcjtag==
+  resolved "https://codeload.github.com/sidorares/json-bigint/tar.gz/2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
   dependencies:
     bignumber.js "^9.0.0"
 


### PR DESCRIPTION
Check-in updated yarn.lock, which I think I missed in the last PR. ATM, this prevents the publish workflow from working: 

https://github.com/eclipse-cdt-cloud/theia-trace-extension/actions/runs/7702565918/job/20991122775#step:5:13

