### PR TITLE
Add Critical path configuration menu and critical path view

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -47,6 +47,7 @@ export declare interface SignalManager {
     fireRequestSelectionRangeChange(payload: TimeRangeUpdatePayload): void;
     fireContributeContextMenu(payload: ContextMenuContributedSignalPayload): void;
     fireContextMenuItemClicked(payload: ContextMenuItemClickedSignalPayload): void;
+    fireTraceContexModelUpdated(payload: { [key: string]: unknown }): void;
 }
 
 export const Signals = {
@@ -84,7 +85,8 @@ export const Signals = {
     REQUEST_SELECTION_RANGE_CHANGE: 'change selection range',
     OUTPUT_DATA_CHANGED: 'output data changed',
     CONTRIBUTE_CONTEXT_MENU: 'contribute context menu',
-    CONTEXT_MENU_ITEM_CLICKED: 'context menu item clicked'
+    CONTEXT_MENU_ITEM_CLICKED: 'context menu item clicked',
+    TRACE_MODEL_UPDATED: 'trace model updated'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -192,6 +194,9 @@ export class SignalManager extends EventEmitter implements SignalManager {
     }
     fireContextMenuItemClicked(payload: ContextMenuItemClickedSignalPayload): void {
         this.emit(Signals.CONTEXT_MENU_ITEM_CLICKED, payload);
+    }
+    fireTraceContexModelUpdated(payload: { [key: string]: unknown }): void {
+        this.emit(Signals.TRACE_MODEL_UPDATED, payload);
     }
 }
 

--- a/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
+++ b/theia-extensions/viewer-prototype/src/browser/theia-rpc-tsp-proxy.ts
@@ -220,6 +220,23 @@ export class TheiaRpcTspProxy implements ITspClient {
     }
 
     /**
+     * Fetch Time Graph tree, Model is a key-value map
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Time graph entry response with model is a key-value map
+     */
+    public async fetchTimeGraphTreeContext(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: unknown }>>> {
+        return this.toTspClientResponse<GenericResponse<{ [key: string]: unknown }>>(
+            await this.tspClient.fetchTimeGraphTreeContext(expUUID, outputID, parameters)
+        );
+    }
+
+    /**
      * Fetch Time Graph states. Model extends TimeGraphModel
      * @param expUUID Experiment UUID
      * @param outputID Output ID


### PR DESCRIPTION
Note that code is hard-coded. A generic way is needed to configure
the menu and command-handler driven by the server.

Alternatively, this feature could be added in a third-party, trace
compass specific front-end extension(s) (i.e. Theia extension/Vscode
extension).

Requires: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/pull/104​

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>