### PR TITLE
Follow recent tsp-typescript-client API additions for configurations

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -16,7 +16,7 @@
         "src"
     ],
     "dependencies": {
-        "tsp-typescript-client": "^0.4.3"
+        "tsp-typescript-client": "^0.5.0"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^3.4.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -39,7 +39,7 @@
         "semantic-ui-react": "^0.86.0",
         "timeline-chart": "^0.4.1",
         "traceviewer-base": "0.3.0",
-        "tsp-typescript-client": "^0.4.3"
+        "tsp-typescript-client": "^0.5.0"
     },
     "devDependencies": {
         "@testing-library/react": "^15.0.6",

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -7,7 +7,7 @@ import '../../style/status-bar.css';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
 import { TimelineChart } from 'timeline-chart/lib/time-graph-model';
 import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
-import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { OutputDescriptor, ProviderType } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { ITspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TimeRange, TimeRangeString } from 'traceviewer-base/lib/utils/time-range';
@@ -735,7 +735,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                     {...outputProps}
                                 ></TraceOverviewComponent>
                             );
-                        case 'TIME_GRAPH':
+                        case ProviderType.TIME_GRAPH:
                             if (this.chartPersistedState && this.chartPersistedState.output.id === output.id) {
                                 outputProps.persistChartState = this.chartPersistedState.payload;
                                 this.chartPersistedState = undefined;
@@ -749,7 +749,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                     className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
                                 />
                             );
-                        case 'TREE_TIME_XY':
+                        case ProviderType.TREE_TIME_XY:
                             if (this.chartPersistedState && this.chartPersistedState.output.id === output.id) {
                                 outputProps.persistChartState = this.chartPersistedState.payload;
                                 this.chartPersistedState = undefined;
@@ -761,7 +761,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                     className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
                                 />
                             );
-                        case 'TABLE':
+                        case ProviderType.TABLE:
                             return (
                                 <TableOutputComponent
                                     key={output.id}
@@ -769,7 +769,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                     className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
                                 />
                             );
-                        case 'DATA_TREE':
+                        case ProviderType.DATA_TREE:
                             return (
                                 <DataTreeOutputComponent
                                     key={output.id}

--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { OutputAddedSignalPayload } from 'traceviewer-base/lib/signals/output-added-signal-payload';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
-import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { OutputDescriptor, ProviderType } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
@@ -91,7 +91,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         const selectedOutput: OutputDescriptor = this._nodeIdToOutput[id];
         this.setState({ selectedOutput: id });
         if (selectedOutput && this._selectedExperiment) {
-            if (selectedOutput.type !== 'NONE') {
+            if (selectedOutput.type !== ProviderType.NONE) {
                 signalManager().fireOutputAddedSignal(
                     new OutputAddedSignalPayload(selectedOutput, this._selectedExperiment)
                 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13796,10 +13796,10 @@ tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.6.2:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
-tsp-typescript-client@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.npmjs.org/tsp-typescript-client/-/tsp-typescript-client-0.4.3.tgz#c2a679c8bed359ff09f4532d0365e0ee42dae461"
-  integrity sha512-6wmi9Y6ftWJHWdNmzt7b5ST2EPP3srDnPfviA/8hSt/VYsFnagDKLCWWuCHVSPee2XmEWG2vfIIy3Q6LzJdHiQ==
+tsp-typescript-client@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/tsp-typescript-client/-/tsp-typescript-client-0.5.0.tgz#02572aeced3e1cba3b82bf07c4d30d6029a980eb"
+  integrity sha512-bV2fsvce4B9sAsZzO/pP0NrCxJmqugmkO5HHoKQ6MPx34BUH/bQ1ODkhk+Zqv/1Hjw8KLn94EXkTpgcvZmSXuA==
   dependencies:
     json-bigint sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473
     node-fetch "^2.5.0"


### PR DESCRIPTION
- Adopt tsp-typescript-client v0.5.0
- Use ProviderType enum instead of string for outputs
- Update API for global configuration
- Add new methods of ITspClient in TheiaRpcTspProxy

Requires https://github.com/eclipse-cdt-cloud/tsp-typescript-client/pull/119 (part of tsp-typescript-client v0.5.0)

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>