### PR TITLE
Don't trigger keyboard shortcuts when typing

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -509,6 +509,14 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     }
 
     private onKeyDown(event: React.KeyboardEvent) {
+        if (
+            document.activeElement &&
+            (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA')
+        ) {
+            // User is typing in an input field, ignore the shortcut
+            return;
+        }
+
         switch (event.key) {
             case '+':
             case '=': {


### PR DESCRIPTION
This fixes a bug.  When a user is typing in a search box or search box, some keyboard shortcuts were triggering.

Adds a check to 'onKeyDown' event handler that checks if the user is focused on an input or textinput field.  If true, does not proceed with executing keyboard shortcuts.

Signed-off-by: William Yang <william.yang@ericsson.com>