### PR TITLE
Fix timegraph misalignment when analysis running

### DIFF
--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -390,8 +390,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             );
             signalManager().emit('ROW_SELECTIONS_CHANGED', signalPayload);
         }
-        if (!isEqual(this.state.columns, prevState.columns)) {
-            if (this.state.columns) {
+        if (this.state.timegraphTree.length > 0 && prevState.timegraphTree.length === 0) {
+            if (this.state.columns && this.state.columns.length > 0) {
                 const header = this.treeRef.current?.querySelector('th');
                 if (header) {
                     new ResizeObserver(target => {


### PR DESCRIPTION
### What it does

Wait for table header to be rendered before setting top margin.

Fixes #1207

### How to test

Remove trace from trace viewer if it exists, to make sure analyses haven't run
Open a timegraph output with a slow analysis, or use breakpoint in analysis to simulate a delay
Wait for analysis to complete, or exit the breakpoint
Observe that timegraph has a top margin equal to tree header and rows are aligned with the tree

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
