### PR TITLE
Support of directory traces other than CTF

### DIFF
--- a/theia-extensions/viewer-prototype/src/node/backend-file-service-impl.ts
+++ b/theia-extensions/viewer-prototype/src/node/backend-file-service-impl.ts
@@ -29,6 +29,11 @@ export class BackendFileServiceImpl implements BackendFileService {
         const stats = await fs.promises.stat(cleanedPath);
         if (stats.isDirectory()) {
             await this.deepFindTraces(cleanedPath, traces, cancellationToken);
+            // No CTF traces found. Add root directory as trace directory.
+            // Back-end will reject if it is not a trace
+            if (traces.length === 0) {
+                traces.push(cleanedPath);
+            }
         } else if (stats.isFile()) {
             traces.push(cleanedPath);
         }


### PR DESCRIPTION
The trace detection algorithm checks recursively for CTF traces. If no CTF trace are found under the root directory, then use the root directory as trace directory. The trace server back-end will validate if this path points to a valid trace or not.

With this it's now possible to open traces that are directories other than CTF.

Note that only a single trace can be opened in the experiment and not set of traces, which is currently only supported with CTF traces.

Examples trace type: uftrace

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>