### PR TITLE
Add filter to Opened Traces widget

### DIFF
--- a/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filter-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -1022,7 +1022,7 @@ Array [
       id="input-filter-icon"
     />
     <input
-      id="input-filter-tree"
+      id="input-filter-text"
       placeholder="Filter"
       style={
         Object {

--- a/packages/react-components/src/components/utils/filter-tree/filter.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/filter.tsx
@@ -39,7 +39,7 @@ export class Filter extends React.Component<FilterProps, FilterState> {
         return (
             <div ref={this.ref} onChange={this.props.onChange} id="input-filter-container">
                 <i id="input-filter-icon" className="codicon codicon-filter"></i>
-                <input id="input-filter-tree" type="text" placeholder="Filter" style={{ width: this.state.width }} />
+                <input id="input-filter-text" type="text" placeholder="Filter" style={{ width: this.state.width }} />
             </div>
         );
     }

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -332,7 +332,7 @@ canvas {
     left: 8px;
 }
 
-#input-filter-tree {
+#input-filter-text {
     background-color: var(--trace-viewer-input-background);
     border-style: solid;
     border-color: var(--trace-viewer-tree-inactiveIndentGuidesStroke);


### PR DESCRIPTION
### What it does

Add filter container to ReactOpenTracesWidget. Add filter string to the widget's state.

When filter is applied, hide rows that don't match the filter for neither the experiment name nor any of the experiment's traces' name. Rows are hidden by returning 0 as row height and rendering to undefined.

Rename CSS class 'input-filter-tree' to generic 'input-filter-text'.

### How to test

Open a few traces and experiments with multiple traces. Type filter strings that match experiment names, trace names, both or none. Repeat with a selected experiment.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
