### PR TITLE
Add support for multi row select and context menu in Timegraph Component

### DIFF
--- a/packages/base/src/signals/context-menu-contributed-signal-payload.tsx
+++ b/packages/base/src/signals/context-menu-contributed-signal-payload.tsx
@@ -1,0 +1,41 @@
+/***************************************************************************************
+ * Copyright (c) 2024 BlackBerry Limited and contributors.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ ***************************************************************************************/
+export interface MenuItem {
+    id: string;
+    label: string;
+    // Parent Menu that this item belongs to - undefined indicates root menu item
+    parentMenuId?: string;
+}
+
+export interface SubMenu {
+    id: string;
+    label: string;
+    items: MenuItem[];
+    submenu: SubMenu | undefined;
+}
+
+export interface ContextMenuItems {
+    submenus: SubMenu[];
+    items: MenuItem[];
+}
+
+export class ContextMenuContributedSignalPayload {
+    private outputDescriptorId: string;
+    private menuItems: ContextMenuItems;
+
+    constructor(descriptorId: string, menuItems: ContextMenuItems) {
+        this.outputDescriptorId = descriptorId;
+        this.menuItems = menuItems;
+    }
+
+    public getOutputDescriptorId(): string {
+        return this.outputDescriptorId;
+    }
+
+    public getMenuItems(): ContextMenuItems {
+        return this.menuItems;
+    }
+}

