### PR TITLE
[Theia v1.45.1] update trace extension used in docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !examples/*/package.json
 !examples/*/resources/
 !examples/*/scripts/
+!examples/docker/
 *.log
 *.tsbuildinfo
 .browser_modules/

--- a/examples/docker/example-package.json
+++ b/examples/docker/example-package.json
@@ -31,7 +31,7 @@
     "@theia/process": "1.45.1",
     "@theia/terminal": "1.45.1",
     "@theia/workspace": "1.45.1",
-    "theia-traceviewer": "0.2.0-next.20231206220005.ff0943f.0"
+    "theia-traceviewer": "0.2.0-next.20240229144356.c22cb2c.0"
   },
   "devDependencies": {
     "@theia/cli": "1.45.1"


### PR DESCRIPTION
Follow-up, after updating to Theia 1.45.1. Update the specific version of the trace extension that's used in the docker image example.