### PR TITLE
Use default empty string when annotation label is absent

### DIFF
--- a/local-libs/traceviewer-libs/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/local-libs/traceviewer-libs/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -296,7 +296,7 @@ export class TspDataProvider {
                 start: annotation.time - chartStart,
                 end: annotation.time + annotation.duration - chartStart
             },
-            label: annotation.label,
+            label: annotation.label ?? '',
             data: {
                 style: annotation.style
             }


### PR DESCRIPTION
### What it does

Use default empty string when annotation label is absent

### How to test

Compile with latest tsp-typescript-client where annotation label has been made optional according to TSP.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
