### PR TITLE
POC: Enable flame graph for user space traces

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "build:examples": "yarn browser build && yarn electron build",
         "start:browser": "yarn browser rebuild && yarn browser start",
         "start:electron": "yarn electron rebuild && yarn electron start",
+        "start:electronmon": "electronmon examples/electron",
         "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/tuxology/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz",
         "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz",
         "start:server": "./trace-compass-server/tracecompass-server",
@@ -75,5 +76,10 @@
         "msgpackr": "^1.10.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
+    },
+    "electronmon": {
+        "patterns": [
+            "!examples/electron/"
+        ]
     }
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -28,6 +28,7 @@
         "@vscode/codicons": "^0.0.29",
         "chart.js": "^2.8.0",
         "d3": "^7.1.1",
+        "flame-chart-js": "^3.3.0",
         "lodash": "^4.17.15",
         "react-chartjs-2": "^2.7.6",
         "react-contexify": "^5.0.0",

--- a/packages/react-components/src/components/aggregatedgraph-output-component.tsx
+++ b/packages/react-components/src/components/aggregatedgraph-output-component.tsx
@@ -23,13 +23,7 @@ import { TspDataProvider } from './data-providers/tsp-data-provider';
 import { ReactTimeGraphContainer } from './utils/timegraph-container-component';
 import { OutputElementStyle } from 'tsp-typescript-client/lib/models/styles';
 import { EntryTree } from './utils/filter-tree/entry-tree';
-import {
-    listToTree,
-    getAllExpandedNodeIds,
-    getIndexOfNode,
-    validateNumArray,
-    getCollapsedNodesFromAutoExpandLevel
-} from './utils/filter-tree/utils';
+import { listToTree, getAllExpandedNodeIds, getIndexOfNode, validateNumArray } from './utils/filter-tree/utils';
 import hash from 'traceviewer-base/lib/utils/value-hash';
 import ColumnHeader from './utils/filter-tree/column-header';
 import { TimeGraphAnnotationComponent } from 'timeline-chart/lib/components/time-graph-annotation';
