### PR TITLE
Initialize view range and render time charts during trace indexing

### DIFF
--- a/packages/react-components/src/components/abstract-xy-output-component.tsx
+++ b/packages/react-components/src/components/abstract-xy-output-component.tsx
@@ -25,6 +25,7 @@ import { ChartOptions } from 'chart.js';
 import { Line, Scatter } from 'react-chartjs-2';
 import { getAllExpandedNodeIds } from './utils/filter-tree/utils';
 import { debounce } from 'lodash';
+import { isEqual } from 'lodash';
 
 export const ZOOM_IN_RATE = 0.8;
 export const ZOOM_OUT_RATE = 1.25;
@@ -226,7 +227,7 @@ export abstract class AbstractXYOutputComponent<
 
     componentDidUpdate(prevProps: AbstractOutputProps, prevState: AbstractXYOutputState): void {
         const viewRangeChanged = this.props.viewRange !== prevProps.viewRange;
-        const checkedSeriesChanged = this.state.checkedSeries !== prevState.checkedSeries;
+        const checkedSeriesChanged = !isEqual(this.state.checkedSeries, prevState.checkedSeries);
         const collapsedNodesChanged = this.state.collapsedNodes !== prevState.collapsedNodes;
         const chartWidthChanged =
             this.props.style.width !== prevProps.style.width ||

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -175,6 +175,7 @@ canvas {
     font-size: 24px;
     display: flex;
     position: absolute;
+    pointer-events: none;
     top: 0;
     height: 100%;
 }
@@ -439,7 +440,7 @@ canvas {
     color: var(--trace-viewer-foreground);
 }
 
-.timgraph-search-bar {
+.timegraph-search-bar {
     background: var(--trace-viewer-editor-background);
     padding-top: 5px;
     padding-bottom: 15px;


### PR DESCRIPTION
Initialize the unit controller view range with either the trace full
range, or the persisted state view range if it is set. When the
experiment hasn't been indexed yet, the initial view range may be empty.

When a new output is opened while the trace is indexing, and the view
range has never been set yet, initialize the view range to the current
partial trace full range. This view range will remain during and after
indexing unless the user changes the view range manually or presses the
Reset button.

When indexing completes, if the view range has never been set yet,
initialize the view range to the final trace full range.

In TimegraphOutputComponent, render the timegraph content and use the
analysis-running-overflow overlay while the analysis is running.

Let the analysis-running-overflow pass through pointer events to the
underlying layer.

In TimegraphOutputComponent componentDidUpdate(), update the chart
layers only if the outputStatus has changed, not always when the
outputStatus is RUNNING. This prevents recursive change of state causing
stack overflow exceptions. Update the chart layers also if the
timegraphTree state has changed. Perform a 'soft' update that does not
refresh rows that already have the correct data. Perform a 'hard' update
only where the marker categories or marker set have changed. Prevent a
possible double update of the markers chart layer.

Extract search bar code to private method and fix typo in its className.

Use a different id for the markers chart layer to help debugging.