### PR TITLE
[examples] "Git ignore" strategy change: blanket ignore -> granular ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
 # LC_COLLATE=C sort .gitignore
-!examples/*/electron-builder.yml
-!examples/*/package.json
-!examples/*/resources/
-!examples/*/scripts/
-!examples/docker/
 *.log
 *.tsbuildinfo
 .browser_modules/
@@ -13,9 +8,12 @@
 /packages/react-components/lib/
 TraceCompassTutorialTraces
 TraceCompassTutorialTraces.tgz
-examples/*
+examples/*/gen-webpack.*
+examples/*/lib
+examples/*/src-gen
+examples/electron/dist/
+license-check-summary.txt*
 node_modules/
 theia-extensions/viewer-prototype/lib/
 trace-compass-server
 trace-compass-server.tar.gz
-license-check-summary.txt*

--- a/README.md
+++ b/README.md
@@ -411,12 +411,11 @@ yarn version:minor
 yarn version:patch
 ```
 
-Modify the _version tag_ in file `./RELEASE`, to match the new release, and similarly update the requested version for the `theia-traceviewer` dependency in both the browser and electron example applications (`examples/electron/package.json` and `examples/browser/package.json`)
-
-Then amend the release commit to include these changes:
+Modify the _version tag_ in file `./RELEASE`, to match the new release. Then amend the release commit to include this change:
 
 ```bash
