### PR TITLE
[viewer-prototype] Use Theia re-export rather than importing inversify directly

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/preferences-frontend-contribution.ts
@@ -1,5 +1,5 @@
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { PortPreferenceProxy, TRACE_VIEWER_DEFAULT_PORT } from '../common/trace-server-url-provider';
 import { TracePreferences, TRACE_PORT } from './trace-server-preference';
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-connection-status-client-impl.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { injectable } from 'inversify';
+import { injectable } from '@theia/core/shared/inversify';
 import { TraceServerConnectionStatusClient } from '../common/trace-server-connection-status';
 
 type Listener = (serverStatus: boolean) => void;

--- a/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/tsp-client-provider-impl.ts
@@ -1,4 +1,4 @@
-import { injectable, inject } from 'inversify';
+import { injectable, inject } from '@theia/core/shared/inversify';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';

--- a/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server-connection-status-backend-impl.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { injectable } from '@theia/core/shared/inversify';
 import { RestClient } from 'tsp-typescript-client/lib/protocol/rest-client';
 import {
     TraceServerConnectionStatusBackend,

--- a/theia-extensions/viewer-prototype/src/node/trace-server-url-provider-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server-url-provider-impl.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { TraceServerConfigService } from '../common/trace-server-config';
 import {
     TraceServerUrlProvider,


### PR DESCRIPTION
This way, we re-use inversify through @theia/core, rather than importing it without declaring it as a dependency in our package.json (i.e. implicit dependency).

This also follows Theia's guidance regarding using their re-exports:
https://github.com/eclipse-theia/theia/tree/master/packages/core#re-exports-mechanism