### PR TITLE
Add libsecret-1-dev to ubuntu image of ci-cd workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
     - name: install dependencies on ubuntu
       if: startsWith(matrix.os,'ubuntu')
       run: |
-        sudo apt install -y make gcc pkg-config build-essential libx11-dev libxkbfile-dev
+        sudo apt install -y make gcc pkg-config build-essential libx11-dev libxkbfile-dev libsecret-1-dev
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Add libsecret-1-dev to ubuntu image to ci-cd workflow

Latest is now Ubuntu 24.04 and the runner doesn't include this library.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>