### PR TITLE
Re-enable all React table-renderer-components tests

### DIFF
--- a/packages/react-components/src/components/__tests__/__snapshots__/table-renderer-components.test.tsx.snap
+++ b/packages/react-components/src/components/__tests__/__snapshots__/table-renderer-components.test.tsx.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<TableOutputComponent /> Cell renderer 1`] = `"test cell"`;
+
+exports[`<TableOutputComponent /> Cell renderer with search selection 1`] = `
+Array [
+  <span>
+    <span
+      style={
+        Object {
+          "backgroundColor": "#FFFF00",
+        }
+      }
+    >
+      test
+    </span>
+  </span>,
+  <span>
+     cell
+  </span>,
+]
+`;
+
+exports[`<TableOutputComponent /> Empty search filter renderer 1`] = `
+<div
+  data-testid="search-filter-element-parent"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <svg
+    aria-hidden="true"
+    className="svg-inline--fa fa-search fa-w-16 "
+    data-icon="search"
+    data-prefix="fas"
+    focusable="false"
+    role="img"
+    style={
+      Object {
+        "marginLeft": "10px",
+      }
+    }
+    viewBox="0 0 512 512"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+      fill="currentColor"
+      style={Object {}}
+    />
+  </svg>
+</div>
+`;
+
+exports[`<TableOutputComponent /> Loading renderer in loading 1`] = `
+<svg
+  aria-hidden="true"
+  className="svg-inline--fa fa-spinner fa-w-16 "
+  data-icon="spinner"
+  data-prefix="fas"
+  focusable="false"
+  role="img"
+  style={Object {}}
+  viewBox="0 0 512 512"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+    fill="currentColor"
+    style={Object {}}
+  />
+</svg>
+`;
+
+exports[`<TableOutputComponent /> Loading renderer not loading 1`] = `"test cell"`;
+
 exports[`<TableOutputComponent /> Renders AG-Grid table with provided props & state 1`] = `
 <div>
   <div

--- a/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
+++ b/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
@@ -7,7 +7,8 @@ import { AbstractOutputProps } from '../abstract-output-component';
 import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
 import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { HttpTspClient } from 'tsp-typescript-client/lib/protocol/http-tsp-client';
