### PR TITLE
Release v0.2.1 (Patch)

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.2.0
+tag: v0.2.1
 
 commitInclude:
   parentOfMergeCommit: true

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "browser-theia-trace-example-app",
-    "version": "0.1.0",
+    "version": "0.2.1",
     "theia": {
         "target": "browser",
         "frontend": {
@@ -29,7 +29,7 @@
         "@theia/terminal": "1.45.1",
         "@theia/vsx-registry": "1.45.1",
         "@theia/workspace": "1.45.1",
-        "theia-traceviewer": "0.2.0"
+        "theia-traceviewer": "0.2.1"
     },
     "devDependencies": {
         "@theia/cli": "1.45.1"

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "electron-theia-trace-example-app",
     "main": "scripts/theia-trace-main.js",
-    "version": "0.1.0",
+    "version": "0.2.1",
     "author": {
         "name": "Trace Compass",
         "email": "tracecompass-dev@eclipse.org"
@@ -40,7 +40,7 @@
         "@theia/terminal": "1.45.1",
         "@theia/vsx-registry": "1.45.1",
         "@theia/workspace": "1.45.1",
-        "theia-traceviewer": "0.2.0"
+        "theia-traceviewer": "0.2.1"
     },
     "devDependencies": {
         "@theia/cli": "1.45.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
     "lerna": "7.3.0",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "npmClient": "yarn",
     "command": {
         "run": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "traceviewer-base",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Trace Viewer base package, contains trace management utilities",
     "license": "MIT",
     "repository": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "traceviewer-react-components",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Trace Compass react components",
     "license": "MIT",
     "repository": {
@@ -36,7 +36,7 @@
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^0.86.0",
         "timeline-chart": "^0.3.1",
-        "traceviewer-base": "0.2.0",
+        "traceviewer-base": "0.2.1",
         "tsp-typescript-client": "^0.4.1"
     },
     "devDependencies": {

--- a/playwright-tests/package.json
+++ b/playwright-tests/package.json
@@ -1,31 +1,31 @@
 {
-  "private": true,
-  "name": "theia-playwright-tests",
-  "version": "1.36.0",
-  "license": "EPL-2.0",
-  "scripts": {
-    "prepare": "yarn clean && yarn build && yarn lint",
-    "clean": "rimraf lib tsconfig.tsbuildinfo",
-    "build": "tsc --incremental && npx playwright install chromium",
-    "lint": "eslint -c ./.eslintrc.js --ext .ts ./tests",
-    "lint:fix": "eslint -c ./.eslintrc.js --ext .ts ./tests --fix",
-    "ui-tests": "yarn && playwright test",
-    "ui-tests-report-generate": "allure generate ./allure-results --clean -o allure-results/allure-report",
-    "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report"
-  },
-  "dependencies": {
-    "@playwright/test": "^1.32.1",
-    "@theia/playwright": "1.47.1"
-  },
-  "devDependencies": {
-    "@typescript-eslint/parser": "^5.57.1",
-    "@typescript-eslint/eslint-plugin": "^5.57.1",
-    "allure-commandline": "^2.21.0",
-    "allure-playwright": "^2.1.0",
-    "eslint": "^8.37.0",
-    "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-import": "^2.27.5",
-    "rimraf": "^2.6.1",
-    "typescript": "~4.5.5"
-  }
+    "private": true,
+    "name": "theia-playwright-tests",
+    "version": "0.2.1",
+    "license": "EPL-2.0",
+    "scripts": {
+        "prepare": "yarn clean && yarn build && yarn lint",
+        "clean": "rimraf lib tsconfig.tsbuildinfo",
+        "build": "tsc --incremental && npx playwright install chromium",
+        "lint": "eslint -c ./.eslintrc.js --ext .ts ./tests",
+        "lint:fix": "eslint -c ./.eslintrc.js --ext .ts ./tests --fix",
+        "ui-tests": "yarn && playwright test",
+        "ui-tests-report-generate": "allure generate ./allure-results --clean -o allure-results/allure-report",
+        "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report"
+    },
+    "dependencies": {
+        "@playwright/test": "^1.32.1",
+        "@theia/playwright": "1.47.1"
+    },
+    "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.57.1",
+        "@typescript-eslint/parser": "^5.57.1",
+        "allure-commandline": "^2.21.0",
+        "allure-playwright": "^2.1.0",
+        "eslint": "^8.37.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "rimraf": "^2.6.1",
+        "typescript": "~4.5.5"
+    }
 }

--- a/theia-extensions/viewer-prototype/package.json
+++ b/theia-extensions/viewer-prototype/package.json
@@ -1,6 +1,6 @@
 {
     "name": "theia-traceviewer",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A Trace Viewer for Theia applications, in the form of a Theia extension",
     "keywords": [
         "theia-extension"
@@ -24,8 +24,8 @@
         "@theia/editor": "1.45.1",
         "@theia/filesystem": "1.45.1",
         "animate.css": "^4.1.1",
-        "traceviewer-base": "0.2.0",
-        "traceviewer-react-components": "0.2.0",
+        "traceviewer-base": "0.2.1",
+        "traceviewer-react-components": "0.2.1",
         "tree-kill": "latest"
     },
     "devDependencies": {


### PR DESCRIPTION
Trigger a patch release (V0.2.1) so that the npm packages in this repo, that we recently updated to use solid revisions of our own-produced dependencies (published as "latest" to npm vs "next") are used. 

Note: the playwright folder's package.json got reformatted by "lerna version"- it's a one-time thing - now that it's done in this commit, next release only the version number should be updated.