### PR TITLE
Show column in TimegraphOutputComponent if back-end provides them

### DIFF
--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -540,6 +540,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                         className="table-tree timegraph-tree"
                         emptyNodes={this.state.emptyNodes}
                         hideEmptyNodes={this.shouldHideEmptyNodes}
+                        headers={this.state.columns}
                     />
                 </div>
                 <div ref={this.markerTreeRef} className="scrollable" style={{ height: this.getMarkersLayerHeight() }}>

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -306,17 +306,19 @@ canvas {
 }
 
 .timegraph-tree {
-    border: 0px;
+    border-collapse: collapse;
 }
 
 .timegraph-tree tr {
     /* TODO: Fix row alignment, this number is arbitrary, it works [on my machine], but it should match line height in timeline-chart */
     line-height: 18px;
+    border:none;
 }
 
 .timegraph-tree td {
     padding: 1px;
-    border: 0px;
+    border-left: 1px solid var(--trace-viewer-tree-inactiveIndentGuidesStroke);
+    border-bottom:none;
 }
 
 #input-filter-container {


### PR DESCRIPTION
No header is drawn with the commit.

Fixes #1149

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>