### PR TITLE
Release v0.2.7 (Patch)

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.2.6
+tag: v0.2.7
 
 commitInclude:
   parentOfMergeCommit: true

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "browser-theia-trace-example-app",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "theia": {
         "target": "browser",
         "frontend": {
@@ -19,7 +19,7 @@
         "@theia/navigator": "1.49.1",
         "@theia/preferences": "1.49.1",
         "@theia/terminal": "1.49.1",
-        "theia-traceviewer": "0.2.6"
+        "theia-traceviewer": "0.2.7"
     },
     "devDependencies": {
         "@theia/cli": "1.49.1"

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "electron-theia-trace-example-app",
     "main": "scripts/theia-trace-main.js",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "author": {
         "name": "Trace Compass",
         "email": "tracecompass-dev@eclipse.org"
@@ -30,7 +30,7 @@
         "@theia/navigator": "1.49.1",
         "@theia/preferences": "1.49.1",
         "@theia/terminal": "1.49.1",
-        "theia-traceviewer": "0.2.6"
+        "theia-traceviewer": "0.2.7"
     },
     "devDependencies": {
         "@theia/cli": "1.49.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.6",
+    "version": "0.2.7",
     "npmClient": "yarn",
     "command": {
         "run": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "traceviewer-base",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "Trace Viewer base package, contains trace management utilities",
     "license": "MIT",
     "repository": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "traceviewer-react-components",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "Trace Compass react components",
     "license": "MIT",
     "repository": {
@@ -38,7 +38,7 @@
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^0.86.0",
         "timeline-chart": "^0.3.4",
-        "traceviewer-base": "0.2.6",
+        "traceviewer-base": "0.2.7",
         "tsp-typescript-client": "^0.4.3"
     },
     "devDependencies": {

--- a/playwright-tests/package.json
+++ b/playwright-tests/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "theia-playwright-tests",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "license": "EPL-2.0",
     "scripts": {
         "prepare": "yarn clean && yarn build && yarn lint",

--- a/theia-extensions/viewer-prototype/package.json
+++ b/theia-extensions/viewer-prototype/package.json
@@ -1,6 +1,6 @@
 {
     "name": "theia-traceviewer",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "A Trace Viewer for Theia applications, in the form of a Theia extension",
     "keywords": [
         "theia-extension"
@@ -25,8 +25,8 @@
         "@theia/filesystem": "1.49.1",
         "@theia/messages": "1.49.1",
         "animate.css": "^4.1.1",
-        "traceviewer-base": "0.2.6",
-        "traceviewer-react-components": "0.2.6",
+        "traceviewer-base": "0.2.7",
+        "traceviewer-react-components": "0.2.7",
         "tree-kill": "latest"
     },
     "devDependencies": {


### PR DESCRIPTION
With this release we publish new npm packages that use the latest version of `timeline-chart` and `tsp-typescript-client` as well as other dependencies, following a "yarn upgrade" in both those libraries.