### PR TITLE
Enable sorting of timegraph tree columns

### DIFF
--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -101,6 +101,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     private onOutputDataChanged = (outputs: OutputDescriptor[]) => this.doHandleOutputDataChangedSignal(outputs);
     private onContextMenuContributed = (payload: ContextMenuContributedSignalPayload) =>
         this.doHandleContextMenuContributed(payload);
+    private onOrderChange = (ids: number[]) => this.doHandleOrderChange(ids);
     private pendingSelection: TimeGraphEntry | undefined;
 
     private _debouncedUpdateChart = debounce(() => {
@@ -301,8 +302,10 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 const columns: ColumnHeader[] = [];
                 if (headers && headers.length > 0) {
                     headers.forEach(header => {
-                        columns.push({ title: header.name, sortable: false, resizable: true, tooltip: header.tooltip });
+                        columns.push({ title: header.name, sortable: true, resizable: true, tooltip: header.tooltip });
                     });
+                } else {
+                    columns.push({ title: '', sortable: true, resizable: true });
                 }
                 this.setState(
                     {
@@ -464,6 +467,11 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         }
     }
 
+    private doHandleOrderChange(ids: number[]) {
+        const ordered = this.state.timegraphTree.slice().sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id));
+        this.setState({ timegraphTree: ordered });
+    }
+
     /**
      * For each line in the tree (this.state.timegraphTree), parse the metadata and try to find
      * matches with the key / values pairs of the selected event.
@@ -518,6 +526,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     renderTree(): React.ReactNode {
+        this.onOrderChange = this.onOrderChange.bind(this);
         // TODO Show header, when we can have entries in-line with timeline-chart
         return (
             <>
@@ -550,6 +559,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                         className="table-tree timegraph-tree"
                         emptyNodes={this.state.emptyNodes}
                         hideEmptyNodes={this.shouldHideEmptyNodes}
+                        onOrderChange={this.onOrderChange}
                         headers={this.state.columns}
                         hideFillers={true}
                     />

--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -96,7 +96,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     };
 
     handleOrderChange = (nodes: TreeNode[]): void => {
-        const ids = getAllExpandedNodeIds(nodes, this.props.collapsedNodes, this.props.emptyNodes);
+        const ids = getAllExpandedNodeIds(nodes, []);
         this.props.onOrderChange(ids);
     };
 


### PR DESCRIPTION
### What it does

Change the sortable property to true for all defined columns in a
timegraph. Add a sortable default column with empty header when no
column headers are defined in the model.

Change the FilterTree onOrderChange callback to include all ordered ids,
including collapsed and hidden nodes.

Add a handler for the onOrderChange callback for a timegraph. When the
callback is handled, reorder the timegraphTree entries according to the
specified order. Update the timegraphTree in the state to trigger
synchronization of the timegraph chart.

### How to test

Open a timegraph with defined columns (e.g. Thread Status) or no defined columns (e.g. Resources Status) and click the column headers to sort the tree. Verify that the timegraph chart is also reordered and that row synchronization still works.

### Follow-ups

Consider adding support to enable or disable the sortable property of each individual column from an updated TSP model.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
