### PR TITLE
Fix time graph filtering and collapsing

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -37,7 +37,7 @@
         "react-virtualized": "^9.21.0",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^0.86.0",
-        "timeline-chart": "^0.4.0",
+        "timeline-chart": "^0.4.1",
         "traceviewer-base": "0.3.0",
         "tsp-typescript-client": "^0.4.3"
     },

--- a/packages/react-components/src/components/utils/filter-tree/table-body.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table-body.tsx
@@ -4,8 +4,8 @@ import { TableRow } from './table-row';
 
 interface TableBodyProps {
     nodes: TreeNode[];
-    selectedNode?: number;
-    multiSelectedNodes?: number[];
+    selectedRow?: number;
+    multiSelectedRows?: number[];
     collapsedNodes: number[];
     isCheckable: boolean;
     isClosable: boolean;
@@ -34,7 +34,6 @@ export class TableBody extends React.Component<TableBodyProps> {
         if (!this.props.nodes) {
             return undefined;
         }
-
         return <tbody>{this.renderRows()}</tbody>;
     }
 }

--- a/packages/react-components/src/components/utils/filter-tree/table.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/table.tsx
@@ -80,7 +80,7 @@ export class Table extends React.Component<TableProps> {
         let nodes = sortNodes(this.props.nodes, this.props.sortConfig);
 
         if (this.props.hideEmptyNodes) {
-            nodes = filterEmptyNodes(nodes, this.props.emptyNodes);
+            nodes = filterEmptyNodes(nodes, this.props.emptyNodes, this.props.collapsedNodes);
         }
 
         return (

--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -3,7 +3,7 @@ import { TreeNode } from './tree-node';
 import { Message } from './message';
 import { Filter } from './filter';
 import { Table } from './table';
-import { getAllExpandedNodeIds, filterEmptyNodes } from './utils';
+import { getAllExpandedNodeIds } from './utils';
 import { SortConfig, sortNodes } from './sort';
 import ColumnHeader from './column-header';
 import { isEqual } from 'lodash';
@@ -96,7 +96,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     };
 
     handleOrderChange = (nodes: TreeNode[]): void => {
-        const ids = getAllExpandedNodeIds(nodes, this.props.collapsedNodes);
+        const ids = getAllExpandedNodeIds(nodes, this.props.collapsedNodes, this.props.emptyNodes);
         this.props.onOrderChange(ids);
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13633,10 +13633,10 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-timeline-chart@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.4.0.tgz#c96301ce89b1306e4f69aa366b44e87bfcd4bffd"
-  integrity sha512-Pmsr+fLVBERWyKO3P9UJRIVWY3Sj+rqvzP4yg/RjCslqdQvl9qpQ+n8Tg7G9bxSvZ/NBKG+EpVpJGPDunPO84Q==
+timeline-chart@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.4.1.tgz#57cefac6cfa928cd84842cfb5031a157d8bb716e"
+  integrity sha512-f5lNTaY4438ml6x4bHdh29/FTXZgMOvunM5FDA1fWocxlq5PCBWvndwSh/HiqOHT0HLuom7jz9juxFtjyFCZmg==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"


### PR DESCRIPTION
Update the filtering of empty nodes to include visible nodes even if any of their parent is filtered-out. Recursively replace filtered-out nodes by their visible children, if any, but only if the filtered-out parent node is not collapsed.

In TimeGraphOutputComponent update the arrows layer after empty nodes have been determined, and filter out empty nodes from the rowIds passed to the arrows layer.

Fixes #1132