### PR TITLE
[customized views] remove UIs related to managing them when irrelevant

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
@@ -26,9 +26,12 @@ export class TraceExplorerViewsWidget extends ReactWidget {
                     id={this.id}
                     title={this.title.label}
                     tspClientProvider={this.tspClientProvider}
-                    onCustomizationClick={() =>
-                        console.warn('Custom Views currently not supported in Theia Trace Extension')
-                    }
+                    // Note: not implemented in the Theia extension yet. By not providing a callback,
+                    // the customizability UIs will be disabled (creating and deleting custom analyses) but
+                    // if created through the vscode extension they will still be visible and usable.
+                    // onCustomizationClick={() =>
+                    //     console.warn('Custom Views currently not supported in Theia Trace Extension')
+                    // }
                 ></ReactAvailableViewsWidget>
             </div>
         );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/theia-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
In the Theia trace extension, the functionality to create custom views has not been implemented. However the UI element - a plus sign button added after the "views" entry of the "configurator" element, used to trigger creating custom views, is always present, even when not supported (no callback provided that create the custom views). This commit removes that button when not relevant. 

There's also the UI element added to remove previously created custom views (the "x" button), that does work in the Theia extension. For consistency, this commit also removes this button. 

Another tweak done when customization is not supported is to filter root "configurator" nodes from the nodes list early, so they are not displayed in the views list. If they have children, from previously configured output descriptors (from the vscode trace extension), then the children will be displayed as before but as root nodes instead of children of their "configurator" node. 

The filtering of "configurator" node is overridable, by creating a class that extends ReactAvailableViewsWidget and overrides method "protected doFilterList(list: OutputDescriptor[]): OutputDescriptor[]"     

e.g. to return the original, unfiltered list.

```diff
diff --git a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
index e559d2e..b15d813 100644
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
@@ -3,6 +3,15 @@ import { ReactWidget, Widget, Message, WidgetManager } from '@theia/core/lib/bro
 import { TspClientProvider } from '../../tsp-client-provider-impl';
 import * as React from 'react';
 import { ReactAvailableViewsWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-views-widget';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+
+class MyUnfilteredReactAvailableViewsWidget extends ReactAvailableViewsWidget {
+    protected doFilterList(list: OutputDescriptor[]): OutputDescriptor[] {
+        console.info('**** in overriden doFilterList() ');
+        // Nope!
+        return list;
+    }
+}
 
 @injectable()
 export class TraceExplorerViewsWidget extends ReactWidget {
@@ -22,7 +31,7 @@ export class TraceExplorerViewsWidget extends ReactWidget {
     render(): React.ReactNode {
         return (
             <div>
-                <ReactAvailableViewsWidget
+                <MyUnfilteredReactAvailableViewsWidget
                     id={this.id}
                     title={this.title.label}
                     tspClientProvider={this.tspClientProvider}
@@ -32,7 +41,7 @@ export class TraceExplorerViewsWidget extends ReactWidget {
                     // onCustomizationClick={() =>
                     //     console.warn('Custom Views currently not supported in Theia Trace Extension')
                     // }
-                ></ReactAvailableViewsWidget>
+                ></MyUnfilteredReactAvailableViewsWidget>
             </div>
         );
     }

```

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Make sure to try both with not-customized data provided and some that were customized using the vscode extension. 

Using the example app, confirm:
- when not customized, the "InAndOut Configurator" view entry is not displayed

When customized, verify that:
- the "InAndOut Configurator" view entry is still not displayed
- the children (customized output descriptors) are displayed under "views": the root entry for each one shows the customized name and its children the available views
- the children do not have the "x" button, that would permit to remove them

(optional) try the new react-compponents library when integrated in the VSCode trace viewer. I've done this test locally.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