-import { ColDef, Column, GridApi, IRowModel, RowNode } from '@ag-grid-community/core';
+import { ColDef, Column, GridApi, IRowModel, IRowNode, RowNode, ValueGetterParams } from '@ag-grid-community/core';
+import { jest } from '@jest/globals';
 
 describe('<TableOutputComponent />', () => {
     let tableComponent: any;
@@ -110,146 +111,154 @@ describe('<TableOutputComponent />', () => {
     });
 
     const mockOnFilterChange = jest.fn();
-    const mockOnClickNext = jest.fn();
-    const mockOnClickPrevious = jest.fn();
+    const mockOnClickNext = jest.fn<() => Promise<boolean>>(() => Promise.resolve(true));
+    const mockOnClickPrevious = jest.fn<() => Promise<boolean>>(() => Promise.resolve(true));
     const mockParentilterInstance = jest.fn();
     const mockCurrentParentModel = jest.fn();
     const mockFilterChangedCallback = jest.fn();
     const mockFilterModifiedCallback = jest.fn();
-    const mockValueGetter = jest.fn();
-    const mockDoesRowPassOtherFilter = jest.fn();
+    const mockValueGetter = jest.fn((params: ValueGetterParams<any, any>) => {
+        return 'mockedValue';
+    });
+    const mockDoesRowPassOtherFilter = jest.fn((rowNode: RowNode) => true) as jest.MockInstance<boolean, [any]> &
+        ((rowNode: any) => boolean);
     const mockShowParentFilter = jest.fn();
+    // split "mockGetValue" into two parts, else it broke vscode syntax highlighting:
+    const mockGetValue = jest.fn(getValueMock);
+    function getValueMock<TValue = any>(
+        node: IRowNode<any>,
+        column?: string | ColDef<any, TValue> | Column<TValue>
+    ): TValue | null | undefined {
+        return 'mockedCellValue' as unknown as TValue;
+    }
 
-    // test('Empty search filter renderer', () => {
-    //     const searchFilter = create(
-    //         <SearchFilterRenderer
-    //             colName={'jest Test'}
-    //             onFilterChange={mockOnFilterChange}
-    //             onclickNext={mockOnClickNext}
-    //             onclickPrevious={mockOnClickPrevious}
-    //             column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)}
-    //             filterParams={{
-    //                 api: new GridApi(),
-    //                 column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
-    //                 colDef: {} as ColDef,
-    //                 columnApi: new ColumnApi(),
-    //                 rowModel: '' as unknown as IRowModel,
-    //                 filterChangedCallback: mockFilterChangedCallback,
-    //                 filterModifiedCallback: mockFilterModifiedCallback,
-    //                 valueGetter: mockValueGetter,
-    //                 doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
-    //                 context: ''
-    //             }}
-    //             currentParentModel={mockCurrentParentModel}
-    //             parentFilterInstance={mockParentilterInstance}
-    //             suppressFilterButton={false}
-    //             api={new GridApi()}
-    //             columnApi={new ColumnApi()}
-    //             showParentFilter={mockShowParentFilter}
-    //             context={''}
-    //             filterModel={new Map<string, string>()}
-    //         />
-    //     ).toJSON();
-    //     expect(searchFilter).toMatchSnapshot();
-    // });
+    test('Empty search filter renderer', () => {
+        const searchFilter = create(
+            <SearchFilterRenderer
+                colName={'jest Test'}
+                onFilterChange={mockOnFilterChange}
+                onclickNext={mockOnClickNext}
+                onclickPrevious={mockOnClickPrevious}
+                api={{} as GridApi}
+                column={{} as Column<any>}
+                filterParams={{
+                    api: {} as GridApi,
+                    column: {} as Column<any>,
+                    colDef: {} as ColDef,
+                    rowModel: '' as unknown as IRowModel,
+                    filterChangedCallback: mockFilterChangedCallback,
+                    filterModifiedCallback: mockFilterModifiedCallback,
+                    valueGetter: mockValueGetter,
+                    getValue: mockGetValue,
+                    doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
+                    context: ''
+                }}
+                currentParentModel={mockCurrentParentModel}
+                parentFilterInstance={mockParentilterInstance}
+                suppressFilterButton={false}
+                showParentFilter={mockShowParentFilter}
+                context={''}
+                filterModel={new Map<string, string>()}
+            />
+        ).toJSON();
+        expect(searchFilter).toMatchSnapshot();
+    });
 
-    // test('Search filter renderer key interactions', () => {
-    //     render(
-    //         <SearchFilterRenderer
-    //             colName={'jest Test'}
-    //             onFilterChange={mockOnFilterChange}
-    //             onclickNext={mockOnClickNext}
-    //             onclickPrevious={mockOnClickPrevious}
-    //             column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)}
-    //             filterParams={{
-    //                 api: new GridApi(),
-    //                 column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
-    //                 colDef: {} as ColDef,
-    //                 columnApi: new ColumnApi(),
-    //                 rowModel: '' as unknown as IRowModel,
-    //                 filterChangedCallback: mockFilterChangedCallback,
-    //                 filterModifiedCallback: mockFilterModifiedCallback,
-    //                 valueGetter: mockValueGetter,
-    //                 doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
-    //                 context: ''
-    //             }}
-    //             currentParentModel={mockCurrentParentModel}
-    //             parentFilterInstance={mockParentilterInstance}
-    //             suppressFilterButton={false}
-    //             api={new GridApi()}
-    //             columnApi={new ColumnApi()}
-    //             showParentFilter={mockShowParentFilter}
-    //             context={''}
-    //             filterModel={new Map<string, string>()}
-    //         />
-    //     );
+    test('Search filter renderer key interactions', () => {
+        render(
+            <SearchFilterRenderer
+                colName={'jest Test'}
+                onFilterChange={mockOnFilterChange}
+                onclickNext={mockOnClickNext}
+                onclickPrevious={mockOnClickPrevious}
+                api={{} as GridApi}
+                column={{} as Column<any>}
+                filterParams={{
+                    api: {} as GridApi,
+                    column: {} as Column<any>,
+                    colDef: {} as ColDef,
+                    rowModel: '' as unknown as IRowModel,
+                    filterChangedCallback: mockFilterChangedCallback,
+                    filterModifiedCallback: mockFilterModifiedCallback,
+                    valueGetter: mockValueGetter,
+                    getValue: mockGetValue,
+                    doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
+                    context: ''
+                }}
+                currentParentModel={mockCurrentParentModel}
+                parentFilterInstance={mockParentilterInstance}
+                suppressFilterButton={false}
+                showParentFilter={mockShowParentFilter}
+                context={''}
+                filterModel={new Map<string, string>()}
+            />
+        );
 
-    //     const parentDiv = screen.getByTestId('search-filter-element-parent');
-    //     fireEvent.click(parentDiv);
-    //     const input = screen.getByTestId('search-filter-element-input');
-    //     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 });
-    //     expect(mockOnClickNext).toHaveBeenCalledTimes(1);
-    //     fireEvent.keyDown(input, { key: 'Escape', code: 'Escape', charCode: 27 });
-    //     expect(mockOnFilterChange).toHaveBeenCalledTimes(1);
-    // });
+        const parentDiv = screen.getByTestId('search-filter-element-parent');
+        fireEvent.click(parentDiv);
+        const input = screen.getByTestId('search-filter-element-input');
+        fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 });
+        expect(mockOnClickNext).toHaveBeenCalledTimes(1);
+        fireEvent.keyDown(input, { key: 'Escape', code: 'Escape', charCode: 27 });
+        expect(mockOnFilterChange).toHaveBeenCalledTimes(1);
+    });
 
