### PR TITLE
Remove gridlines in Available Views view

### DIFF
--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -267,6 +267,7 @@ canvas {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+    border: 0px;
 }
 
 .avail-views-table tr {


### PR DESCRIPTION
The gridlines are not needed because there are visual effects like mouse pointer and background change when hovering over a line, which provide visual clues for the user.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>