### PR TITLE
Add Server Offline Landing to Placeholder Widget

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -48,6 +48,7 @@ export interface TraceContextProps {
     removeResizeHandler: (handler: () => void) => void;
     backgroundTheme: string;
     persistedState?: PersistedState;
+    serverStatus?: boolean;
 }
 
 export interface TraceContextState {
@@ -491,20 +492,29 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     }
 
     render(): JSX.Element {
+        const { serverStatus } = this.props;
         const shouldRenderOutputs =
             this.state.style.width > 0 && (this.props.outputs.length || this.props.overviewDescriptor);
         return (
-            <div
-                className="trace-context-container"
-                onContextMenu={event => this.onContextMenu(event)}
-                onKeyDown={event => this.onKeyDown(event)}
-                onKeyUp={event => this.onKeyUp(event)}
-                ref={this.traceContextContainer}
-            >
-                <TooltipComponent ref={this.tooltipComponent} />
-                <TooltipXYComponent ref={this.tooltipXYComponent} />
-                {shouldRenderOutputs ? this.renderOutputs() : this.renderPlaceHolder()}
-            </div>
+            <>
+                {/* Render the grey-out overlay if the server is down */}
+                {serverStatus === false && (
+                    <div className="overlay">
+                        <div className="warning-text">Please reconnect to resume using the application.</div>
+                    </div>
+                )}
+                <div
+                    className="trace-context-container"
+                    onContextMenu={event => this.onContextMenu(event)}
+                    onKeyDown={event => this.onKeyDown(event)}
+                    onKeyUp={event => this.onKeyUp(event)}
+                    ref={this.traceContextContainer}
+                >
+                    <TooltipComponent ref={this.tooltipComponent} />
+                    <TooltipXYComponent ref={this.tooltipXYComponent} />
+                    {shouldRenderOutputs ? this.renderOutputs() : this.renderPlaceHolder()}
+                </div>
+            </>
         );
     }
 

--- a/packages/react-components/src/trace-explorer/trace-explorer-placeholder-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-placeholder-widget.tsx
@@ -4,28 +4,38 @@ import * as React from 'react';
 
 export interface ReactPlaceholderWidgetProps {
     loading: boolean;
+    serverOn: boolean;
+    tracesOpen: boolean;
     handleOpenTrace: () => void;
+    handleStartServer: () => void;
 }
 
