### PR TITLE
Update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,11 +411,12 @@ yarn version:minor
 yarn version:patch
 ```
 
-Modify the _version tag_ in file `./RELEASE`, to match the new release. Then amend the release commit to include this change:
+Modify the _version tag_ in file `./RELEASE`, to match the new release, and similarly update the requested version for the `theia-traceviewer` dependency in both the browser and electron example applications (`examples/electron/package.json` and `examples/browser/package.json`)
+
+Then amend the release commit to include these changes:
 
 ```bash
-<edit ./RELEASES to update tag>
-git add RELEASE && git commit --amend
+git add RELEASE examples/electron/package.json examples/browser/package.json && git commit --amend
 ```
 
 Finally, push the branch and use it to create a PR. When the PR is merged, a GitHub release should be created with auto-generated release notes, as well as a git tag. Then the `publish-latest` CI job should trigger and if everything goes well, publish the new version of the repo's packages to `npm`.


### PR DESCRIPTION
During the recent first automated release, we [noticed that there's an extra step](https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1058#issuecomment-2013137494) to be done in this repository: the requested version of "theia-traceviewer" needs to be updated in the example applications.

I think this does not happen automatically, even though the example applications are part of the lerna workspace,  because of our current .gitignore file, which ignores these folders.