### PR TITLE
Refactor Connection Status Logic

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-server-status-widget.tsx
@@ -7,6 +7,7 @@ import { CommandService } from '@theia/core';
 export class TraceExplorerServerStatusWidget extends ReactWidget {
     static ID = 'trace-explorer-server-status-widget';
     static LABEL = 'Trace Explorer Server Status Widget';
+    private serverOn = false;
 
     @inject(CommandService) protected readonly commandService!: CommandService;
 
@@ -17,16 +18,22 @@ export class TraceExplorerServerStatusWidget extends ReactWidget {
         this.update();
     }
 
+    public updateStatus = (status: boolean): void => {
+        this.serverOn = status;
+        this.update();
+    };
+
     render(): React.ReactNode {
+        const className = this.serverOn ? 'fa fa-check-circle-o fa-lg' : 'fa fa-times-circle-o fa-lg';
+        const title = this.serverOn
+            ? 'Server health and latency are good. No known issues'
+            : 'Trace Viewer Critical Error: Trace Server Offline';
+        const color = this.serverOn ? 'green' : 'red';
+
         return (
             <div className="server-status-header">
                 <span className="theia-header">Server Status </span>
-                <i
-                    id="server-status-id"
-                    className="fa fa-times-circle-o fa-lg"
-                    title="Trace Viewer Critical Error: Trace Server Offline"
-                    style={{ color: 'red', marginLeft: '5px' }}
-                />
+                <i id="server-status-id" className={className} title={title} style={{ color, marginLeft: '5px' }} />
             </div>
         );
     }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -102,7 +102,7 @@ export class TraceExplorerWidget extends BaseWidget {
 
     protected onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
-        if (this._numberOfOpenedTraces > 0) {
+        if (this._numberOfOpenedTraces > 0 && this.connectionStatusClient.getStatus() === true) {
             this.traceViewsContainer.show();
             this.placeholderWidget.hide();
         } else {

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -115,12 +115,12 @@ export class TraceExplorerWidget extends BaseWidget {
     }
 
     protected async onAfterShow(): Promise<void> {
-        this.connectionStatusClient.addConnectionStatusListener();
+        this.connectionStatusClient.activate();
         const status = await this.traceServerConnectionStatusProxy.getStatus();
         this.connectionStatusClient.updateStatus(status);
     }
 
     protected onAfterHide(): void {
-        this.connectionStatusClient.removeConnectionStatusListener();
+        this.connectionStatusClient.deactivate();
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -83,12 +83,14 @@ export class TraceExplorerWidget extends BaseWidget {
         layout.addWidget(this.traceViewsContainer);
         this.node.tabIndex = 0;
         signalManager().on(Signals.OPENED_TRACES_UPDATED, this.onUpdateSignal);
+        this.connectionStatusClient.addServerStatusChangeListener(this.onServerStatusChange);
         this.update();
     }
 
     dispose(): void {
         super.dispose();
         signalManager().off(Signals.OPENED_TRACES_UPDATED, this.onUpdateSignal);
+        this.connectionStatusClient.removeServerStatusChangeListener(this.onServerStatusChange);
     }
 
     protected onUpdateSignal = (payload: OpenedTracesUpdatedSignalPayload): void =>
@@ -122,5 +124,12 @@ export class TraceExplorerWidget extends BaseWidget {
 
     protected onAfterHide(): void {
         this.connectionStatusClient.deactivate();
+    }
+
+    protected onServerStatusChange = (status: boolean): void => this.doHandleOnServerStatusChange(status);
+
+    protected doHandleOnServerStatusChange(status: boolean): void {
+        this.serverStatusWidget.updateStatus(status);
+        this.update();
     }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
@@ -38,16 +38,4 @@ export class TraceServerConnectionStatusClientImpl implements TraceServerConnect
     getStatus(): boolean {
         return this.lastStatus;
     }
-
-    static renderStatus(status: boolean): void {
-        if (document.getElementById('server-status-id')) {
-            document.getElementById('server-status-id')!.className = status
-                ? 'fa fa-check-circle-o fa-lg'
-                : 'fa fa-times-circle-o fa-lg';
-            document.getElementById('server-status-id')!.title = status
-                ? 'Server health and latency are good. No known issues'
-                : 'Trace Viewer Critical Error: Trace Server Offline';
-            document.getElementById('server-status-id')!.style.color = status ? 'green' : 'red';
-        }
-    }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
@@ -12,11 +12,11 @@ export class TraceServerConnectionStatusClientImpl implements TraceServerConnect
         }
     }
 
-    addConnectionStatusListener(): void {
+    activate(): void {
         this.active = true;
     }
 
-    removeConnectionStatusListener(): void {
+    deactivate(): void {
         this.active = false;
     }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
@@ -2,13 +2,17 @@
 import { injectable } from 'inversify';
 import { TraceServerConnectionStatusClient } from '../common/trace-server-connection-status';
 
+type Listener = (serverStatus: boolean) => void;
 @injectable()
 export class TraceServerConnectionStatusClientImpl implements TraceServerConnectionStatusClient {
     protected active = false;
+    protected lastStatus = false;
+    protected listeners: Listener[] = [];
 
     updateStatus(status: boolean): void {
         if (this.active) {
-            TraceServerConnectionStatusClientImpl.renderStatus(status);
+            this.lastStatus = status;
+            this.listeners.forEach(listener => listener(status));
         }
     }
 
@@ -18,6 +22,21 @@ export class TraceServerConnectionStatusClientImpl implements TraceServerConnect
 
     deactivate(): void {
         this.active = false;
+    }
+
+    addServerStatusChangeListener(listener: Listener): void {
+        this.listeners.push(listener);
+    }
+
+    removeServerStatusChangeListener(listener: Listener): void {
+        const index = this.listeners.indexOf(listener);
+        if (index) {
+            this.listeners.splice(index, 1);
+        }
+    }
+
+    getStatus(): boolean {
+        return this.lastStatus;
     }
 
     static renderStatus(status: boolean): void {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -24,7 +24,7 @@ import { TracePreferences, TRACE_PATH, TRACE_ARGS } from '../trace-server-prefer
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { ChartShortcutsDialog } from '../trace-explorer/trace-explorer-sub-widgets/charts-cheatsheet-component';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import { TraceServerConnectionStatusClientImpl } from '../trace-server-connection-status-client-impl';
+import { TraceServerConnectionStatusClient } from '../../common/trace-server-connection-status';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { ITspClient } from 'tsp-typescript-client';
 
@@ -50,6 +50,8 @@ export class TraceViewerContribution
     @inject(TracePreferences) protected tracePreferences: TracePreferences;
     @inject(TraceServerConfigService) protected readonly traceServerConfigService: TraceServerConfigService;
     @inject(MessageService) protected readonly messageService: MessageService;
+    @inject(TraceServerConnectionStatusClient)
+    protected readonly serverStatusService: TraceServerConnectionStatusClient;
 
     readonly id = TraceViewerWidget.ID;
     readonly label = 'Trace Viewer';
@@ -94,7 +96,7 @@ export class TraceViewerContribution
                         progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                     }
                     progress.cancel();
-                    TraceServerConnectionStatusClientImpl.renderStatus(true);
+                    this.serverStatusService.updateStatus(true);
                     signalManager().fireTraceServerStartedSignal();
                     this.openDialog(rootPath);
                 }
@@ -163,7 +165,7 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
-                        TraceServerConnectionStatusClientImpl.renderStatus(true);
+                        this.serverStatusService.updateStatus(true);
                         signalManager().fireTraceServerStartedSignal();
                         return super.open(traceURI, options);
                     }
@@ -230,7 +232,7 @@ export class TraceViewerContribution
                         } else {
                             progress.report({ message: 'Trace server started.', work: { done: 100, total: 100 } });
                         }
-                        TraceServerConnectionStatusClientImpl.renderStatus(true);
+                        this.serverStatusService.updateStatus(true);
                         signalManager().fireTraceServerStartedSignal();
                         return;
                     }
@@ -261,7 +263,7 @@ export class TraceViewerContribution
                 try {
                     await this.traceServerConfigService.stopTraceServer();
                     this.messageService.info('Trace server terminated successfully.');
-                    TraceServerConnectionStatusClientImpl.renderStatus(false);
+                    this.serverStatusService.updateStatus(false);
                 } catch (err) {
                     this.messageService.error('Failed to stop the trace server.');
                 }

--- a/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
@@ -31,9 +31,9 @@ export interface TraceServerConnectionStatusClient {
     /**
      * Subscribe this client to the connection status
      */
-    addConnectionStatusListener(): void;
+    activate(): void;
     /**
      * Unsubscribe this client from the connection status
      */
-    removeConnectionStatusListener(): void;
+    deactivate(): void;
 }

--- a/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-connection-status.ts
@@ -36,4 +36,21 @@ export interface TraceServerConnectionStatusClient {
      * Unsubscribe this client from the connection status
      */
     deactivate(): void;
+
+    /**
+     * Adds event listener for server status change
+     * @param fn event listener
+     */
+    addServerStatusChangeListener(fn: (status: boolean) => void): void;
+
+    /**
+     * Removes event listener for server status change.
+     * @param fn event listener to be removed
+     */
+    removeServerStatusChangeListener(fn: (status: boolean) => void): void;
+
+    /**
+     * Get the status of the server
+     */
+    getStatus(): boolean;
 }


### PR DESCRIPTION
This is to improve the tracking of TraceServer status state in the application.  This will support the implementation of the remote use case in the vscode-trace-extension.

This change consists of four commits:

1) **Rename subscription events in Connection client**
'addConnectionStatusListener' changed to 'activate'
'removeConnectionStatusListener' changed to 'deactivate'
This is more accurate.

2) **Add Server Status Change Listeners**
Adds methods to add and remove functions that are executed when the
server status is updated.

3) **Remove Direct DOM Manipulation from ServerStatusWidget**
Removes direct DOM manipulation from TraceExplorerServerStatusWidget.
Refactors it to use the server status change event listeners and change
what is rendered through Theia ReactWidget's component lifecycle.

4) **Check Server Status On Update**
Check the server status every update in the trace-explorer-widget.
This ensures that the 'Open Trace' placeholder widget is displayed
when the server is offline, not just when there are no opened traces.

Signed-off-by: Will Yang <william.yang@ericsson.com>