### PR TITLE
Remove custom reset zoom logic and UI for flame graph due to regressi…

### DIFF
--- a/packages/react-components/src/components/gantt-chart-output-component.tsx
+++ b/packages/react-components/src/components/gantt-chart-output-component.tsx
@@ -63,11 +63,6 @@ export class GanttChartOutputComponent extends AbstractGanttOutputComponent<
         // TODO Show header, when we can have entries in-line with timeline-chart
         return (
             <>
-                <div className="zoom-reset-button-container">
-                    <button className="item zoom-reset-button" onClick={this.handleResetZoom} aria-label="reset zoom">
-                        <i className="codicon codicon-arrow-both" /> Reset Zoom
-                    </button>
-                </div>
                 <div
                     ref={this.chartTreeRef}
                     className="scrollable"
@@ -122,20 +117,4 @@ export class GanttChartOutputComponent extends AbstractGanttOutputComponent<
             </>
         );
     }
-
-    private handleResetZoom = () => {
-        // Reset the view range to the initial global view range snapshot
-        const initial = this.initialViewRangeSnapshot || this.props.unitController.viewRange;
-        this.props.unitController.viewRange = {
-            start: initial.start,
-            end: initial.end
-        };
-        if (this.chartLayer) {
-            this.chartLayer.update();
-        }
-        this.setState(prev => ({ zoomResetCounter: (prev.zoomResetCounter ?? 0) + 1 }));
-        if (this.props.onResetZoom) {
-            this.props.onResetZoom();
-        }
-    };
 }

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -59,7 +59,6 @@ export interface TraceContextState {
     backgroundTheme: string;
     pinnedView: OutputDescriptor | undefined;
     ganttChartRanges?: Record<string, { start: bigint; end: bigint }>;
-    ganttChartResetZoomKey?: number;
 }
 
 export interface PersistedState {
@@ -184,8 +183,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                 lineColor: this.props.backgroundTheme === 'light' ? 0x757575 : 0xbbbbbb
             },
             backgroundTheme: this.props.backgroundTheme,
-            ganttChartRanges: {},
-            ganttChartResetZoomKey: 0
+            ganttChartRanges: {}
         };
         const absoluteRange = traceRange.getDuration();
         const offset = viewRange.getOffset();
@@ -837,7 +835,6 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                     addWidgetResizeHandler={this.addWidgetResizeHandler}
                                     removeWidgetResizeHandler={this.removeWidgetResizeHandler}
                                     className={this.state.pinnedView?.id === output.id ? 'pinned-view-shadow' : ''}
-                                    onResetZoom={this.handleGanttChartResetZoom}
                                 >
                                     <div
                                         style={{
@@ -848,7 +845,6 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                                         }}
                                     >
                                         <TimeAxisComponent
-                                            key={this.state.ganttChartResetZoomKey}
                                             unitController={ganttChartUnitController}
                                             style={{ ...this.state.style, width: chartWidth, verticalAlign: 'bottom' }}
                                             addWidgetResizeHandler={this.addWidgetResizeHandler}
@@ -1044,9 +1040,5 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                 [outputId]: newRange
             }
         }));
-    };
-
-    private handleGanttChartResetZoom = () => {
-        this.setState(prev => ({ ganttChartResetZoomKey: (prev.ganttChartResetZoomKey ?? 0) + 1 }));
     };
 }


### PR DESCRIPTION
…on from refactoring. No fix yet.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/theia-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->

This PR removes the custom reset zoom button from flame graph and related logic implementations. This reset zoom functionality breaking is a regression introduced by #1214. No fixes found as of this moment.

> [!NOTE]
> N.B. Only this reset zoom button, introduced by #1205, is found to be broken. Might need a much deeper code change. Zooming in and out via established methods is still working as expected. 

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Should not see the reset zoom button anymore. Other ways to zoom in and out still works.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

There might be some ways to have the reset zoom functionality just for the flame graph by using the signal manager.

Found that there is a partial fix by including a resetZoomKey in the key props of GanttChartOutputComponent which resets both the x axis and the chart but the view loses its height upon reset.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
