### PR TITLE
Fix filter tree filter text box width

### DIFF
--- a/packages/react-components/src/components/utils/filter-tree/filter.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/filter.tsx
@@ -19,7 +19,7 @@ export class Filter extends React.Component<FilterProps, FilterState> {
         };
         this.resizeObserver = new ResizeObserver(entries => {
             this.setState({
-                width: entries[0].contentRect.width
+                width: entries[0].contentRect.right
             });
         });
     }

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -332,6 +332,7 @@ canvas {
     padding: 3px;
     margin-bottom: 5px;
     text-indent: 23px;
+    box-sizing: border-box;
     color: var(--trace-viewer-input-placeholder-foreground);
 }
 


### PR DESCRIPTION
Use box-sizing: border-box setting so that the provided width includes the filter text box padding and border.

Use the reference element's right position as provided width so that it can include the reference element's left margin.