-    // const cellRendererProps: any = {
-    //     value: 'test cell',
-    //     valueFormatted: 'test cell',
-    //     getValue: function () {
-    //         return 'test cell';
-    //     },
-    //     setValue: function (val: any): void {
-    //         const value = val;
-    //     },
-    //     formatValue: function (value: any) {
-    //         return value;
-    //     },
-    //     data: {},
-    //     node: {} as RowNode,
-    //     colDef: {} as ColDef,
-    //     column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
-    //     rowIndex: 0,
-    //     api: new GridApi(),
-    //     columnApi: new ColumnApi(),
-    //     context: '',
-    //     refreshCell: () => {},
-    //     $scope: '',
-    //     eGridCell: document.createElement('div'),
-    //     eParentOfValue: document.createElement('div'),
-    //     addRenderedRowListener: function (eventType: string, listener: Function): void {
-    //         throw new Error('Function not implemented.');
-    //     },
-    //     searchResultsColor: '#FFFF00',
-    //     filterModel: new Map<string, string>()
-    // };
+    const cellRendererProps: any = {
+        value: 'test cell',
+        valueFormatted: 'test cell',
+        getValue: function () {
+            return 'test cell';
+        },
+        setValue: function (val: any): void {
+            const value = val;
+        },
+        formatValue: function (value: any) {
+            return value;
+        },
+        data: {},
+        node: {} as RowNode,
+        colDef: {} as ColDef,
+        column: {} as Column<any>,
+        rowIndex: 0,
+        api: {} as GridApi,
+        context: '',
+        refreshCell: () => {},
+        $scope: '',
+        eGridCell: document.createElement('div'),
+        eParentOfValue: document.createElement('div'),
+        addRenderedRowListener: function (eventType: string, listener: Function): void {
+            throw new Error('Function not implemented.');
+        },
+        searchResultsColor: '#FFFF00',
+        filterModel: new Map<string, string>()
+    };
 
-    // test('Cell renderer', () => {
-    //     const cellRenderer = create(<CellRenderer {...cellRendererProps} />).toJSON();
-    //     expect(cellRenderer).toMatchSnapshot();
-    // });
+    test('Cell renderer', () => {
+        const cellRenderer = create(<CellRenderer {...cellRendererProps} />).toJSON();
+        expect(cellRenderer).toMatchSnapshot();
+    });
 
-    // test('Cell renderer with search selection', () => {
-    //     cellRendererProps.colDef.field = 'testField';
-    //     cellRendererProps.filterModel.set('testField', 'test');
-    //     cellRendererProps.data = { isMatched: true };
+    test('Cell renderer with search selection', () => {
+        cellRendererProps.colDef.field = 'testField';
+        cellRendererProps.filterModel.set('testField', 'test');
+        cellRendererProps.data = { isMatched: true };
 
-    //     const cellRenderer = create(<CellRenderer {...cellRendererProps} />).toJSON();
-    //     expect(cellRenderer).toMatchSnapshot();
-    // });
+        const cellRenderer = create(<CellRenderer {...cellRendererProps} />).toJSON();
+        expect(cellRenderer).toMatchSnapshot();
+    });
 
-    // test('Loading renderer not loading', () => {
-    //     delete cellRendererProps.filterModel;
-    //     delete cellRendererProps.searchResultsColor;
+    test('Loading renderer not loading', () => {
+        delete cellRendererProps.filterModel;
+        delete cellRendererProps.searchResultsColor;
 
-    //     const loadingRenderer = create(<LoadingRenderer {...cellRendererProps} />).toJSON();
-    //     expect(loadingRenderer).toMatchSnapshot();
-    // });
+        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps} />).toJSON();
+        expect(loadingRenderer).toMatchSnapshot();
+    });
 
-    // test('Loading renderer in loading', () => {
-    //     cellRendererProps.value = undefined;
+    test('Loading renderer in loading', () => {
+        cellRendererProps.value = undefined;
 
-    //     const loadingRenderer = create(<LoadingRenderer {...cellRendererProps} />).toJSON();
-    //     expect(loadingRenderer).toMatchSnapshot();
-    // });
+        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps} />).toJSON();
+        expect(loadingRenderer).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
Fixes #1100

Had to mock some ag-grid objects that were used in the newly re-enabled tests.

It turns-out that many of these objects were not really used during our tests
(e.g. api: GridApi, column: Column). So for these, it was enough to mock
them using an empty JS object and use keyword "as" to present them as the real
thing. e.g.:

```JS
<SearchFilterRenderer
    api={{} as GridApi}
    column={{} as Column<any>}
>
```

To run the re-enabled tests against the original jest snapshots, you can checkout the snapshot file's version prior to the ag-grid upgrade:

```bash
$ pwd
<...>/theia-trace-extension

$ git log --oneline 
[...newer commits]
b911f00 Bump ag-grid-community from 28.2.1 to 32.0.1  // **6-deep vs this PR**
167c526 Update 0011-tsp-analysis-api for custom analysis // **7-deep vs this PR**
[... older commits]

$ git checkout HEAD~7 ./packages/react-components/src/components/__tests__/__snapshots__/table-renderer-components.test.tsx.snap
$ yarn && yarn test
```

Expected result: a single test should fail - one that was not disabled: `<TableOutputComponent /> › Renders AG-Grid table with provided props & state`
I believe that test fails/failed because of the newer version of ag-grid generates slightly different HTML code when rendered. 

Confirm that all the newly re-enabled tests passed, using the original snapshot.