### PR TITLE
Import style in trace-explorer-opened-traces-widget.tsx

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
@@ -1,15 +1,15 @@
+import { faCopy, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as React from 'react';
 import { flushSync } from 'react-dom';
-import { List, ListRowProps, Index, AutoSizer } from 'react-virtualized';
-import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
-import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
-import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 import ReactModal from 'react-modal';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCopy } from '@fortawesome/free-solid-svg-icons';
+import { AutoSizer, Index, List, ListRowProps } from 'react-virtualized';
+import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { OpenedTracesUpdatedSignalPayload } from 'traceviewer-base/lib/signals/opened-traces-updated-signal-payload';
+import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+import '../../style/output-components-style.css';
 
 export interface ReactOpenTracesWidgetProps {
     id: string;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/theia-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Import style in `trace-explorer-opened-traces-widget.tsx`. With this it's guaranteed that the styles are loaded when using this react component outside this repository (e.g. in `vscode-trace-extension`). This is consistent how other components import their styles (e.g. see commit 8e545aa).


<!-- Include relevant issues and describe how they are addressed. -->

### How to test

No change when running in theia-trace-extension.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