-git add RELEASE examples/electron/package.json examples/browser/package.json && git commit --amend
+<edit ./RELEASES to update tag>
+git add RELEASE && git commit --amend
 ```
 
 Finally, push the branch and use it to create a PR. When the PR is merged, a GitHub release should be created with auto-generated release notes, as well as a git tag. Then the `publish-latest` CI job should trigger and if everything goes well, publish the new version of the repo's packages to `npm`.

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,49 +1,49 @@
 {
-  "private": true,
-  "name": "browser-theia-trace-example-app",
-  "version": "0.1.0",
-  "theia": {
-    "target": "browser",
-    "frontend": {
-      "config": {
-        "applicationName": "Theia-Trace Example Application",
-        "preferences": {
-          "editor.autoSave": "on",
-          "trace-viewer.port": 8080
+    "private": true,
+    "name": "browser-theia-trace-example-app",
+    "version": "0.1.0",
+    "theia": {
+        "target": "browser",
+        "frontend": {
+            "config": {
+                "applicationName": "Theia-Trace Example Application",
+                "preferences": {
+                    "editor.autoSave": "on",
+                    "trace-viewer.port": 8080
+                }
+            }
         }
-      }
-    }
-  },
-  "dependencies": {
-    "@theia/core": "1.45.1",
-    "@theia/editor": "1.45.1",
-    "@theia/filesystem": "1.45.1",
-    "@theia/getting-started": "1.45.1",
-    "@theia/keymaps": "1.45.1",
-    "@theia/markers": "1.45.1",
-    "@theia/messages": "1.45.1",
-    "@theia/monaco": "1.45.1",
-    "@theia/navigator": "1.45.1",
-    "@theia/preferences": "1.45.1",
-    "@theia/process": "1.45.1",
-    "@theia/terminal": "1.45.1",
-    "@theia/vsx-registry": "1.45.1",
-    "@theia/workspace": "1.45.1",
-    "theia-traceviewer": "0.2.0"
-  },
-  "devDependencies": {
-    "@theia/cli": "1.45.1"
-  },
-  "scripts": {
-    "prepare": "yarn build",
-    "build": "theia build --mode development",
-    "rebuild": "theia rebuild:browser --cacheRoot ../..",
-    "start": "TRACE_SERVER_PATH=../../trace-compass-server/tracecompass-server theia start --plugins=local-dir:../plugins",
-    "watch": "theia build --watch --mode development"
-  },
-  "engines": {
-    "yarn": ">=1.7.0 <2",
-    "node": ">=16 <19"
-  },
-  "theiaPluginsDir": "../plugins"
+    },
+    "dependencies": {
+        "@theia/core": "1.45.1",
+        "@theia/editor": "1.45.1",
+        "@theia/filesystem": "1.45.1",
+        "@theia/getting-started": "1.45.1",
+        "@theia/keymaps": "1.45.1",
+        "@theia/markers": "1.45.1",
+        "@theia/messages": "1.45.1",
+        "@theia/monaco": "1.45.1",
+        "@theia/navigator": "1.45.1",
+        "@theia/preferences": "1.45.1",
+        "@theia/process": "1.45.1",
+        "@theia/terminal": "1.45.1",
+        "@theia/vsx-registry": "1.45.1",
+        "@theia/workspace": "1.45.1",
+        "theia-traceviewer": "0.2.0"
+    },
+    "devDependencies": {
+        "@theia/cli": "1.45.1"
+    },
+    "scripts": {
+        "prepare": "yarn build",
+        "build": "theia build --mode development",
+        "rebuild": "theia rebuild:browser --cacheRoot ../..",
+        "start": "TRACE_SERVER_PATH=../../trace-compass-server/tracecompass-server theia start --plugins=local-dir:../plugins",
+        "watch": "theia build --watch --mode development"
+    },
+    "engines": {
+        "yarn": ">=1.7.0 <2",
+        "node": ">=16 <19"
+    },
+    "theiaPluginsDir": "../plugins"
 }

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -1,69 +1,69 @@
 {
-  "private": true,
-  "name": "electron-theia-trace-example-app",
-  "main": "scripts/theia-trace-main.js",
-  "version": "0.1.0",
-  "author": {
-    "name": "Trace Compass",
-    "email": "tracecompass-dev@eclipse.org"
-  },
-  "theia": {
-    "target": "electron",
-    "backend": {
-      "config": {
-        "startupTimeout": -1
-      }
+    "private": true,
+    "name": "electron-theia-trace-example-app",
+    "main": "scripts/theia-trace-main.js",
+    "version": "0.1.0",
+    "author": {
+        "name": "Trace Compass",
+        "email": "tracecompass-dev@eclipse.org"
     },
-    "frontend": {
-      "config": {
-        "applicationName": "Theia-Trace Example Application",
-        "preferences": {
-          "editor.autoSave": "on",
-          "trace-viewer.port": 8080
+    "theia": {
+        "target": "electron",
+        "backend": {
+            "config": {
+                "startupTimeout": -1
+            }
+        },
+        "frontend": {
+            "config": {
+                "applicationName": "Theia-Trace Example Application",
+                "preferences": {
+                    "editor.autoSave": "on",
+                    "trace-viewer.port": 8080
+                }
+            }
         }
-      }
-    }
-  },
-  "dependencies": {
-    "@theia/core": "1.45.1",
-    "@theia/editor": "1.45.1",
-    "@theia/electron": "1.45.1",
-    "@theia/filesystem": "1.45.1",
-    "@theia/getting-started": "1.45.1",
-    "@theia/keymaps": "1.45.1",
-    "@theia/markers": "1.45.1",
-    "@theia/messages": "1.45.1",
-    "@theia/monaco": "1.45.1",
-    "@theia/navigator": "1.45.1",
-    "@theia/preferences": "1.45.1",
-    "@theia/process": "1.45.1",
-    "@theia/terminal": "1.45.1",
-    "@theia/vsx-registry": "1.45.1",
-    "@theia/workspace": "1.45.1",
-    "theia-traceviewer": "0.2.0"
-  },
-  "devDependencies": {
-    "@theia/cli": "1.45.1",
-    "electron": "^23.2.4",
-    "electron-builder": "~23.6.0"
-  },
-  "scripts": {
-    "prepare": "yarn build",
-    "build": "theia build --mode development",
-    "rebuild": "theia rebuild:electron --cacheRoot ../..",
-    "start": "TRACE_SERVER_PATH=../../trace-compass-server/tracecompass-server theia start --plugins=local-dir:../plugins",
-    "watch": "theia build --watch --mode development",
-    "clean:dist": "rimraf dist",
-    "package": "yarn clean:dist && yarn rebuild && electron-builder",
-    "package:preview": "yarn clean:dist && yarn rebuild && electron-builder --dir"
-  },
-  "engines": {
-    "yarn": ">=1.7.0 <2",
-    "node": ">=16 <19"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension"
-  },
-  "theiaPluginsDir": "../plugins"
+    },
+    "dependencies": {
+        "@theia/core": "1.45.1",
+        "@theia/editor": "1.45.1",
+        "@theia/electron": "1.45.1",
+        "@theia/filesystem": "1.45.1",
+        "@theia/getting-started": "1.45.1",
+        "@theia/keymaps": "1.45.1",
+        "@theia/markers": "1.45.1",
+        "@theia/messages": "1.45.1",
+        "@theia/monaco": "1.45.1",
+        "@theia/navigator": "1.45.1",
+        "@theia/preferences": "1.45.1",
+        "@theia/process": "1.45.1",
+        "@theia/terminal": "1.45.1",
+        "@theia/vsx-registry": "1.45.1",
+        "@theia/workspace": "1.45.1",
+        "theia-traceviewer": "0.2.0"
+    },
+    "devDependencies": {
+        "@theia/cli": "1.45.1",
+        "electron": "^23.2.4",
+        "electron-builder": "~23.6.0"
+    },
+    "scripts": {
+        "prepare": "yarn build",
+        "build": "theia build --mode development",
+        "rebuild": "theia rebuild:electron --cacheRoot ../..",
+        "start": "TRACE_SERVER_PATH=../../trace-compass-server/tracecompass-server theia start --plugins=local-dir:../plugins",
+        "watch": "theia build --watch --mode development",
+        "clean:dist": "rimraf dist",
+        "package": "yarn clean:dist && yarn rebuild && electron-builder",
+        "package:preview": "yarn clean:dist && yarn rebuild && electron-builder --dir"
+    },
+    "engines": {
+        "yarn": ">=1.7.0 <2",
+        "node": ">=16 <19"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/eclipse-cdt-cloud/theia-trace-extension"
+    },
+    "theiaPluginsDir": "../plugins"
 }


### PR DESCRIPTION
This PR reverts the recent change in release/publish documentation. It's no longer necessary to manually handle the update of version of "theia-traceviewer" for the browser and electron examples, with the change in "git ignore" strategy, that's also included in this PR (separate commit). 

Until now, the example applications were ignored by default, with a few files having exceptions. This had a non-obvious side-affect when using `lerna version`, which would then ignores these folders even if they are part of the lerna workspace. This resulted in our root package.json "version:<*>" "scripts" entries, not updating the version of the "theia-traceviewer" dependency in the examples package.json, which we then had to do manually. 

See below for a test run of "yarn version:major" that shows that, with this change,  the examples applications are now handled automatically:

```bash
theia-trace-extension$ yarn version:major
yarn run v1.22.21
$ lerna version major --exact --no-push --git-tag-command /usr/bin/true --yes -m "Release %s (Major)"
lerna notice cli v7.4.2
lerna info current version 0.2.0
lerna info Looking for changed packages since v0.1.0

Changes:
 - browser-theia-trace-example-app: 0.1.0 => 1.0.0 (private)
 - electron-theia-trace-example-app: 0.1.0 => 1.0.0 (private)
 - traceviewer-base: 0.2.0 => 1.0.0
 - traceviewer-react-components: 0.2.0 => 1.0.0
 - theia-traceviewer: 0.2.0 => 1.0.0
```
Corresponding "diff" for one example package.json:
```diff
diff --git a/examples/browser/package.json b/examples/browser/package.json
index 1b45638..2cbba3b 100644
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "browser-theia-trace-example-app",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "theia": {
         "target": "browser",
         "frontend": {
@@ -29,7 +29,7 @@
         "@theia/terminal": "1.45.1",
         "@theia/vsx-registry": "1.45.1",
         "@theia/workspace": "1.45.1",
-        "theia-traceviewer": "0.2.0"
+        "theia-traceviewer": "1.0.0"
     },
     "devDependencies": {
         "@theia/cli": "1.45.1"

```