### PR TITLE
Add webpack.config.js to docker example

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 
 # Build the browser theia-trace-extension application
 COPY example-package.json /app/tte/package.json
+COPY webpack.config.js /app/tte/webpack.config.js
 WORKDIR /app/tte/
 RUN yarn && \
     npx theia build --app-target=\"browser\" --mode production && \

--- a/examples/docker/webpack.config.js
+++ b/examples/docker/webpack.config.js
@@ -1,0 +1,25 @@
+/**
+ * This file can be edited to customize webpack configuration.
+ * To reset delete this file and rerun theia build again.
+ */
+// @ts-check
+const config = require('./gen-webpack.config.js');
+const webpack = require("webpack");
+
+
+/**
+ * Expose bundled modules on window.theia.moduleName namespace, e.g.
+ * window['theia']['@theia/core/lib/common/uri'].
+ * Such syntax can be used by external code, for instance, for testing.
+config.module.rules.push({
+    test: /\.js$/,
+    loader: require.resolve('@theia/application-manager/lib/expose-loader')
+}); */
+
+config[0].plugins.push(new webpack.DefinePlugin({
+  'process.env': {
+    NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
+  }
+}));
+
+module.exports = config;


### PR DESCRIPTION
Add webpack.config.js to example docker image. 

Some views like statistics view have features to right-click on the entries and select time ranges, but this feature requires some Node.js-specific features like "process", which is missing for the docker example.

Fixes #1066

Signed-off-by: Siwei Zhang <siwei.zhang@ericsson.com>