--- a/packages/base/src/signals/context-menu-item-clicked-signal-payload.tsx
+++ b/packages/base/src/signals/context-menu-item-clicked-signal-payload.tsx
@@ -1,0 +1,35 @@
+/***************************************************************************************
+ * Copyright (c) 2024 BlackBerry Limited and contributors.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ ***************************************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export class ContextMenuItemClickedSignalPayload {
+    private outputDescriptorId: string;
+    private itemId: string;
+    private parentMenuId: string | undefined;
+    private props: { [key: string]: any };
+
+    constructor(descriptorId: string, itemId: string, props: { [key: string]: any }, parentMenuId?: string) {
+        this.outputDescriptorId = descriptorId;
+        this.itemId = itemId;
+        this.props = props;
+        this.parentMenuId = parentMenuId;
+    }
+
+    public getOutputDescriptorId(): string {
+        return this.outputDescriptorId;
+    }
+
+    public getItemId(): string {
+        return this.itemId;
+    }
+
+    public getProps(): { [key: string]: any } {
+        return this.props;
+    }
+
+    public getParentMenuId(): string | undefined {
+        return this.parentMenuId;
+    }
+}

--- a/packages/base/src/signals/row-selections-changed-signal-payload.tsx
+++ b/packages/base/src/signals/row-selections-changed-signal-payload.tsx
@@ -1,0 +1,33 @@
+/***************************************************************************************
+ * Copyright (c) 2024 BlackBerry Limited and contributors.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ ***************************************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export class RowSelectionsChangedSignalPayload {
+    private traceId: string;
+    private outputDescriptorId: string;
+    private rows: { id: number; parentId?: number; metadata?: { [key: string]: any } }[];
+
+    constructor(
+        traceId: string,
+        descriptorId: string,
+        rows: { id: number; parentId?: number; metadata?: { [key: string]: any } }[]
+    ) {
+        this.outputDescriptorId = descriptorId;
+        this.traceId = traceId;
+        this.rows = rows;
+    }
+
+    public getOutputDescriptorId(): string {
+        return this.outputDescriptorId;
+    }
+
+    public getTraceId(): string {
+        return this.traceId;
+    }
+
+    public getRows(): { id: number; parentId?: number; metadata?: { [key: string]: any } }[] {
+        return this.rows;
+    }
+}

--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -5,6 +5,9 @@ import { Trace } from 'tsp-typescript-client/lib/models/trace';
 import { OpenedTracesUpdatedSignalPayload } from './opened-traces-updated-signal-payload';
 import { OutputAddedSignalPayload } from './output-added-signal-payload';
 import { TimeRangeUpdatePayload } from './time-range-data-signal-payloads';
+import { ContextMenuContributedSignalPayload } from './context-menu-contributed-signal-payload';
+import { ContextMenuItemClickedSignalPayload } from './context-menu-item-clicked-signal-payload';
+import { RowSelectionsChangedSignalPayload } from './row-selections-changed-signal-payload';
 
 export declare interface SignalManager {
     fireTraceOpenedSignal(trace: Trace): void;
@@ -20,6 +23,7 @@ export declare interface SignalManager {
     fireThemeChangedSignal(theme: string): void;
     // TODO - Refactor or remove this signal.  Similar signal to fireRequestSelectionRangeChange
     fireSelectionChangedSignal(payload: { [key: string]: string }): void;
+    fireRowSelectionsChanged(payload: RowSelectionsChangedSignalPayload): void;
     fireCloseTraceViewerTabSignal(traceUUID: string): void;
     fireTraceViewerTabActivatedSignal(experiment: Experiment): void;
     fireUpdateZoomSignal(hasZoomedIn: boolean): void;
@@ -41,6 +45,8 @@ export declare interface SignalManager {
     fireSelectionRangeUpdated(payload: TimeRangeUpdatePayload): void;
     fireViewRangeUpdated(payload: TimeRangeUpdatePayload): void;
     fireRequestSelectionRangeChange(payload: TimeRangeUpdatePayload): void;
+    fireContributeContextMenu(payload: ContextMenuContributedSignalPayload): void;
+    fireContextMenuItemClicked(payload: ContextMenuItemClickedSignalPayload): void;
 }
 
 export const Signals = {
@@ -57,6 +63,7 @@ export const Signals = {
     ITEM_PROPERTIES_UPDATED: 'item properties updated',
     THEME_CHANGED: 'theme changed',
     SELECTION_CHANGED: 'selection changed',
+    ROW_SELECTIONS_CHANGED: 'rows selected changed',
     CLOSE_TRACEVIEWERTAB: 'tab closed',
     TRACEVIEWERTAB_ACTIVATED: 'widget activated',
     UPDATE_ZOOM: 'update zoom',
@@ -75,7 +82,9 @@ export const Signals = {
     VIEW_RANGE_UPDATED: 'view range updated',
     SELECTION_RANGE_UPDATED: 'selection range updated',
     REQUEST_SELECTION_RANGE_CHANGE: 'change selection range',
-    OUTPUT_DATA_CHANGED: 'output data changed'
+    OUTPUT_DATA_CHANGED: 'output data changed',
+    CONTRIBUTE_CONTEXT_MENU: 'contribute context menu',
+    CONTEXT_MENU_ITEM_CLICKED: 'context menu item clicked'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -96,6 +105,10 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireExperimentSelectedSignal(experiment: Experiment | undefined): void {
         this.emit(Signals.EXPERIMENT_SELECTED, experiment);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fireRowSelectionsChanged(payload: RowSelectionsChangedSignalPayload): void {
+        this.emit(Signals.ROW_SELECTIONS_CHANGED, payload);
     }
     fireExperimentUpdatedSignal(experiment: Experiment): void {
         this.emit(Signals.EXPERIMENT_UPDATED, experiment);
@@ -173,6 +186,12 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireRequestSelectionRangeChange(payload: TimeRangeUpdatePayload): void {
         this.emit(Signals.REQUEST_SELECTION_RANGE_CHANGE, payload);
+    }
+    fireContributeContextMenu(payload: ContextMenuContributedSignalPayload): void {
+        this.emit(Signals.CONTRIBUTE_CONTEXT_MENU, payload);
+    }
+    fireContextMenuItemClicked(payload: ContextMenuItemClickedSignalPayload): void {
+        this.emit(Signals.CONTEXT_MENU_ITEM_CLICKED, payload);
     }
 }
 

--- a/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
@@ -11,10 +11,12 @@ interface EntryTreeProps {
     showCheckboxes: boolean;
     showCloseIcons: boolean;
     selectedRow?: number;
+    multiSelectedRows?: number[];
     collapsedNodes: number[];
     showFilter: boolean;
     onToggleCheck: (ids: number[]) => void;
     onRowClick: (id: number) => void;
+    onMultipleRowClick?: (id: number, isShiftClicked?: boolean) => void;
     onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
     onClose: (id: number) => void;
     onToggleCollapse: (id: number, nodes: TreeNode[]) => void;
@@ -43,7 +45,8 @@ export class EntryTree extends React.Component<EntryTreeProps> {
         this.props.checkedSeries !== nextProps.checkedSeries ||
         this.props.entries !== nextProps.entries ||
         this.props.collapsedNodes !== nextProps.collapsedNodes ||
-        this.props.selectedRow !== nextProps.selectedRow;
+        this.props.selectedRow !== nextProps.selectedRow ||
+        this.props.multiSelectedRows !== nextProps.multiSelectedRows;
 
     render(): JSX.Element {
         return <FilterTree nodes={listToTree(this.props.entries, this.props.headers)} {...this.props} />;

--- a/packages/react-components/src/components/utils/filter-tree/table-body.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-body.tsx
@@ -5,12 +5,14 @@ import { TableRow } from './table-row';
 interface TableBodyProps {
     nodes: TreeNode[];
     selectedNode?: number;
+    multiSelectedNodes?: number[];
     collapsedNodes: number[];
     isCheckable: boolean;
     isClosable: boolean;
     getCheckedStatus: (id: number) => number;
     onToggleCollapse: (id: number) => void;
     onRowClick: (id: number) => void;
+    onMultipleRowClick?: (id: number, isShiftClicked?: boolean) => void;
     onClose: (id: number) => void;
     onToggleCheck: (id: number) => void;
     onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;

--- a/packages/react-components/src/components/utils/filter-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-row.tsx
@@ -8,6 +8,7 @@ interface TableRowProps {
     node: TreeNode;
     level: number;
     selectedRow?: number;
+    multiSelectedRows?: number[];
     collapsedNodes: number[];
     isCheckable: boolean;
     isClosable: boolean;
@@ -16,6 +17,7 @@ interface TableRowProps {
     onClose: (id: number) => void;
     onToggleCheck: (id: number) => void;
     onRowClick: (id: number) => void;
+    onMultipleRowClick?: (id: number, isShiftClicked?: boolean) => void;
     onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
 }
 
@@ -89,9 +91,14 @@ export class TableRow extends React.Component<TableRowProps> {
         return undefined;
     };
 
-    onClick = (): void => {
-        const { node, onRowClick } = this.props;
-        if (onRowClick) {
+    onClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+        const { node, onRowClick, onMultipleRowClick } = this.props;
+
+        if (onMultipleRowClick && e.ctrlKey) {
+            onMultipleRowClick(node.id, false);
+        } else if (onMultipleRowClick && e.shiftKey) {
+            onMultipleRowClick(node.id, true);
+        } else {
             onRowClick(node.id);
         }
     };
@@ -108,16 +115,22 @@ export class TableRow extends React.Component<TableRowProps> {
             return undefined;
         }
         const children = this.renderChildren();
-        const { node, selectedRow } = this.props;
-        const className = selectedRow === node.id ? 'selected' : '';
+        const { node, selectedRow, multiSelectedRows } = this.props;
+        let className = '';
 
-        return (
-            <React.Fragment>
-                <tr className={className} onClick={this.onClick} onContextMenu={this.onContextMenu}>
-                    {this.renderRow()}
-                </tr>
-                {children}
-            </React.Fragment>
-        );
+        if (selectedRow === node.id || multiSelectedRows?.includes(node.id)) {
+            className = 'selected';
+        }
+
+        {
+            return (
+                <React.Fragment>
+                    <tr className={className} onClick={this.onClick} onContextMenu={this.onContextMenu}>
+                        {this.renderRow()}
+                    </tr>
+                    {children}
+                </React.Fragment>
+            );
+        }
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/table.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table.tsx
@@ -8,11 +8,13 @@ import ColumnHeader from './column-header';
 interface TableProps {
     nodes: TreeNode[];
     selectedRow?: number;
+    multiSelectedRows?: number[];
     collapsedNodes: number[];
     isCheckable: boolean;
     isClosable: boolean;
     sortConfig: SortConfig[];
     onRowClick: (id: number) => void;
+    onMultipleRowClick?: (id: number, isShiftClicked?: boolean) => void;
     onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
     getCheckedStatus: (id: number) => number;
     onToggleCollapse: (id: number) => void;

--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -16,9 +16,11 @@ interface FilterTreeProps {
     checkedSeries: number[]; // Optional
     collapsedNodes: number[];
     selectedRow?: number;
+    multiSelectedRows?: number[];
     onToggleCheck: (ids: number[]) => void; // Optional
     onClose: (id: number) => void;
     onRowClick: (id: number) => void;
+    onMultipleRowClick?: (id: number, isShiftClicked?: boolean) => void;
     onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
     onToggleCollapse: (id: number, nodes: TreeNode[]) => void;
     onOrderChange: (ids: number[]) => void;
@@ -269,6 +271,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
         <Table
             nodes={nodes}
             selectedRow={this.props.selectedRow}
+            multiSelectedRows={this.props.multiSelectedRows}
             collapsedNodes={this.props.collapsedNodes}
             isCheckable={this.props.showCheckboxes}
             isClosable={this.props.showCloseIcons}
@@ -277,6 +280,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             onToggleCollapse={this.handleCollapse}
             onToggleCheck={this.handleCheck}
             onRowClick={this.props.onRowClick}
+            onMultipleRowClick={this.props.onMultipleRowClick}
             onContextMenu={this.props.onContextMenu}
             onClose={this.handleClose}
             onSort={this.handleOrderChange}

--- a/packages/react-components/src/trace-explorer/trace-explorer-sub-widgets/time-graph-navigation-shortcuts-table.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-sub-widgets/time-graph-navigation-shortcuts-table.tsx
@@ -39,6 +39,16 @@ export class TimeGraphShortcutsTable extends React.Component {
                                         <span className="shortcuts-table-keybinding-key">,</span>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <td>Multi-Select</td>
+                                    <td className="shortcuts-table-keybinding">
+                                        <span className="shortcuts-table-keybinding-key">Ctrl</span>
+                                        <span className="shortcuts-table-keybinding-key">Click</span>
+                                        <span>or</span>
+                                        <span className="shortcuts-table-keybinding-key">Shift</span>
+                                        <span className="shortcuts-table-keybinding-key">Click</span>
+                                    </td>
+                                </tr>
                             </tbody>
                         </table>
                     </div>

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -239,6 +239,10 @@ canvas {
     background-color: var(--trace-viewer-selection-background) !important;
 }
 
+.table-tree tr.multiselected td {
+    background-color: var(--trace-viewer-list-hoverBackground) !important;
+}
+
 .resize-handle {
     float: right;
     position: absolute;

--- a/packages/react-components/style/react-contextify.css
+++ b/packages/react-components/style/react-contextify.css
@@ -10,7 +10,7 @@
     box-shadow: 0px 10px 30px -5px rgba(0, 0, 0, 0.3);
     border-radius: 6px;
     padding: 6px 0;
-    min-width: 200px;
+    min-width: 150px;
     z-index: 100;
   }
   .react-contexify__submenu--is-open, .react-contexify__submenu--is-open > .react-contexify__item__content {


### PR DESCRIPTION
Changes made:
- Support for adding context menu via signals
- Support for making multiple selections in data tree of timegraph component
- Added Signals to notify context menu selection and multi row selections

This change will allow for a context menu to be added to the timegraph component based on the outputDescriptor id via a signal. The component also adds the ability to select multiple rows. The multi selections can be passed with the item clicked signal payload as well as through a rowSelectionsChanged signal. The end goal is to provide the timegraph views with the ability to make multi-row selections and perform some actions with the selections.

Signed-off-by: Neel Gondalia ngondalia@blackberry.com