@@ -81,7 +75,10 @@ export type TimegraphOutputState = AbstractTreeOutputState & {
 
 const COARSE_RESOLUTION_FACTOR = 8; // resolution factor to use for first (coarse) update
 const MENU_ID = 'timegraph.menuId-';
-export class TimegraphOutputComponent extends AbstractTreeOutputComponent<TimegraphOutputProps, TimegraphOutputState> {
+export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
+    TimegraphOutputProps,
+    TimegraphOutputState
+> {
     private totalHeight = 0;
     private rowController: TimeGraphRowController;
     private markerRowController: TimeGraphRowController;
@@ -322,16 +319,11 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 } else {
                     columns.push({ title: '', sortable: true, resizable: true });
                 }
-                const autoCollapsedNodes = getCollapsedNodesFromAutoExpandLevel(
-                    listToTree(treeResponse.model.entries, columns),
-                    treeResponse.model.autoExpandLevel
-                );
                 this.setState(
                     {
                         outputStatus: treeResponse.status,
                         aggregatedGraph: treeResponse.model.entries,
                         defaultOrderedIds: treeResponse.model.entries.map(entry => entry.id),
-                        collapsedNodes: autoCollapsedNodes,
                         columns
                     },
                     this.updateTotalHeight
@@ -553,6 +545,73 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     renderTree(): React.ReactNode {
         this.onOrderChange = this.onOrderChange.bind(this);
         this.onOrderReset = this.onOrderReset.bind(this);
+
+        // console.log(this.props.outputDescriptor.type);
+
+        if (this.props.outputDescriptor.type === 'GANTT_CHART') {
+            return (
+                <>
+                    <div
+                        ref={this.timeGraphTreeRef}
+                        className="scrollable"
+                        onScroll={() => this.synchronizeTreeScroll()}
+                        style={{
+                            height:
+                                parseInt(this.props.style.height.toString()) -
+                                this.getMarkersLayerHeight() -
+                                (document.getElementById(
+                                    this.props.traceId + this.props.outputDescriptor.id + 'searchBar'
+                                )?.offsetHeight ?? 0)
+                        }}
+                        tabIndex={0}
+                    >
+                        {this.renderContextMenu()}
+                        <EntryTree
+                            collapsedNodes={this.state.collapsedNodes}
+                            showFilter={false}
+                            entries={this.state.aggregatedGraph}
+                            showCheckboxes={false}
+                            onToggleCollapse={this.onToggleCollapse}
+                            onRowClick={this.onRowClick}
+                            onMultipleRowClick={this.onMultipleRowClick}
+                            selectedRow={this.state.selectedRow}
+                            multiSelectedRows={this.state.multiSelectedRows}
+                            showHeader={true}
+                            onContextMenu={this.onCtxMenu}
+                            className="table-tree timegraph-tree"
+                            emptyNodes={this.state.emptyNodes}
+                            hideEmptyNodes={this.shouldHideEmptyNodes}
+                            onOrderChange={this.onOrderChange}
+                            onOrderReset={this.onOrderReset}
+                            headers={this.state.columns}
+                            hideFillers={true}
+                            type={this.props.outputDescriptor.type}
+                        />
+                    </div>
+                    <div
+                        ref={this.markerTreeRef}
+                        className="scrollable"
+                        style={{ height: this.getMarkersLayerHeight() }}
+                    >
+                        <EntryTree
+                            collapsedNodes={this.state.collapsedMarkerNodes}
+                            showFilter={false}
+                            entries={this.state.markerCategoryEntries}
+                            showCheckboxes={false}
+                            showCloseIcons={true}
+                            onRowClick={this.onMarkerRowClick}
+                            selectedRow={this.state.selectedMarkerRow}
+                            onToggleCollapse={this.onToggleAnnotationCollapse}
+                            onClose={this.onMarkerCategoryRowClose}
+                            showHeader={false}
+                            className="table-tree timegraph-tree"
+                            hideFillers={true}
+                        />
+                    </div>
+                </>
+            );
+        }
+
         // TODO Show header, when we can have entries in-line with timeline-chart
         return (
             <>
@@ -1167,6 +1226,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             this.pendingSelection = undefined;
             this.selectAndReveal(foundElement);
         }
+
         return {
             rows: rows,
             range: newRange,

--- a/packages/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/packages/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -20,6 +20,18 @@ enum ElementType {
     ANNOTATION = 'annotation'
 }
 
+export interface GetDataParams {
+    ids: number[];
+    entries: TimeGraphEntry[];
+    fetchArrows: boolean;
+    totalTimeRange: TimeRange;
+    worldRange?: TimelineChart.TimeGraphRange;
+    nbTimes?: number;
+    annotationMarkers?: string[];
+    markerSetId?: string;
+    additionalProperties?: { [key: string]: any };
+}
+
 export class TspDataProvider {
     private client: ITspClient;
     private outputId: string;
@@ -132,6 +144,7 @@ export class TspDataProvider {
 
         if (tspClientStatesResponse.isOk() && stateResponse) {
             this.timeGraphRows = stateResponse.model.rows;
+
             this.timeGraphRowsOrdering(ids);
         } else {
             this.timeGraphRows = [];
@@ -162,6 +175,140 @@ export class TspDataProvider {
             );
             arrows = this.getArrows(tspClientArrowsResponse, worldRange, nbTimes);
         }
+
+        return {
+            id: 'model',
+            totalLength: this.totalRange,
+            rows,
+            arrows,
+            rangeEvents,
+            data: {
+                originalStart: chartStart
+            }
+        };
+    }
+
+    async getDataGanttChart({
+        ids,
+        entries,
+        fetchArrows,
+        totalTimeRange,
+        worldRange,
+        nbTimes,
+        annotationMarkers,
+        markerSetId,
+        additionalProperties
+    }: GetDataParams): Promise<TimelineChart.TimeGraphModel> {
+        this.timeGraphEntries = [...entries];
+        // if (!this.timeGraphEntries.length || !nbTimes) {
+        //     return {
+        //         id: 'model',
+        //         totalLength: this.totalRange,
+        //         rows: [],
+        //         rangeEvents: [],
+        //         arrows: [],
+        //         data: {}
+        //     };
+        // }
+
+        // Fire all TSP requests
+        this.totalRange = totalTimeRange.getEnd() - totalTimeRange.getStart();
+        const start = totalTimeRange.getStart();
+        const end = totalTimeRange.getStart();
+        const timeGraphStateParams = QueryHelper.selectionTimeRangeQuery(
+            start,
+            end,
+            nbTimes!,
+            ids,
+            additionalProperties ? additionalProperties : {}
+        );
+        const statesPromise = this.client.fetchTimeGraphStates(this.traceUUID, this.outputId, timeGraphStateParams);
+
+        const additionalProps: { [key: string]: any } = {};
+        if (annotationMarkers) {
+            additionalProps['requested_marker_categories'] = annotationMarkers;
+        }
+        if (markerSetId) {
+            additionalProps['requested_marker_set'] = markerSetId;
+        }
+        const annotationParams = QueryHelper.selectionTimeRangeQuery(start, end, nbTimes!, ids, additionalProps);
+        const annotations: Map<number, TimelineChart.TimeGraphAnnotation[]> = new Map();
+        const annotationsPromise = this.client.fetchAnnotations(this.traceUUID, this.outputId, annotationParams);
+
+        const arrowStart = this.timeGraphEntries[0].start;
+        const arrowEnd = this.timeGraphEntries[0].start;
+        const fetchParameters = QueryHelper.timeRangeQuery(arrowStart, arrowEnd, nbTimes);
+
+        // Wait for responses
+        const [tspClientAnnotationsResponse, tspClientStatesResponse] = await Promise.all([
+            annotationsPromise,
+            statesPromise
+        ]);
+
+        // the start time which is normalized to logical 0 in timeline chart.
+        const chartStart = totalTimeRange.getStart();
+
+        const annotationsResponse = tspClientAnnotationsResponse.getModel();
+        const rangeEvents: TimelineChart.TimeGraphAnnotation[] = [];
+        if (tspClientAnnotationsResponse.isOk() && annotationsResponse) {
+            Object.entries(annotationsResponse.model.annotations).forEach(([category, categoryArray]) => {
+                categoryArray.forEach(annotation => {
+                    if (annotation.type === Type.CHART) {
+                        if (annotation.entryId === -1) {
+                            rangeEvents.push(this.getAnnotation(category, annotation, rangeEvents.length, chartStart));
+                        } else {
+                            let entryArray = annotations.get(annotation.entryId);
+                            if (entryArray === undefined) {
+                                entryArray = [];
+                                annotations.set(annotation.entryId, entryArray);
+                            }
+                            entryArray.push(this.getAnnotation(category, annotation, entryArray.length, chartStart));
+                        }
+                    }
+                });
+            });
+        }
+
+        const stateResponse = tspClientStatesResponse.getModel();
+
+        if (tspClientStatesResponse.isOk() && stateResponse) {
+            this.timeGraphRows = stateResponse.model.rows;
+            // console.log('State Rows:', this.timeGraphRows);
+            // console.log('Mapped Entries:', this.timeGraphEntries);
+            this.timeGraphRowsOrdering(ids);
+        } else {
+            this.timeGraphRows = [];
+        }
+
+        const rows: TimelineChart.TimeGraphRowModel[] = [];
+        this.timeGraphRows.forEach((row: TimeGraphRow) => {
+            const rowId: number = row.entryId;
+
+            const entry = this.timeGraphEntries.find(tgEntry => tgEntry.id === rowId);
+            if (entry) {
+                rows.push(this.getRowModel(row, BigInt(0), rowId, entry));
+            }
+        });
+
+        for (const [entryId, entryArray] of annotations.entries()) {
+            const row = rows.find(tgEntry => tgEntry.id === entryId);
+            if (row) {
+                row.annotations = entryArray;
+            }
+        }
+
+        let arrows: TimelineChart.TimeGraphArrow[] = [];
+        if (fetchArrows) {
+            const tspClientArrowsResponse = await this.client.fetchTimeGraphArrows(
+                this.traceUUID,
+                this.outputId,
+                fetchParameters
+            );
+            arrows = this.getArrows(tspClientArrowsResponse, worldRange, nbTimes);
+        }
+
+        console.warn('Hello world');
+        console.log(rows[0].states[0].id);
 
         return {
             id: 'model',

--- a/packages/react-components/src/components/flamegraph-output-component.tsx
+++ b/packages/react-components/src/components/flamegraph-output-component.tsx
@@ -86,7 +86,7 @@ export class FlamegraphOutputComponent extends AbstractTreeOutputComponent<Timeg
         this.chartLayer.updateChart(this.filterExpressionsMap());
     }, 500);
 
-    private ignorantUnitController = new TimeGraphUnitController(BigInt(12));
+    // private ignorantUnitController = new TimeGraphUnitController(BigInt(Number.POSITIVE_INFINITY));
 
     constructor(props: TimegraphOutputProps) {
         super(props);
@@ -985,6 +985,7 @@ export class FlamegraphOutputComponent extends AbstractTreeOutputComponent<Timeg
         const selectionRange = new TimeGraphChartSelectionRange('chart-selection-range', {
             color: this.props.style.cursorColor
         });
+
         return (
             <ReactTimeGraphContainer
                 ref={this.containerRef}
@@ -1003,7 +1004,7 @@ export class FlamegraphOutputComponent extends AbstractTreeOutputComponent<Timeg
                 }}
                 addWidgetResizeHandler={this.props.addWidgetResizeHandler}
                 removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
-                unitController={this.ignorantUnitController}
+                unitController={this.props.unitController}
                 id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
                 layers={[
                     grid,

--- a/packages/react-components/src/components/flamegraph-output-component.tsx
+++ b/packages/react-components/src/components/flamegraph-output-component.tsx
@@ -15,8 +15,7 @@ import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 import { TimeGraphEntry } from 'tsp-typescript-client/lib/models/timegraph';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
-import { AbstractOutputProps } from './abstract-output-component';
-import { AbstractTreeOutputComponent, AbstractTreeOutputState } from './abstract-tree-output-component';
+import { AbstractTreeOutputComponent } from './abstract-tree-output-component';
 import { StyleProperties } from './data-providers/style-properties';
 import { StyleProvider } from './data-providers/style-provider';
 import { TspDataProvider } from './data-providers/tsp-data-provider';
@@ -47,38 +46,12 @@ import {
 import { ContextMenuItemClickedSignalPayload } from 'traceviewer-base/lib/signals/context-menu-item-clicked-signal-payload';
 import { RowSelectionsChangedSignalPayload } from 'traceviewer-base/lib/signals/row-selections-changed-signal-payload';
 import { ItemPropertiesSignalPayload } from 'traceviewer-base/lib/signals/item-properties-signal-payload';
-
-export type TimegraphOutputProps = AbstractOutputProps & {
-    addWidgetResizeHandler: (handler: () => void) => void;
-    removeWidgetResizeHandler: (handler: () => void) => void;
-};
-
-export type TimegraphOutputState = AbstractTreeOutputState & {
-    aggregatedGraph: TimeGraphEntry[];
-    defaultOrderedIds: number[];
-    markerCategoryEntries: Entry[];
-    markerLayerData:
-        | { rows: TimelineChart.TimeGraphRowModel[]; range: TimelineChart.TimeGraphRange; resolution: number }
-        | undefined;
-    selectedRow?: number;
-    multiSelectedRows?: number[];
-    selectedMarkerRow?: number;
-    collapsedNodes: number[];
-    collapsedMarkerNodes: number[];
-    columns: ColumnHeader[];
-    searchString: string;
-    filters: string[];
-    menuItems?: ContextMenuItems;
-    emptyNodes: number[];
-    marginTop: number;
-};
+import { TimegraphOutputProps, TimegraphOutputState } from './timegraph-output-component';
+import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
 
 const COARSE_RESOLUTION_FACTOR = 8; // resolution factor to use for first (coarse) update
 const MENU_ID = 'timegraph.menuId-';
-export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
-    TimegraphOutputProps,
-    TimegraphOutputState
-> {
+export class FlamegraphOutputComponent extends AbstractTreeOutputComponent<TimegraphOutputProps, TimegraphOutputState> {
     private totalHeight = 0;
     private rowController: TimeGraphRowController;
     private markerRowController: TimeGraphRowController;
@@ -113,11 +86,13 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
         this.chartLayer.updateChart(this.filterExpressionsMap());
     }, 500);
 
+    private ignorantUnitController = new TimeGraphUnitController(BigInt(12));
+
     constructor(props: TimegraphOutputProps) {
         super(props);
         this.state = {
             outputStatus: ResponseStatus.RUNNING,
-            aggregatedGraph: [],
+            timegraph: [],
             defaultOrderedIds: [],
             markerCategoryEntries: [],
             markerLayerData: undefined,
@@ -234,19 +209,19 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
             },
             mouseout: () => {
                 this.closeTooltip();
-            },
-            click: (el, ev, clickCount) => {
-                if (clickCount === 2) {
-                    const start = el.model.range.start;
-                    const end = el.model.range.end;
-                    if (start !== end) {
-                        this.props.unitController.viewRange = {
-                            start,
-                            end
-                        };
-                    }
-                }
             }
+            // click: (el, ev, clickCount) => {
+            //     if (clickCount === 2) {
+            //         const start = el.model.range.start;
+            //         const end = el.model.range.end;
+            //         if (start !== end) {
+            //             this.props.unitController.viewRange = {
+            //                 start,
+            //                 end
+            //             };
+            //         }
+            //     }
+            // }
         });
         this.markersChartLayer.registerMouseInteractions({
             click: el => {
@@ -322,7 +297,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
                 this.setState(
                     {
                         outputStatus: treeResponse.status,
-                        aggregatedGraph: treeResponse.model.entries,
+                        timegraph: treeResponse.model.entries,
                         defaultOrderedIds: treeResponse.model.entries.map(entry => entry.id),
                         columns
                     },
@@ -349,12 +324,12 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
             this.selectedMarkerCategories = this.props.markerCategories;
             this.chartLayer.updateChart(this.filterExpressionsMap());
             this.markersChartLayer.updateChart();
-            this.rangeEventsLayer.update();
+            // this.rangeEventsLayer.update();
             this.arrowLayer.update();
         } else {
             if (
                 this.state.outputStatus !== prevState.outputStatus ||
-                !isEqual(this.state.aggregatedGraph, prevState.aggregatedGraph) ||
+                !isEqual(this.state.timegraph, prevState.timegraph) ||
                 !isEqual(this.state.collapsedNodes, prevState.collapsedNodes)
             ) {
                 this.chartLayer.update();
@@ -437,7 +412,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     }
 
     private updateTotalHeight() {
-        const visibleEntries = [...this.state.aggregatedGraph].filter(entry => this.isVisible(entry));
+        const visibleEntries = [...this.state.timegraph].filter(entry => this.isVisible(entry));
         this.totalHeight = visibleEntries.length * this.props.style.rowHeight;
         this.rowController.totalHeight = this.totalHeight;
     }
@@ -456,7 +431,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
             if (collapsedNodes.includes(parentId)) {
                 return false;
             }
-            const parent = this.state.aggregatedGraph.find(e => e.id === parentId);
+            const parent = this.state.timegraph.find(e => e.id === parentId);
             parentId = parent ? parent.parentId : undefined;
         }
         return true;
@@ -481,8 +456,8 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     }
 
     private doHandleOrderChange(ids: number[]) {
-        const ordered = this.state.aggregatedGraph.slice().sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id));
-        this.setState({ aggregatedGraph: ordered });
+        const ordered = this.state.timegraph.slice().sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id));
+        this.setState({ timegraph: ordered });
     }
 
     private doHandleOrderReset() {
@@ -504,7 +479,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
         let element: TimeGraphEntry | undefined = undefined;
         let max = 0;
         if (payload && payload.load) {
-            this.state.aggregatedGraph.forEach(el => {
+            this.state.timegraph.forEach(el => {
                 if (el.metadata) {
                     let cnt = 0;
                     Object.entries(el.metadata).forEach(([key, values]) => {
@@ -545,73 +520,6 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     renderTree(): React.ReactNode {
         this.onOrderChange = this.onOrderChange.bind(this);
         this.onOrderReset = this.onOrderReset.bind(this);
-
-        // console.log(this.props.outputDescriptor.type);
-
-        if (this.props.outputDescriptor.type === 'GANTT_CHART') {
-            return (
-                <>
-                    <div
-                        ref={this.timeGraphTreeRef}
-                        className="scrollable"
-                        onScroll={() => this.synchronizeTreeScroll()}
-                        style={{
-                            height:
-                                parseInt(this.props.style.height.toString()) -
-                                this.getMarkersLayerHeight() -
-                                (document.getElementById(
-                                    this.props.traceId + this.props.outputDescriptor.id + 'searchBar'
-                                )?.offsetHeight ?? 0)
-                        }}
-                        tabIndex={0}
-                    >
-                        {this.renderContextMenu()}
-                        <EntryTree
-                            collapsedNodes={this.state.collapsedNodes}
-                            showFilter={false}
-                            entries={this.state.aggregatedGraph}
-                            showCheckboxes={false}
-                            onToggleCollapse={this.onToggleCollapse}
-                            onRowClick={this.onRowClick}
-                            onMultipleRowClick={this.onMultipleRowClick}
-                            selectedRow={this.state.selectedRow}
-                            multiSelectedRows={this.state.multiSelectedRows}
-                            showHeader={true}
-                            onContextMenu={this.onCtxMenu}
-                            className="table-tree timegraph-tree"
-                            emptyNodes={this.state.emptyNodes}
-                            hideEmptyNodes={this.shouldHideEmptyNodes}
-                            onOrderChange={this.onOrderChange}
-                            onOrderReset={this.onOrderReset}
-                            headers={this.state.columns}
-                            hideFillers={true}
-                            type={this.props.outputDescriptor.type}
-                        />
-                    </div>
-                    <div
-                        ref={this.markerTreeRef}
-                        className="scrollable"
-                        style={{ height: this.getMarkersLayerHeight() }}
-                    >
-                        <EntryTree
-                            collapsedNodes={this.state.collapsedMarkerNodes}
-                            showFilter={false}
-                            entries={this.state.markerCategoryEntries}
-                            showCheckboxes={false}
-                            showCloseIcons={true}
-                            onRowClick={this.onMarkerRowClick}
-                            selectedRow={this.state.selectedMarkerRow}
-                            onToggleCollapse={this.onToggleAnnotationCollapse}
-                            onClose={this.onMarkerCategoryRowClose}
-                            showHeader={false}
-                            className="table-tree timegraph-tree"
-                            hideFillers={true}
-                        />
-                    </div>
-                </>
-            );
-        }
-
         // TODO Show header, when we can have entries in-line with timeline-chart
         return (
             <>
@@ -632,7 +540,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
                     <EntryTree
                         collapsedNodes={this.state.collapsedNodes}
                         showFilter={false}
-                        entries={this.state.aggregatedGraph}
+                        entries={this.state.timegraph}
                         showCheckboxes={false}
                         onToggleCollapse={this.onToggleCollapse}
                         onRowClick={this.onRowClick}
@@ -727,7 +635,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const entryModels: { id: number; parentId?: number; metadata?: { [key: string]: any } }[] = [];
         for (const id of ids) {
-            const element = this.state.aggregatedGraph.find(el => el.id === id);
+            const element = this.state.timegraph.find(el => el.id === id);
             if (element) {
                 entryModels.push({ id: element.id, parentId: element.parentId, metadata: element.metadata });
             }
@@ -830,7 +738,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     }
 
     resultsAreEmpty(): boolean {
-        return this.state.aggregatedGraph.length === 0;
+        return this.state.timegraph.length === 0;
     }
 
     private isFilteredIn(row: TimelineChart.TimeGraphRowModel, strategy?: string): boolean {
@@ -1095,7 +1003,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
                 }}
                 addWidgetResizeHandler={this.props.addWidgetResizeHandler}
                 removeWidgetResizeHandler={this.props.removeWidgetResizeHandler}
-                unitController={this.props.unitController}
+                unitController={this.ignorantUnitController}
                 id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
                 layers={[
                     grid,
@@ -1149,7 +1057,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     }
 
     private getTimegraphRowIds() {
-        const { aggregatedGraph: timegraphTree, columns, collapsedNodes } = this.state;
+        const { timegraph: timegraphTree, columns, collapsedNodes } = this.state;
         const rowIds = getAllExpandedNodeIds(listToTree(timegraphTree, columns), collapsedNodes);
         return { rowIds };
     }
@@ -1176,7 +1084,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
         const nbTimes = Math.ceil(Number(end - start) / resolution) + 1;
         const timeGraphData: TimelineChart.TimeGraphModel = await this.tspDataProvider.getData(
             ids,
-            this.state.aggregatedGraph,
+            this.state.timegraph,
             fetchArrows,
             this.props.range,
             newRange,
@@ -1226,7 +1134,6 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
             this.pendingSelection = undefined;
             this.selectAndReveal(foundElement);
         }
-
         return {
             rows: rows,
             range: newRange,
@@ -1577,13 +1484,13 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     }
 
     private expandParents(entry: TimeGraphEntry) {
-        let foundNode = this.state.aggregatedGraph.find(node => node.id === entry?.id);
+        let foundNode = this.state.timegraph.find(node => node.id === entry?.id);
         if (foundNode) {
             let parentId: number | undefined = foundNode.parentId;
             const ids: number[] = [];
             while (parentId && parentId >= 0) {
                 ids.push(parentId);
-                foundNode = this.state.aggregatedGraph.find(node => node.id === parentId);
+                foundNode = this.state.timegraph.find(node => node.id === parentId);
                 parentId = foundNode?.parentId;
             }
 
@@ -1608,7 +1515,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     public onRowClick = (id: number): void => {
         const rowIndex = getIndexOfNode(
             id,
-            listToTree(this.state.aggregatedGraph, this.state.columns),
+            listToTree(this.state.timegraph, this.state.columns),
             this.state.collapsedNodes,
             this.state.emptyNodes
         );
@@ -1623,7 +1530,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     };
 
     public onMultipleRowClick = (id: number, isShiftClicked?: boolean): void => {
-        const tree = listToTree(this.state.aggregatedGraph, this.state.columns);
+        const tree = listToTree(this.state.timegraph, this.state.columns);
         const rowIndex = getIndexOfNode(id, tree, this.state.collapsedNodes, this.state.emptyNodes);
 
         if (isShiftClicked) {
@@ -1725,7 +1632,7 @@ export class AggregatedgraphOutputComponent extends AbstractTreeOutputComponent<
     private selectAndReveal(item: TimeGraphEntry) {
         const rowIndex = getIndexOfNode(
             item.id,
-            listToTree(this.state.aggregatedGraph, this.state.columns),
+            listToTree(this.state.timegraph, this.state.columns),
             this.state.collapsedNodes,
             this.state.emptyNodes
         );

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -60,7 +60,7 @@ export type TimegraphOutputProps = AbstractOutputProps & {
 };
 
 export type TimegraphOutputState = AbstractTreeOutputState & {
-    aggregatedGraph: TimeGraphEntry[];
+    timegraph: TimeGraphEntry[];
     defaultOrderedIds: number[];
     markerCategoryEntries: Entry[];
     markerLayerData:
@@ -120,7 +120,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         super(props);
         this.state = {
             outputStatus: ResponseStatus.RUNNING,
-            aggregatedGraph: [],
+            timegraph: [],
             defaultOrderedIds: [],
             markerCategoryEntries: [],
             markerLayerData: undefined,
@@ -329,7 +329,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 this.setState(
                     {
                         outputStatus: treeResponse.status,
-                        aggregatedGraph: treeResponse.model.entries,
+                        timegraph: treeResponse.model.entries,
                         defaultOrderedIds: treeResponse.model.entries.map(entry => entry.id),
                         collapsedNodes: autoCollapsedNodes,
                         columns
@@ -362,7 +362,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         } else {
             if (
                 this.state.outputStatus !== prevState.outputStatus ||
-                !isEqual(this.state.aggregatedGraph, prevState.aggregatedGraph) ||
+                !isEqual(this.state.timegraph, prevState.timegraph) ||
                 !isEqual(this.state.collapsedNodes, prevState.collapsedNodes)
             ) {
                 this.chartLayer.update();
@@ -445,7 +445,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private updateTotalHeight() {
-        const visibleEntries = [...this.state.aggregatedGraph].filter(entry => this.isVisible(entry));
+        const visibleEntries = [...this.state.timegraph].filter(entry => this.isVisible(entry));
         this.totalHeight = visibleEntries.length * this.props.style.rowHeight;
         this.rowController.totalHeight = this.totalHeight;
     }
@@ -464,7 +464,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             if (collapsedNodes.includes(parentId)) {
                 return false;
             }
-            const parent = this.state.aggregatedGraph.find(e => e.id === parentId);
+            const parent = this.state.timegraph.find(e => e.id === parentId);
             parentId = parent ? parent.parentId : undefined;
         }
         return true;
@@ -489,8 +489,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private doHandleOrderChange(ids: number[]) {
-        const ordered = this.state.aggregatedGraph.slice().sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id));
-        this.setState({ aggregatedGraph: ordered });
+        const ordered = this.state.timegraph.slice().sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id));
+        this.setState({ timegraph: ordered });
     }
 
     private doHandleOrderReset() {
@@ -512,7 +512,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         let element: TimeGraphEntry | undefined = undefined;
         let max = 0;
         if (payload && payload.load) {
-            this.state.aggregatedGraph.forEach(el => {
+            this.state.timegraph.forEach(el => {
                 if (el.metadata) {
                     let cnt = 0;
                     Object.entries(el.metadata).forEach(([key, values]) => {
@@ -573,7 +573,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     <EntryTree
                         collapsedNodes={this.state.collapsedNodes}
                         showFilter={false}
-                        entries={this.state.aggregatedGraph}
+                        entries={this.state.timegraph}
                         showCheckboxes={false}
                         onToggleCollapse={this.onToggleCollapse}
                         onRowClick={this.onRowClick}
@@ -668,7 +668,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const entryModels: { id: number; parentId?: number; metadata?: { [key: string]: any } }[] = [];
         for (const id of ids) {
-            const element = this.state.aggregatedGraph.find(el => el.id === id);
+            const element = this.state.timegraph.find(el => el.id === id);
             if (element) {
                 entryModels.push({ id: element.id, parentId: element.parentId, metadata: element.metadata });
             }
@@ -771,7 +771,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     resultsAreEmpty(): boolean {
-        return this.state.aggregatedGraph.length === 0;
+        return this.state.timegraph.length === 0;
     }
 
     private isFilteredIn(row: TimelineChart.TimeGraphRowModel, strategy?: string): boolean {
@@ -1090,7 +1090,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private getTimegraphRowIds() {
-        const { aggregatedGraph: timegraphTree, columns, collapsedNodes } = this.state;
+        const { timegraph: timegraphTree, columns, collapsedNodes } = this.state;
         const rowIds = getAllExpandedNodeIds(listToTree(timegraphTree, columns), collapsedNodes);
         return { rowIds };
     }
@@ -1117,7 +1117,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         const nbTimes = Math.ceil(Number(end - start) / resolution) + 1;
         const timeGraphData: TimelineChart.TimeGraphModel = await this.tspDataProvider.getData(
             ids,
-            this.state.aggregatedGraph,
+            this.state.timegraph,
             fetchArrows,
             this.props.range,
             newRange,
@@ -1517,13 +1517,13 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private expandParents(entry: TimeGraphEntry) {
-        let foundNode = this.state.aggregatedGraph.find(node => node.id === entry?.id);
+        let foundNode = this.state.timegraph.find(node => node.id === entry?.id);
         if (foundNode) {
             let parentId: number | undefined = foundNode.parentId;
             const ids: number[] = [];
             while (parentId && parentId >= 0) {
                 ids.push(parentId);
-                foundNode = this.state.aggregatedGraph.find(node => node.id === parentId);
+                foundNode = this.state.timegraph.find(node => node.id === parentId);
                 parentId = foundNode?.parentId;
             }
 
@@ -1548,7 +1548,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     public onRowClick = (id: number): void => {
         const rowIndex = getIndexOfNode(
             id,
-            listToTree(this.state.aggregatedGraph, this.state.columns),
+            listToTree(this.state.timegraph, this.state.columns),
             this.state.collapsedNodes,
             this.state.emptyNodes
         );
@@ -1563,7 +1563,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     };
 
     public onMultipleRowClick = (id: number, isShiftClicked?: boolean): void => {
-        const tree = listToTree(this.state.aggregatedGraph, this.state.columns);
+        const tree = listToTree(this.state.timegraph, this.state.columns);
         const rowIndex = getIndexOfNode(id, tree, this.state.collapsedNodes, this.state.emptyNodes);
 
         if (isShiftClicked) {
@@ -1665,7 +1665,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     private selectAndReveal(item: TimeGraphEntry) {
         const rowIndex = getIndexOfNode(
             item.id,
-            listToTree(this.state.aggregatedGraph, this.state.columns),
+            listToTree(this.state.timegraph, this.state.columns),
             this.state.collapsedNodes,
             this.state.emptyNodes
         );

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -758,6 +758,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                 />
                             );
                         case ProviderType.DATA_TREE:
+                        case 'GANTT_CHART':
                             return (
                                 <DataTreeOutputComponent
                                     key={output.id}

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -716,12 +716,6 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                         pinned: this.state.pinnedView ? this.state.pinnedView === output : undefined
                     };
 
-                    const flamegraphRange = new TimeRange(
-                        BigInt(0),
-                        this.state.currentRange.getEnd() + this.state.currentRange.getStart(),
-                        BigInt(0)
-                    );
-
                     switch (responseType) {
                         case 'OVERVIEW':
                             return (
@@ -774,6 +768,11 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                 />
                             );
                         case 'GANTT_CHART':
+                            const flamegraphRange = new TimeRange(
+                                BigInt(0),
+                                this.state.currentRange.getEnd() + this.state.currentRange.getStart(),
+                                BigInt(0)
+                            );
                             return (
                                 <FlamegraphOutputComponent
                                     key={output.id}

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -27,6 +27,7 @@ import { cloneDeep } from 'lodash';
 import { UnitControllerHistoryHandler } from './utils/unit-controller-history-handler';
 import { TraceOverviewComponent } from './trace-overview-component';
 import { TimeRangeUpdatePayload } from 'traceviewer-base/lib/signals/time-range-data-signal-payloads';
+import { AggregatedgraphOutputComponent } from './aggregatedgraph-output-component';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -758,11 +759,20 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                 />
                             );
                         case ProviderType.DATA_TREE:
-                        case 'GANTT_CHART':
                             return (
                                 <DataTreeOutputComponent
                                     key={output.id}
                                     {...outputProps}
+                                    className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
+                                />
+                            );
+                        case 'GANTT_CHART':
+                            return (
+                                <AggregatedgraphOutputComponent
+                                    key={output.id}
+                                    {...outputProps}
+                                    addWidgetResizeHandler={this.addWidgetResizeHandler}
+                                    removeWidgetResizeHandler={this.removeWidgetResizeHandler}
                                     className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
                                 />
                             );

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -27,7 +27,7 @@ import { cloneDeep } from 'lodash';
 import { UnitControllerHistoryHandler } from './utils/unit-controller-history-handler';
 import { TraceOverviewComponent } from './trace-overview-component';
 import { TimeRangeUpdatePayload } from 'traceviewer-base/lib/signals/time-range-data-signal-payloads';
-import { AggregatedgraphOutputComponent } from './aggregatedgraph-output-component';
+import { FlamegraphOutputComponent } from './flamegraph-output-component';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -715,6 +715,13 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                         setChartOffset: this.setChartOffset,
                         pinned: this.state.pinnedView ? this.state.pinnedView === output : undefined
                     };
+
+                    const flamegraphRange = new TimeRange(
+                        BigInt(0),
+                        this.state.currentRange.getEnd() + this.state.currentRange.getStart(),
+                        BigInt(0)
+                    );
+
                     switch (responseType) {
                         case 'OVERVIEW':
                             return (
@@ -768,9 +775,11 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                             );
                         case 'GANTT_CHART':
                             return (
-                                <AggregatedgraphOutputComponent
+                                <FlamegraphOutputComponent
                                     key={output.id}
                                     {...outputProps}
+                                    range={flamegraphRange}
+                                    viewRange={flamegraphRange}
                                     addWidgetResizeHandler={this.addWidgetResizeHandler}
                                     removeWidgetResizeHandler={this.removeWidgetResizeHandler}
                                     className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}

--- a/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/entry-tree.tsx
@@ -28,6 +28,7 @@ interface EntryTreeProps {
     headers: ColumnHeader[];
     className: string;
     hideFillers?: boolean;
+    type: string;
 }
 
 export class EntryTree extends React.Component<EntryTreeProps> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,7 +3862,7 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.3.8", "@types/react@^18", "@types/react@^18.0.15":
+"@types/react@*", "@types/react@^18", "@types/react@^18.0.15":
   version "18.3.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.8.tgz#1672ab19993f8aca7c7dc844c07d5d9e467d5a79"
   integrity sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==
@@ -5731,10 +5731,26 @@ color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colorette@^1.2.1:
   version "1.4.0"
@@ -7872,6 +7888,14 @@ fix-path@^4.0.0:
   dependencies:
     shell-path "^3.0.0"
 
+flame-chart-js@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/flame-chart-js/-/flame-chart-js-3.3.0.tgz#f607fd0ed3216aa0425ee81beba0eafec844528f"
+  integrity sha512-bjgRBK7o/479BTt1t3piu+UIT0ctxVUkiJblMeIba5mMxc+7rk+/cv9fvEiCmuv+e+86aKm61r5wwza5myDGSw==
+  dependencies:
+    color "^3.1.3"
+    events "^3.2.0"
+
 flat-cache@^3.0.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
@@ -8831,6 +8855,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-async-function@^2.0.0:
   version "2.1.0"
@@ -10765,11 +10794,6 @@ mute-stream@^1.0.0, mute-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
-
-nan@2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3"
-  integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==
 
 nano@^10.1.3:
   version "10.1.4"
@@ -13062,6 +13086,13 @@ simple-get@^4.0.0:
     decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 simple-update-notifier@2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,7 +3862,7 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18", "@types/react@^18.0.15":
+"@types/react@*", "@types/react@18.3.8", "@types/react@^18", "@types/react@^18.0.15":
   version "18.3.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.8.tgz#1672ab19993f8aca7c7dc844c07d5d9e467d5a79"
   integrity sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==
@@ -10794,6 +10794,11 @@ mute-stream@^1.0.0, mute-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
+nan@2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3"
+  integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==
 
 nano@^10.1.3:
   version "10.1.4"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/theia-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

- Adds a modified duplication of `timegraph-output-component.tsx` called `flamegraph-output-component.tsx` for the lack of a better name.
    -  Mostly adjustments in nomenclature for classes and properties
- Adds a GANTT_CHART case to handle the ProviderType in `trace-context-component.tsx` which returns the `FlamegraphOutputComponent`
    - The component takes in a time range of `[0,very big number)` to fetch all the states from the experiment. Currently, it is set to a value: start + end of range
- Adds a new script in `package.json` called `start:electronmon` and the electronmon dependency which will help with development by auto-reloading the Electron application.

### How to test

1. Simply pull this PR branch to local system.
2. Run `yarn` to install the new dependencies
3. Run `yarn start:electronmon` to start the Electron app

### Follow-ups

This is an early stage investigative proof of concept to show that we are able to get flame graph working on Webview leveraging the existing time graph implementation to render the flame graph.

Upcoming works would include, in such order:
- Disconnect the signal handling logic so that the flame graph view is independent from the experiment syncs (e.g. zooming) by implementing a custom UnitController
- Render the x-axis as an arbitrary numerical range instead of timestamps
- Complete separation from the time graph logic and render the data as a weighted tree
- Clean up and refactoring

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
