### PR TITLE
Import style in trace-explorer-views-widget.tsx

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import '../../style/output-components-style.css';
 import { OutputAddedSignalPayload } from 'traceviewer-base/lib/signals/output-added-signal-payload';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { OutputDescriptor, ProviderType } from 'tsp-typescript-client/lib/models/output-descriptor';


### PR DESCRIPTION
With this it's guaranteed that the styles are loaded when using this react component outside this repository (e.g. in vscode-trace-extension)

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>