### PR TITLE
Hide empty rows when filter is applied

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -37,7 +37,7 @@
         "react-virtualized": "^9.21.0",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^0.86.0",
-        "timeline-chart": "^0.3.4",
+        "timeline-chart": "^0.4.0",
         "traceviewer-base": "0.2.7",
         "tsp-typescript-client": "^0.4.3"
     },

--- a/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
@@ -13,6 +13,8 @@ interface EntryTreeProps {
     selectedRow?: number;
     multiSelectedRows?: number[];
     collapsedNodes: number[];
+    emptyNodes: number[];
+    hideEmptyNodes: boolean;
     showFilter: boolean;
     onToggleCheck: (ids: number[]) => void;
     onRowClick: (id: number) => void;
@@ -46,7 +48,9 @@ export class EntryTree extends React.Component<EntryTreeProps> {
         this.props.entries !== nextProps.entries ||
         this.props.collapsedNodes !== nextProps.collapsedNodes ||
         this.props.selectedRow !== nextProps.selectedRow ||
-        this.props.multiSelectedRows !== nextProps.multiSelectedRows;
+        this.props.multiSelectedRows !== nextProps.multiSelectedRows ||
+        this.props.hideEmptyNodes !== nextProps.hideEmptyNodes ||
+        this.props.emptyNodes !== nextProps.emptyNodes;
 
     render(): JSX.Element {
         return <FilterTree nodes={listToTree(this.props.entries, this.props.headers)} {...this.props} />;

--- a/packages/react-components/src/components/utils/filter-tree/table.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table.tsx
@@ -4,6 +4,7 @@ import { TableHeader } from './table-header';
 import { TableBody } from './table-body';
 import { SortConfig, sortState, nextSortState, sortNodes } from './sort';
 import ColumnHeader from './column-header';
+import { filterEmptyNodes } from './utils';
 
 interface TableProps {
     nodes: TreeNode[];
@@ -26,6 +27,8 @@ interface TableProps {
     headers: ColumnHeader[];
     className: string;
     hideFillers?: boolean;
+    emptyNodes: number[];
+    hideEmptyNodes: boolean;
 }
 
 export class Table extends React.Component<TableProps> {
@@ -74,6 +77,12 @@ export class Table extends React.Component<TableProps> {
             gridTemplateColumns = gridTemplateColumns.concat(' minmax(0px, 1fr)');
         }
 
+        let nodes = sortNodes(this.props.nodes, this.props.sortConfig);
+
+        if (this.props.hideEmptyNodes) {
+            nodes = filterEmptyNodes(nodes, this.props.emptyNodes);
+        }
+
         return (
             <div>
                 <table style={{ gridTemplateColumns: gridTemplateColumns }} className={this.props.className}>
@@ -86,7 +95,7 @@ export class Table extends React.Component<TableProps> {
                             hideFillers={this.props.hideFillers}
                         />
                     )}
-                    <TableBody {...this.props} nodes={sortNodes(this.props.nodes, this.props.sortConfig)} />
+                    <TableBody {...this.props} nodes={nodes} />
                 </table>
             </div>
         );

--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -3,7 +3,7 @@ import { TreeNode } from './tree-node';
 import { Message } from './message';
 import { Filter } from './filter';
 import { Table } from './table';
-import { getAllExpandedNodeIds } from './utils';
+import { getAllExpandedNodeIds, filterEmptyNodes } from './utils';
 import { SortConfig, sortNodes } from './sort';
 import ColumnHeader from './column-header';
 import { isEqual } from 'lodash';
@@ -15,6 +15,8 @@ interface FilterTreeProps {
     showFilter: boolean; // Optional
     checkedSeries: number[]; // Optional
     collapsedNodes: number[];
+    emptyNodes: number[];
+    hideEmptyNodes: boolean;
     selectedRow?: number;
     multiSelectedRows?: number[];
     onToggleCheck: (ids: number[]) => void; // Optional
@@ -274,6 +276,8 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             selectedRow={this.props.selectedRow}
             multiSelectedRows={this.props.multiSelectedRows}
             collapsedNodes={this.props.collapsedNodes}
+            emptyNodes={this.props.emptyNodes}
+            hideEmptyNodes={this.props.hideEmptyNodes}
             isCheckable={this.props.showCheckboxes}
             isClosable={this.props.showCloseIcons}
             sortConfig={this.state.sortConfig}

--- a/packages/react-components/src/components/utils/filter-tree/utils.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/utils.tsx
@@ -70,3 +70,31 @@ export const validateNumArray = (arr: any | undefined): boolean => {
     }
     return false;
 };
+
+/**
+ * Removes specified nodes from the tree structure.
+ * @param nodes The array of root nodes of the tree.
+ * @param nodesToRemove An array of node IDs to be removed.
+ * @returns A new array of root nodes with specified nodes removed.
+ */
+export function filterEmptyNodes(nodes: TreeNode[], nodesToRemove: number[]): TreeNode[] {
+    // return nodes;
+    return nodes.reduce((acc: TreeNode[], node) => {
+        // If the current node is in the removal list, don't add it to the accumulator
+        if (nodesToRemove.includes(node.id)) {
+            return acc;
+        }
+
+        // Create a new node object with the same properties
+        const newNode: TreeNode = { ...node };
+
+        // Recursively remove nodes from children
+        if (newNode.children.length > 0) {
+            newNode.children = filterEmptyNodes(newNode.children, nodesToRemove);
+        }
+
+        // Add the new node to the accumulator
+        acc.push(newNode);
+        return acc;
+    }, []);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13633,10 +13633,10 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-timeline-chart@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.npmjs.org/timeline-chart/-/timeline-chart-0.3.4.tgz#2833ac5c1250ae1273bc8287b989af350b373792"
-  integrity sha512-npz+x1/b11DzNAmh3FBS3QGLuUbvmOioZ9CSEi2e/97vo046ds1Y1wHR6vvmnhqVMmKSf0/TueQB6F8NhmhCdg==
+timeline-chart@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.4.0.tgz#c96301ce89b1306e4f69aa366b44e87bfcd4bffd"
+  integrity sha512-Pmsr+fLVBERWyKO3P9UJRIVWY3Sj+rqvzP4yg/RjCslqdQvl9qpQ+n8Tg7G9bxSvZ/NBKG+EpVpJGPDunPO84Q==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"


### PR DESCRIPTION
Hide rows that have no non-null state in their model, when a filter is applied. Gaps between states in the row model should be make rows visible when strategy is SAMPLED, but not when it is DEEP.

Keep an up-to-date list of empty nodes after fetching row models from the server.

Add emptyNodes and hideEmptyNodes to the properties of EntryTree, Tree and Table. Filter the empty nodes when rendering the Table.

Remove the updateSearchFilters callback when adding or removing a filter as the state change will handle it already.

Removed unused dataRows in TimegraphOuputState