### PR TITLE
Fix scroll sync break after refactoring into abstract Gantt

### DIFF
--- a/packages/react-components/src/components/abstract-gantt-output-component.tsx
+++ b/packages/react-components/src/components/abstract-gantt-output-component.tsx
@@ -100,7 +100,7 @@ export abstract class AbstractGanttOutputComponent<
     private rangeEventsLayer: TimeGraphRangeEventsLayer;
 
     private horizontalContainer: React.RefObject<HTMLDivElement>;
-    private chartTreeRef: React.RefObject<HTMLDivElement>;
+    protected chartTreeRef: React.RefObject<HTMLDivElement>;
     protected markerTreeRef: React.RefObject<HTMLDivElement>;
     private containerRef: React.RefObject<ReactTimeGraphContainer>;
 

--- a/packages/react-components/src/components/gantt-chart-output-component.tsx
+++ b/packages/react-components/src/components/gantt-chart-output-component.tsx
@@ -69,7 +69,7 @@ export class GanttChartOutputComponent extends AbstractGanttOutputComponent<
                     </button>
                 </div>
                 <div
-                    ref={this.treeRef}
+                    ref={this.chartTreeRef}
                     className="scrollable"
                     onScroll={() => this.synchronizeTreeScroll()}
                     style={{

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -39,7 +39,7 @@ export class TimegraphOutputComponent extends AbstractGanttOutputComponent {
         return (
             <>
                 <div
-                    ref={this.treeRef}
+                    ref={this.chartTreeRef}
                     className="scrollable"
                     onScroll={() => this.synchronizeTreeScroll()}
                     style={{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/theia-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Fixes a regression introduced by the refactoring of Timegraph and GanttChart into AbstractGantt which breaks the vertical scroll synchronization between the tree and the chart.

This was due to using a wrong ref to control the scroll sync.

`chartTreeRef` from the AbstractGanttOutputComponent class was suposed to be used instead of `treeRef` of the AbstractTreeOutputComponent class.

### How to test

Compare the behaviors on `master` branch and this PR branch when opening the Flame Chart and Flame Graph views and vertically scrolling on either the tree or the chart area.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
