### PR TITLE
Fix timegraph misalignment when entry label is blank

### DIFF
--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -312,7 +312,6 @@ canvas {
 }
 
 .timegraph-tree tr {
-    /* TODO: Fix row alignment, this number is arbitrary, it works [on my machine], but it should match line height in timeline-chart */
     line-height: 18px;
 }
 
@@ -323,6 +322,7 @@ canvas {
 }
 
 .timegraph-tree td {
+    height: 18px;
     padding: 1px;
     border-left: 1px solid var(--trace-viewer-tree-inactiveIndentGuidesStroke);
     border-right: none;


### PR DESCRIPTION
### What it does

Set the height for timegraph td in .css stylesheet since the line-height for timegraph tr does not apply if there is no text.

Fixes #1208

### How to test

Open kernel trace and Resources status view. Check that separator rows between CPUs have same height in tree and timegraph.

### Follow-ups

Consider supporting variable height rows. See issue #133.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
