### PR TITLE
Update filter-chip style so that it can be styled in vscode

### DIFF
--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -515,8 +515,8 @@ canvas {
 }
 
 .filter-chip {
-    background-color: var(--theia-selection-background) !important;
-    color: var(--trace-viewer-ui-font-color0);
+    background-color: var(--trace-viewer-selection-background) !important;
+    color: var(--trace-viewer-ui-font-color0) !important;
     border-radius: 15px !important;
     border-width: 1px !important;
     display: flex;


### PR DESCRIPTION
**Before in vscode-trace-extension**:
![image](https://github.com/user-attachments/assets/d26aad39-bafc-4470-8185-e72ff2dd4cb6)

![image](https://github.com/user-attachments/assets/19982092-78b2-4bcf-bb3e-80dff6ed7220)

**After: in vscode-trace-extension**
![image](https://github.com/user-attachments/assets/f3f5d6f2-c36e-44ac-954e-166eae7d35e7)

![image](https://github.com/user-attachments/assets/64c49912-0621-4893-99d8-44fd95043a05)

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>