-export class ReactExplorerPlaceholderWidget extends React.Component<ReactPlaceholderWidgetProps, unknown> {
+export class ReactExplorerPlaceholderWidget extends React.Component<ReactPlaceholderWidgetProps, {}> {
     constructor(props: ReactPlaceholderWidgetProps) {
         super(props);
     }
 
     render(): React.ReactNode {
+        const { loading, serverOn, handleOpenTrace, handleStartServer } = this.props;
+        const onClick = serverOn ? handleOpenTrace : handleStartServer;
+        const infoText = serverOn
+            ? 'You have not yet opened a trace.'
+            : 'No trace server instance is currently running.';
+        const buttonText = serverOn ? 'Open Trace' : 'Start Trace Server';
+
         return (
             <div className="placeholder-container" tabIndex={0}>
-                <div className="center">{'You have not yet opened a trace.'}</div>
+                <div className="center">{infoText}</div>
                 <div className="placeholder-open-workspace-button-container">
                     <button
                         className="plcaeholder-open-workspace-button"
-                        title="Select a trace to open"
-                        onClick={this.props.handleOpenTrace}
-                        disabled={this.props.loading}
+                        title={buttonText}
+                        onClick={onClick}
+                        disabled={loading}
                     >
-                        {this.props.loading && <FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />}
-                        {this.props.loading && <span>Connecting to trace server</span>}
-                        {!this.props.loading && <span>Open Trace</span>}
+                        {loading && <FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />}
+                        {loading && <span>Connecting to trace server</span>}
+                        {!loading && <span>{buttonText}</span>}
                     </button>
                 </div>
             </div>

--- a/packages/react-components/src/trace-explorer/trace-explorer-placeholder-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-placeholder-widget.tsx
@@ -21,7 +21,7 @@ export class ReactExplorerPlaceholderWidget extends React.Component<ReactPlaceho
         const infoText = serverOn
             ? 'You have not yet opened a trace.'
             : 'No trace server instance is currently running.';
-        const buttonText = serverOn ? 'Open Trace' : 'Start Trace Server';
+        const buttonText = serverOn ? 'Open Trace' : 'Resume Trace Extension';
 
         return (
             <div className="placeholder-container" tabIndex={0}>

--- a/packages/react-components/style/trace-viewer.css
+++ b/packages/react-components/style/trace-viewer.css
@@ -14,3 +14,23 @@ div {
     margin: 0px 5px 0px 5px;
     height: 100%;
 }
+
+/* Grey out container */
+.overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent black */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 999; /* Ensure the overlay appears on top */
+}
+  
+.warning-text {
+    color: white; /* Color of the warning text */
+    text-align: center;
+    font-size: 24px;
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-placeholder-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-placeholder-widget.tsx
@@ -2,8 +2,9 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import { ReactWidget } from '@theia/core/lib/browser';
 import * as React from 'react';
 import { CommandService } from '@theia/core';
-import { OpenTraceCommand } from '../../trace-viewer/trace-viewer-commands';
+import { OpenTraceCommand, StartServerCommand } from '../../trace-viewer/trace-viewer-commands';
 import { ReactExplorerPlaceholderWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-placeholder-widget';
+import { TraceServerConnectionStatusClient } from '../../../common/trace-server-connection-status';
 
 @injectable()
 export class TraceExplorerPlaceholderWidget extends ReactWidget {
@@ -11,10 +12,14 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
     static LABEL = 'Trace Explorer Placeholder Widget';
 
     state = {
-        loading: false
+        loading: false,
+        serverStatus: false,
+        tracesOpened: false
     };
 
     @inject(CommandService) protected readonly commandService!: CommandService;
+    @inject(TraceServerConnectionStatusClient)
+    protected traceServerConnectionStatusProxy: TraceServerConnectionStatusClient;
 
     @postConstruct()
     protected init(): void {
@@ -23,10 +28,17 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
         this.update();
     }
 
+    dispose(): void {
+        super.dispose();
+    }
+
     render(): React.ReactNode {
-        const { loading } = this.state;
+        const { loading, serverStatus, tracesOpened } = this.state;
         return (
             <ReactExplorerPlaceholderWidget
+                tracesOpen={tracesOpened}
+                serverOn={serverStatus}
+                handleStartServer={this.handleStartServer}
                 loading={loading}
                 handleOpenTrace={this.handleOpenTrace}
             ></ReactExplorerPlaceholderWidget>
@@ -41,5 +53,20 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
         await this.commandService.executeCommand(OpenTraceCommand.id);
         this.state.loading = false;
         this.update();
+    }
+
+    protected handleStartServer = async (): Promise<void> => this.doHandleStartServer();
+
+    private async doHandleStartServer() {
+        this.state.loading = true;
+        this.update();
+        await this.commandService.executeCommand(StartServerCommand.id);
+        this.state.loading = false;
+        this.update();
+    }
+
+    public setStateAndShow(newState: { serverStatus: boolean; tracesOpened: boolean }): void {
+        this.state = { ...newState, ...this.state };
+        this.show();
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-placeholder-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-placeholder-widget.tsx
@@ -66,7 +66,8 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
     }
 
     public setStateAndShow(newState: { serverStatus: boolean; tracesOpened: boolean }): void {
-        this.state = { ...newState, ...this.state };
+        this.state = { ...this.state, ...newState };
         this.show();
+        this.update();
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
@@ -7,6 +7,7 @@ import { CommandService } from '@theia/core';
 export class TraceExplorerServerStatusWidget extends ReactWidget {
     static ID = 'trace-explorer-server-status-widget';
     static LABEL = 'Trace Explorer Server Status Widget';
+    private serverOn = false;
 
     @inject(CommandService) protected readonly commandService!: CommandService;
 
@@ -17,16 +18,24 @@ export class TraceExplorerServerStatusWidget extends ReactWidget {
         this.update();
     }
 
+    public updateStatus = (status: boolean): void => {
+        this.serverOn = status;
+        this.update();
+    };
+
     render(): React.ReactNode {
+        const className = this.serverOn ? 'fa fa-check-circle-o fa-lg' : 'fa fa-times-circle-o fa-lg';
+
+        const title = this.serverOn
+            ? 'Server health and latency are good. No known issues'
+            : 'Trace Viewer Critical Error: Trace Server Offline';
+
+        const color = this.serverOn ? 'green' : 'red';
+
         return (
             <div className="server-status-header">
                 <span className="theia-header">Server Status </span>
-                <i
-                    id="server-status-id"
-                    className="fa fa-times-circle-o fa-lg"
-                    title="Trace Viewer Critical Error: Trace Server Offline"
-                    style={{ color: 'red', marginLeft: '5px' }}
-                />
+                <i id="server-status-id" className={className} title={title} style={{ color, marginLeft: '5px' }} />
             </div>
         );
     }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -137,5 +137,6 @@ export class TraceExplorerWidget extends BaseWidget {
 
     protected doHandleOnServerStatusChange(status: boolean): void {
         this.serverStatusWidget.updateStatus(status);
+        this.update();
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -24,9 +24,9 @@ import { TracePreferences, TRACE_PATH, TRACE_ARGS } from '../trace-server-prefer
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { ChartShortcutsDialog } from '../trace-explorer/trace-explorer-sub-widgets/charts-cheatsheet-component';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import { TraceServerConnectionStatusClientImpl } from '../trace-server-connection-status-client-impl';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { ITspClient } from 'tsp-typescript-client';
+import { TraceServerConnectionStatusClient } from '../../common/trace-server-connection-status';
 
 interface TraceViewerWidgetOpenerOptions extends WidgetOpenerOptions {
     traceUUID: string;
@@ -50,6 +50,8 @@ export class TraceViewerContribution
     @inject(TracePreferences) protected tracePreferences: TracePreferences;
     @inject(TraceServerConfigService) protected readonly traceServerConfigService: TraceServerConfigService;
     @inject(MessageService) protected readonly messageService: MessageService;
+    @inject(TraceServerConnectionStatusClient)
+    protected readonly serverStatusService: TraceServerConnectionStatusClient;
 
     readonly id = TraceViewerWidget.ID;
     readonly label = 'Trace Viewer';
@@ -94,7 +96,7 @@ export class TraceViewerContribution
                         progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                     }
                     progress.cancel();
-                    TraceServerConnectionStatusClientImpl.renderStatus(true);
+                    this.serverStatusService.updateStatus(true);
                     signalManager().fireTraceServerStartedSignal();
                     this.openDialog(rootPath);
                 }
@@ -163,7 +165,7 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
-                        TraceServerConnectionStatusClientImpl.renderStatus(true);
+                        this.serverStatusService.updateStatus(true);
                         signalManager().fireTraceServerStartedSignal();
                         return super.open(traceURI, options);
                     }
@@ -230,7 +232,7 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
-                        TraceServerConnectionStatusClientImpl.renderStatus(true);
+                        this.serverStatusService.updateStatus(true);
                         signalManager().fireTraceServerStartedSignal();
                         return;
                     }
@@ -261,7 +263,7 @@ export class TraceViewerContribution
                 try {
                     await this.traceServerConfigService.stopTraceServer();
                     this.messageService.info('Trace server terminated successfully.');
-                    TraceServerConnectionStatusClientImpl.renderStatus(false);
+                    this.serverStatusService.updateStatus(false);
                 } catch (err) {
                     this.messageService.error('Failed to stop the trace server.');
                 }

--- a/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
@@ -31,9 +31,23 @@ export interface TraceServerConnectionStatusClient {
     /**
      * Subscribe this client to the connection status
      */
-    addConnectionStatusListener(): void;
+    activate(): void;
     /**
      * Unsubscribe this client from the connection status
      */
-    removeConnectionStatusListener(): void;
+    deactivate(): void;
+
+    /**
+     * Adds event listener for server status change
+     * @param fn event listener
+     */
+    addServerStatusChangeListener(fn: (status: boolean) => void): void;
+
+    /**
+     * Removes event listener for server status change.
+     * @param fn event listener to be removed
+     */
+    removeServerStatusChangeListener(fn: (status: boolean) => void): void;
+
+    status: boolean;
 }


### PR DESCRIPTION
Adds a prompt to start the server when the front-end detects that there is no server currently running.  This provides a clearer application flow for the user.

Starting a server that has no traces stored.

[Starting a server that has no traces stored.](https://github.com/eclipse-cdt-cloud/theia-trace-extension/assets/98342456/f749e3ae-a264-4ee3-85a2-7c5f1f7644f9)

Starting a server with traces stored.

[Starting a server with traces stored.](https://github.com/eclipse-cdt-cloud/theia-trace-extension/assets/98342456/0247f5bf-14b2-4036-a5bb-e07b018adb59)

Signed-off-by: Will Yang <william.yang@ericsson.com>